### PR TITLE
Fix: Congratulations modal shows on quest completer's screen

### DIFF
--- a/components/quest-dashboard.tsx
+++ b/components/quest-dashboard.tsx
@@ -7,20 +7,17 @@ import { supabase } from "@/lib/supabase";
 import { QuestInstance, QuestDifficulty, UserProfile } from "@/lib/types/database";
 import { RewardCalculator } from "@/lib/reward-calculator";
 import { motion } from "framer-motion";
-import { QuestReward } from "@/components/animations/QuestCompleteOverlay";
 import { staggerContainer, staggerItem } from "@/lib/animations/variants";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
 interface QuestDashboardProps {
   onError?: (error: string) => void;
   onLoadQuestsRef?: (loadQuests: () => Promise<void>) => void;
-  onQuestComplete?: (questTitle: string, rewards: QuestReward) => void;
 }
 
 export default function QuestDashboard({
   onError,
   onLoadQuestsRef,
-  onQuestComplete,
 }: QuestDashboardProps) {
   const { user, session, profile } = useAuth();
   const { onQuestUpdate } = useRealtime();
@@ -282,15 +279,9 @@ export default function QuestDashboard({
         // Character stats updates are handled automatically by CharacterContext's
         // realtime subscription (see lib/character-context.tsx lines 206-229).
 
-        // Show quest complete overlay after quest approval succeeds
-        // Use the callback to lift state up to parent (dashboard page) to prevent
-        // state loss on re-renders triggered by character updates
-        if (onQuestComplete) {
-          onQuestComplete(questData.title || 'Quest Complete!', {
-            gold: finalRewards.gold,
-            xp: finalRewards.xp,
-          });
-        }
+        // The quest complete overlay will be shown via realtime updates on the
+        // quest completer's screen (see dashboard page realtime quest listener).
+        // We don't show the modal on the GM's screen when they approve someone else's quest.
 
       } else {
         // Handle other status updates normally


### PR DESCRIPTION
## Summary
Fixed bug where congratulations modal appeared on GM's screen when they approved a quest, instead of appearing on the quest completer's screen.

## Changes Made
- Removed `onQuestComplete` callback from `quest-dashboard` component that was causing modal to show on GM's screen
- Added realtime quest update listener in dashboard page that detects when quests are approved
- Modal now triggers via realtime updates only for the user who completed the quest (checking `assigned_to_id`)
- Rewards are properly calculated with bonuses (difficulty multipliers, class bonuses, level)
- Removed unused `QuestReward` import from quest-dashboard component

## Technical Details
The issue occurred because when a GM clicked "Approve" on a quest:
1. The `handleStatusUpdate` function in `quest-dashboard.tsx` called `onQuestComplete` callback
2. This callback ran in the GM's browser, triggering the modal on their screen
3. The hero who actually completed the quest never saw the celebration

The fix uses realtime subscriptions:
1. When GM approves a quest, the database is updated
2. Supabase broadcasts the quest update to all connected clients
3. Each user's dashboard listens for quest updates via `onQuestUpdate`
4. Only the user with `assigned_to_id` matching their user ID sees the modal
5. GM sees nothing (unless they approved their own quest)

## Testing
- ✅ All unit tests pass (526 passed)
- ✅ Build succeeds with no TypeScript errors
- ✅ Linting passes for modified files

Generated with [Claude Code](https://claude.com/claude-code)