### PR TITLE
Hotfix: GM Can Cancel Assigned Individual Quests (v0.2.6)

### DIFF
--- a/components/quest-dashboard.tsx
+++ b/components/quest-dashboard.tsx
@@ -992,15 +992,26 @@ export default function QuestDashboard({ onError, onLoadQuestsRef }: QuestDashbo
                       <span className={`px-3 py-1 rounded-full text-xs font-semibold ${getStatusColor(quest.status)}`}>
                         {statusLabel}
                       </span>
-                      {quest.status === "COMPLETED" && (
-                        <button
-                          type="button"
-                          className="mt-3 px-4 py-2 rounded-md bg-emerald-700 text-white hover:bg-emerald-600 transition"
-                          onClick={() => handleApproveQuest(quest.id)}
-                        >
-                          Approve
-                        </button>
-                      )}
+                      <div className="flex flex-col gap-2 mt-3">
+                        {quest.status === "COMPLETED" && (
+                          <button
+                            type="button"
+                            className="px-4 py-2 rounded-md bg-emerald-700 text-white hover:bg-emerald-600 transition"
+                            onClick={() => handleApproveQuest(quest.id)}
+                          >
+                            Approve
+                          </button>
+                        )}
+                        {quest.status !== "COMPLETED" && quest.status !== "APPROVED" && (
+                          <button
+                            type="button"
+                            className="px-4 py-2 rounded-md bg-rose-700 text-white hover:bg-rose-600 transition"
+                            onClick={() => handleCancelQuest(quest.id)}
+                          >
+                            Cancel Quest
+                          </button>
+                        )}
+                      </div>
                     </div>
                   </div>
                 </motion.div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chorequest",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

Fixes issue where Guild Masters (GMs) cannot cancel assigned individual quests, which prevented resolving duplicate quests.

- Fixes #63 - GM cannot cancel assigned individual quests to resolve duplicates

## Problem

Previously, the Cancel Quest button only appeared for unassigned quests. This created problems when:
- Duplicate quests were generated (e.g., when changing family week start day mid-cycle)
- A character ended up with two active quests from the same template
- GMs could cancel family quests but not assigned individual quests

## Changes

### Quest Dashboard UI (components/quest-dashboard.tsx)
- Added Cancel Quest button to "Family Quests" section for assigned quests
- Cancel button appears for all active quests (not COMPLETED or APPROVED)
- Maintains existing DELETE behavior (consistent with unassigned quests)
- Uses existing `handleCancelQuest` function with confirmation dialog

## Technical Implementation

- Modified components/quest-dashboard.tsx (lines 991-1015)
- No database schema changes required
- RLS policies already support GM deletion of assigned quests
- Consistent styling and behavior with existing cancel buttons

## Test Plan

✅ Build passes with zero compilation errors
✅ All 597 unit tests pass
✅ Lint errors are pre-existing (not introduced by this change)

## Testing Checklist

Please verify:
- [ ] GM can cancel assigned individual quest
- [ ] GM can cancel unassigned individual quest (existing behavior maintained)
- [ ] Confirmation dialog appears before cancellation
- [ ] Non-GM members cannot see cancel button on assigned quests
- [ ] Canceled quest is removed from the list
- [ ] Cannot cancel COMPLETED or APPROVED quests
- [ ] Duplicate quest scenario works (change week start day, cancel duplicate)