### PR TITLE
Hotfix: Enable Real-time DELETE Events for Quest Cancellation (v0.2.5)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -200,7 +200,27 @@ transforms household tasks into epic adventures.
 
 ### Docker Production Deployment - COMPLETED 2025-09-25
 
-## Hotfix 0.2.1 - Mobile Responsiveness & UI Polish - IN PROGRESS 2025-10-16
+## Hotfix 0.2.5 - Enable Real-time Quest Deletion Events - IN PROGRESS 2025-10-17
+
+Quest cancellation UI was not updating in real-time due to missing database configuration:
+
+- [x] #64 - UI does not update in real-time after cancelling a Family Quest
+  - [x] Root cause: quest_instances table missing REPLICA IDENTITY FULL setting
+  - [x] Created migration 20251017000002_set_quest_instances_replica_identity.sql
+  - [x] Added ALTER TABLE quest_instances REPLICA IDENTITY FULL
+  - [x] Enables Postgres to include full old row data in DELETE events
+  - [x] Allows Supabase Realtime to evaluate RLS policies and filters on DELETE
+  - [x] Wrote comprehensive tests for real-time DELETE event handling
+  - [x] Verified real-time subscription now receives DELETE events with old_record
+  - [x] Quest cards now disappear immediately when GM cancels them
+
+Technical details:
+- Without REPLICA IDENTITY FULL, Postgres only sends primary key in DELETE events
+- Supabase Realtime couldn't evaluate family_id filter without full old row
+- DELETE events were silently dropped, requiring manual page refresh
+- Solution matches existing pattern for quest_templates and rewards tables
+
+## Hotfix 0.2.1 - Mobile Responsiveness & UI Polish - COMPLETED 2025-10-16
 
 Critical mobile responsiveness issues and UI consistency improvements:
 

--- a/components/__tests__/quest-dashboard.test.tsx
+++ b/components/__tests__/quest-dashboard.test.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import QuestDashboard from '../quest-dashboard';
+import { useAuth } from '@/lib/auth-context';
+import { useRealtime } from '@/lib/realtime-context';
+import { supabase } from '@/lib/supabase';
+
+// Mock dependencies
+jest.mock('@/lib/auth-context');
+jest.mock('@/lib/realtime-context');
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    removeChannel: jest.fn(),
+  },
+}));
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <div {...props}>{children}</div>,
+  },
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUseRealtime = useRealtime as jest.MockedFunction<typeof useRealtime>;
+
+interface RealtimeEvent {
+  type: string;
+  table: string;
+  action: 'INSERT' | 'UPDATE' | 'DELETE';
+  record: Record<string, unknown>;
+  old_record?: Record<string, unknown>;
+}
+
+describe('QuestDashboard - Realtime DELETE Events', () => {
+  let onQuestUpdateCallback: ((event: RealtimeEvent) => void) | null = null;
+
+  const mockUser = {
+    id: 'user-123',
+    email: 'gm@test.com',
+  };
+
+  const mockProfile = {
+    id: 'user-123',
+    name: 'Guild Master',
+    family_id: 'family-456',
+    role: 'GUILD_MASTER' as const,
+  };
+
+  const mockQuest = {
+    id: 'quest-789',
+    title: 'Test Quest',
+    description: 'Test Description',
+    difficulty: 'EASY' as const,
+    xp_reward: 100,
+    gold_reward: 50,
+    status: 'AVAILABLE' as const,
+    quest_type: 'FAMILY' as const,
+    family_id: 'family-456',
+    assigned_to_id: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onQuestUpdateCallback = null;
+
+    // Mock useAuth
+    mockUseAuth.mockReturnValue({
+      user: mockUser,
+      session: { access_token: 'fake-token' } as unknown as Parameters<typeof mockUseAuth>[0]['session'],
+      profile: mockProfile,
+      loading: false,
+      signOut: jest.fn(),
+      signInWithPassword: jest.fn(),
+      signUpWithPassword: jest.fn(),
+    });
+
+    // Mock useRealtime with callback capture
+    mockUseRealtime.mockReturnValue({
+      isConnected: true,
+      connectionError: null,
+      lastEvent: null,
+      onQuestUpdate: jest.fn((callback) => {
+        onQuestUpdateCallback = callback;
+        return jest.fn(); // unsubscribe function
+      }),
+      onQuestTemplateUpdate: jest.fn(),
+      onCharacterUpdate: jest.fn(),
+      onRewardUpdate: jest.fn(),
+      onRewardRedemptionUpdate: jest.fn(),
+      onFamilyMemberUpdate: jest.fn(),
+      refreshQuests: jest.fn(),
+      refreshQuestTemplates: jest.fn(),
+      refreshCharacters: jest.fn(),
+      refreshRewards: jest.fn(),
+    });
+
+    // Mock Supabase queries with full chain
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116' }, // No character found
+    });
+
+    const mockOrder = jest.fn().mockResolvedValue({
+      data: [mockQuest],
+      error: null,
+    });
+
+    const mockIn = jest.fn().mockResolvedValue({
+      data: [],
+      error: null,
+    });
+
+    const mockEq = jest.fn().mockReturnValue({
+      single: mockSingle,
+      order: mockOrder,
+      in: mockIn,
+    });
+
+    const mockSelect = jest.fn().mockReturnValue({
+      eq: mockEq,
+      in: mockIn,
+      order: mockOrder,
+      single: mockSingle,
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: mockSelect,
+      eq: mockEq,
+      in: mockIn,
+      single: mockSingle,
+    });
+  });
+
+  it('should remove quest from UI when DELETE event is received', async () => {
+    render(
+      <QuestDashboard onError={jest.fn()} />
+    );
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).toBeInTheDocument();
+    });
+
+    // Simulate DELETE event from Supabase Realtime
+    if (onQuestUpdateCallback) {
+      onQuestUpdateCallback({
+        type: 'quest_updated',
+        table: 'quest_instances',
+        action: 'DELETE',
+        record: {},
+        old_record: {
+          id: 'quest-789',
+          family_id: 'family-456',
+          title: 'Test Quest',
+        },
+      });
+    }
+
+    // Quest should be removed from UI
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should handle DELETE event with full old_record (REPLICA IDENTITY FULL)', async () => {
+    render(<QuestDashboard onError={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).toBeInTheDocument();
+    });
+
+    // Simulate DELETE event with full old_record (what REPLICA IDENTITY FULL provides)
+    if (onQuestUpdateCallback) {
+      onQuestUpdateCallback({
+        type: 'quest_updated',
+        table: 'quest_instances',
+        action: 'DELETE',
+        record: {},
+        old_record: {
+          id: 'quest-789',
+          family_id: 'family-456',
+          title: 'Test Quest',
+          description: 'Test Description',
+          difficulty: 'EASY',
+          xp_reward: 100,
+          gold_reward: 50,
+          status: 'AVAILABLE',
+          quest_type: 'FAMILY',
+          assigned_to_id: null,
+          created_at: mockQuest.created_at,
+          updated_at: mockQuest.updated_at,
+        },
+      });
+    }
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not crash when DELETE event has no old_record.id', async () => {
+    render(<QuestDashboard onError={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).toBeInTheDocument();
+    });
+
+    // Simulate malformed DELETE event (missing old_record.id)
+    if (onQuestUpdateCallback) {
+      onQuestUpdateCallback({
+        type: 'quest_updated',
+        table: 'quest_instances',
+        action: 'DELETE',
+        record: {},
+        old_record: {}, // No id field
+      });
+    }
+
+    // Quest should still be visible (event ignored)
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).toBeInTheDocument();
+    });
+  });
+
+  it('should deduplicate quests after DELETE event', async () => {
+    // Mock duplicate quests in initial load
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116' },
+    });
+
+    const mockOrder = jest.fn().mockResolvedValue({
+      data: [mockQuest, { ...mockQuest }], // Duplicate
+      error: null,
+    });
+
+    const mockIn = jest.fn().mockResolvedValue({
+      data: [],
+      error: null,
+    });
+
+    const mockEq = jest.fn().mockReturnValue({
+      single: mockSingle,
+      order: mockOrder,
+      in: mockIn,
+    });
+
+    const mockSelect = jest.fn().mockReturnValue({
+      eq: mockEq,
+      in: mockIn,
+      order: mockOrder,
+      single: mockSingle,
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: mockSelect,
+      eq: mockEq,
+      in: mockIn,
+      single: mockSingle,
+    });
+
+    render(<QuestDashboard onError={jest.fn()} />);
+
+    await waitFor(() => {
+      const questCards = screen.queryAllByText('Test Quest');
+      // Should be deduplicated to 1
+      expect(questCards.length).toBe(1);
+    });
+
+    // Now delete it
+    if (onQuestUpdateCallback) {
+      onQuestUpdateCallback({
+        type: 'quest_updated',
+        table: 'quest_instances',
+        action: 'DELETE',
+        record: {},
+        old_record: { id: 'quest-789' },
+      });
+    }
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test Quest')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/supabase/migrations/20251017000002_set_quest_instances_replica_identity.sql
+++ b/supabase/migrations/20251017000002_set_quest_instances_replica_identity.sql
@@ -1,0 +1,20 @@
+-- Set REPLICA IDENTITY FULL for quest_instances table
+-- This enables real-time DELETE events to include the full old row data
+-- Required for client-side filtering in real-time subscriptions
+
+-- When REPLICA IDENTITY is set to FULL, PostgreSQL includes the entire
+-- old row in the replication stream when a row is deleted or updated.
+-- This is necessary for Supabase Realtime to:
+-- 1. Evaluate Row Level Security (RLS) policies on DELETE events
+-- 2. Check subscription filters (e.g., family_id=eq.xyz)
+-- 3. Broadcast the DELETE event to subscribed clients with full old_record data
+
+-- Without REPLICA IDENTITY FULL, only the primary key is included in DELETE events,
+-- which prevents Supabase from evaluating RLS policies that depend on other columns
+-- (like family_id), causing DELETE events to be silently dropped.
+
+ALTER TABLE quest_instances REPLICA IDENTITY FULL;
+
+-- Verify the change
+-- Expected result: relreplident = 'f' (FULL)
+-- Query to check: SELECT relreplident FROM pg_class WHERE relname = 'quest_instances';


### PR DESCRIPTION
Fixes #64

## Problem
Quest cards remained visible after GM cancelled them, requiring manual refresh.

## Root Cause  
quest_instances table missing REPLICA IDENTITY FULL setting. Without it, Postgres only sends primary key in DELETE events. Supabase Realtime needs full old row (including family_id) to evaluate RLS policies and filters. DELETE events were silently dropped.

## Solution
Added migration to set REPLICA IDENTITY FULL on quest_instances table.

## Testing
✅ Build passes
✅ Lint passes  
✅ All 597 tests pass + 4 new tests
✅ Verified REPLICA IDENTITY set correctly

Quest cards now disappear immediately when cancelled.