### PR TITLE
Add test screenshot patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ next-env.d.ts
 # database
 prisma/dev.db
 prisma/dev.db-journal
+
+# test screenshots and debug files
+*.png
+test-*.png
+debug-*.png


### PR DESCRIPTION
## Summary
- Add *.png, test-*.png, and debug-*.png patterns to .gitignore
- Prevents E2E test artifacts from being committed to version control
- Keeps repository clean from temporary debug screenshots

## Test plan
- [x] Verify .gitignore patterns are correctly added
- [x] Confirm existing screenshots are now ignored by git status

🤖 Generated with [Claude Code](https://claude.ai/code)