### PR TITLE
Fix remaining lint errors

### DIFF
--- a/tests/e2e/helpers/setup-helpers.ts
+++ b/tests/e2e/helpers/setup-helpers.ts
@@ -121,7 +121,7 @@ export async function clearBrowserState(page: Page): Promise<void> {
         sessionStorage.clear();
       }
     });
-  } catch (error) {
+  } catch {
     // Ignore localStorage access errors (happens on initial page load)
   }
 }
@@ -139,7 +139,7 @@ export async function commonBeforeEach(page: Page): Promise<void> {
       localStorage.clear();
       sessionStorage.clear();
     });
-  } catch (error) {
+  } catch {
     // Ignore localStorage access errors
   }
 }

--- a/tests/e2e/quest-completion-rewards.spec.ts
+++ b/tests/e2e/quest-completion-rewards.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { setupUserWithCharacter, commonBeforeEach } from './helpers/setup-helpers';
 
 test.describe("Quest Completion Rewards", () => {
@@ -104,7 +104,7 @@ test.describe("Quest Completion Rewards", () => {
   });
 });
 
-async function createAndCompleteQuest(page: any, title: string, difficulty: string, xp: number) {
+async function createAndCompleteQuest(page: Page, title: string, difficulty: string, xp: number) {
   await page.click('button:text("⚡ Create Quest")');
   await page.locator('.fixed button:has-text("Custom Quest")').click();
   await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary
- Remove unused `error` parameters in catch blocks in `setup-helpers.ts` 
- Replace explicit `any` type with proper `Page` type in quest completion helper function
- Add missing `Page` import to `quest-completion-rewards.spec.ts`

## Test plan
- [x] All lint errors resolved (`npm run lint` passes clean)
- [x] Build passes successfully (`npm run build` completes without errors)
- [x] No functional changes - purely code quality improvements

🤖 Generated with [Claude Code](https://claude.ai/code)