### PR TITLE
Add XP and currency formatting utilities

### DIFF
--- a/lib/format-utils.ts
+++ b/lib/format-utils.ts
@@ -1,0 +1,11 @@
+export function formatXP(xp: number): string {
+  return xp.toLocaleString();
+}
+
+export function formatGold(gold: number): string {
+  return gold.toLocaleString();
+}
+
+export function formatNumber(value: number): string {
+  return value.toLocaleString();
+}


### PR DESCRIPTION
## Summary
• Add formatXP(), formatGold(), and formatNumber() utility functions
• Format numbers with locale-specific thousands separators (e.g., 1,234)
• Small utility enhancement ready for quest rewards and character displays

## Test plan
- [x] Verified functions format numbers correctly with commas
- [x] Tested edge cases (0, 999, large numbers)
- [x] Build passes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)