### PR TITLE
Fix Docker container startup syntax error

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -389,6 +389,14 @@ development tasks organized by implementation phases.
 - [x] **PR Creation** - Created PR #23 with comprehensive deployment documentation, merged successfully to main
 - [x] **Release Preparation** - Created GitHub release v0.1.0 with zero-interaction Docker deployment as primary installation method
 
+#### 🔄 Current Infrastructure Tasks
+
+- [x] **Docker Entrypoint Syntax Error Fix** - Fixed shell syntax error preventing container startup (line 63 bash-specific syntax in /bin/sh script)
+  - [x] **Identify syntax error** - Found bash-specific here-string syntax (`<<<`) causing "unexpected redirection" error
+  - [x] **Fix POSIX compatibility** - Replace with `echo` pipe for /bin/sh compatibility
+  - [x] **Test container startup** - Verify fix resolves production deployment issue
+  - [x] **Update documentation** - Record fix in development session history
+
 #### 🔄 Future Infrastructure Tasks
 
 - [ ] **NGINX Reverse Proxy** - Load balancing and SSL termination

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ seed_database() {
     echo "🌱 Checking if database seeding is needed..."
 
     # Check if this is a fresh database by looking for users
-    if npx prisma db execute --stdin <<< "SELECT COUNT(*) FROM users LIMIT 1;" 2>/dev/null | grep -q "0"; then
+    if echo "SELECT COUNT(*) FROM users LIMIT 1;" | npx prisma db execute --stdin 2>/dev/null | grep -q "0"; then
         echo "📋 Database appears empty, running seed..."
 
         if npm run db:seed; then


### PR DESCRIPTION
## Summary

- Fixes production Docker container startup failures with "syntax error: unexpected redirection"
- Replaces bash-specific here-string syntax with POSIX-compliant shell commands
- Resolves container restart loops in production deployment

## Root Cause

The `entrypoint.sh` script used bash-specific here-string syntax (`<<<`) in a `/bin/sh` script:

```bash
# Before (broken)
npx prisma db execute --stdin <<< "SELECT COUNT(*) FROM users LIMIT 1;" 2>/dev/null | grep -q "0"
```

This created conflicting redirections and used non-POSIX syntax, causing container startup failures.

## Solution

Replaced with POSIX-compliant `echo` pipe:

```bash
# After (working)
echo "SELECT COUNT(*) FROM users LIMIT 1;" | npx prisma db execute --stdin 2>/dev/null | grep -q "0"
```

## Testing

- ✅ Build passes (`npm run build`)
- ✅ Linting clean (`npm run lint`) 
- ✅ All unit tests pass (60/60 tests)
- ✅ Maintains identical database seeding functionality
- ✅ Shell syntax is POSIX-compliant for maximum container compatibility
- ✅ **User confirmed**: Docker container now starts successfully in production

## Impact

- Resolves production deployment issues for all users
- Enables reliable zero-interaction Docker deployment
- Maintains all existing database initialization logic
- No breaking changes to functionality

🤖 Generated with [Claude Code](https://claude.ai/code)