### PR TITLE
Refactor: Decompose quest-management-tab and quest-dashboard (#48)

### DIFF
--- a/components/admin/__tests__/quest-management-section.test.tsx
+++ b/components/admin/__tests__/quest-management-section.test.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { QuestManagementSection } from "../quest-management-section";
+import { QuestInstance } from "@/lib/types/database";
+
+jest.mock("@/components/quests/quest-card", () => {
+  return function MockQuestCard({
+    quest,
+    viewMode,
+    hideAssignment,
+  }: {
+    quest: { id: string; title: string };
+    viewMode: string;
+    hideAssignment?: boolean;
+  }) {
+    return (
+      <div
+        data-testid={`quest-card-${quest.id}`}
+        data-view-mode={viewMode}
+        data-hide-assignment={hideAssignment ? "true" : "false"}
+      >
+        {quest.title}
+      </div>
+    );
+  };
+});
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+jest.mock("@/lib/animations/variants", () => ({
+  staggerContainer: {},
+}));
+
+const makeQuest = (overrides: Partial<QuestInstance> = {}): QuestInstance => ({
+  id: "quest-1",
+  title: "Test Quest",
+  description: "",
+  difficulty: "EASY",
+  status: "PENDING",
+  xp_reward: 100,
+  gold_reward: 50,
+  category: "DAILY",
+  created_by_id: "user-1",
+  due_date: null,
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+  recurrence_pattern: null,
+  assigned_to_id: null,
+  completed_at: null,
+  approved_at: null,
+  streak_bonus: null,
+  streak_count: null,
+  volunteer_bonus: null,
+  volunteered_by: null,
+  template_id: null,
+  quest_type: null,
+  cycle_start_date: null,
+  cycle_end_date: null,
+  family_id: "family-1",
+  ...overrides,
+});
+
+const defaultProps = {
+  title: "Unassigned",
+  count: 0,
+  quests: [] as QuestInstance[],
+  emptyMessage: "All quests have been assigned",
+  familyMembers: [],
+  selectedAssignee: {},
+  getAssignedHeroName: jest.fn().mockReturnValue(undefined),
+  onAssigneeChange: jest.fn(),
+  onAssign: jest.fn(),
+  onApprove: jest.fn(),
+  onDeny: jest.fn(),
+  onCancel: jest.fn(),
+  onRelease: jest.fn(),
+};
+
+describe("QuestManagementSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders section header with title and count", () => {
+    render(
+      <QuestManagementSection {...defaultProps} title="Unassigned" count={3} />,
+    );
+
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows empty message when quests array is empty", () => {
+    render(<QuestManagementSection {...defaultProps} quests={[]} />);
+
+    expect(
+      screen.getByText("All quests have been assigned"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId(/quest-card/)).not.toBeInTheDocument();
+  });
+
+  it("renders quest cards when quests are present", () => {
+    const quests = [
+      makeQuest({ id: "q1", title: "Quest One" }),
+      makeQuest({ id: "q2", title: "Quest Two" }),
+    ];
+
+    render(
+      <QuestManagementSection {...defaultProps} quests={quests} count={2} />,
+    );
+
+    expect(screen.getByTestId("quest-card-q1")).toBeInTheDocument();
+    expect(screen.getByTestId("quest-card-q2")).toBeInTheDocument();
+    expect(
+      screen.queryByText("All quests have been assigned"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("passes gm viewMode to QuestCard", () => {
+    const quests = [makeQuest({ id: "q1" })];
+
+    render(
+      <QuestManagementSection {...defaultProps} quests={quests} count={1} />,
+    );
+
+    expect(screen.getByTestId("quest-card-q1")).toHaveAttribute(
+      "data-view-mode",
+      "gm",
+    );
+  });
+
+  it("passes hideAssignment=false by default", () => {
+    const quests = [makeQuest({ id: "q1" })];
+
+    render(
+      <QuestManagementSection {...defaultProps} quests={quests} count={1} />,
+    );
+
+    expect(screen.getByTestId("quest-card-q1")).toHaveAttribute(
+      "data-hide-assignment",
+      "false",
+    );
+  });
+
+  it("passes hideAssignment=true when prop is set", () => {
+    const quests = [makeQuest({ id: "q1" })];
+
+    render(
+      <QuestManagementSection
+        {...defaultProps}
+        quests={quests}
+        count={1}
+        hideAssignment
+      />,
+    );
+
+    expect(screen.getByTestId("quest-card-q1")).toHaveAttribute(
+      "data-hide-assignment",
+      "true",
+    );
+  });
+});

--- a/components/admin/__tests__/useQuestManagementActions.test.ts
+++ b/components/admin/__tests__/useQuestManagementActions.test.ts
@@ -1,0 +1,248 @@
+import { renderHook, act } from "@testing-library/react";
+import { useQuestManagementActions } from "../useQuestManagementActions";
+import { questInstanceApiService } from "@/lib/quest-instance-api-service";
+
+jest.mock("@/lib/quest-instance-api-service", () => ({
+  questInstanceApiService: {
+    assignFamilyQuest: jest.fn(),
+    approveQuest: jest.fn(),
+    denyQuest: jest.fn(),
+    cancelQuest: jest.fn(),
+    releaseQuest: jest.fn(),
+  },
+}));
+
+const mockApi = jest.mocked(questInstanceApiService);
+
+const makeProps = () => ({
+  reload: jest.fn().mockResolvedValue(undefined),
+  success: jest.fn(),
+  error: jest.fn(),
+});
+
+describe("useQuestManagementActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("handleAssignQuest", () => {
+    it("assigns quest, clears assignee, shows success, and reloads", async () => {
+      const props = makeProps();
+      mockApi.assignFamilyQuest.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      await act(async () => {
+        await result.current.handleAssignQuest("quest-1", "char-1");
+      });
+
+      expect(mockApi.assignFamilyQuest).toHaveBeenCalledWith(
+        "quest-1",
+        "char-1",
+      );
+      expect(props.success).toHaveBeenCalledWith(
+        "Quest assigned successfully!",
+      );
+      expect(props.reload).toHaveBeenCalled();
+      expect(result.current.selectedAssignee["quest-1"]).toBe("");
+    });
+
+    it("does nothing when characterId is empty", async () => {
+      const props = makeProps();
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      await act(async () => {
+        await result.current.handleAssignQuest("quest-1", "");
+      });
+
+      expect(mockApi.assignFamilyQuest).not.toHaveBeenCalled();
+    });
+
+    it("shows error notification on failure", async () => {
+      const props = makeProps();
+      mockApi.assignFamilyQuest.mockRejectedValueOnce(new Error("API error"));
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      await act(async () => {
+        await result.current.handleAssignQuest("quest-1", "char-1");
+      });
+
+      expect(props.error).toHaveBeenCalledWith("API error");
+      expect(result.current.isProcessing).toBe(false);
+    });
+  });
+
+  describe("handleApproveQuest", () => {
+    it("approves quest, shows success, and reloads", async () => {
+      const props = makeProps();
+      mockApi.approveQuest.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      await act(async () => {
+        await result.current.handleApproveQuest("quest-1");
+      });
+
+      expect(mockApi.approveQuest).toHaveBeenCalledWith("quest-1");
+      expect(props.success).toHaveBeenCalledWith("Quest approved!");
+      expect(props.reload).toHaveBeenCalled();
+    });
+
+    it("shows error notification on failure", async () => {
+      const props = makeProps();
+      mockApi.approveQuest.mockRejectedValueOnce(new Error("Approve failed"));
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      await act(async () => {
+        await result.current.handleApproveQuest("quest-1");
+      });
+
+      expect(props.error).toHaveBeenCalledWith("Approve failed");
+    });
+  });
+
+  describe("confirmation modal flow", () => {
+    it("handleDenyQuest opens modal with deny action", () => {
+      const props = makeProps();
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleDenyQuest("quest-1");
+      });
+
+      expect(result.current.confirmModal.isOpen).toBe(true);
+      expect(result.current.confirmModal.action).toBe("deny");
+      expect(result.current.confirmModal.questId).toBe("quest-1");
+      expect(result.current.confirmModal.title).toBe(
+        "Send Quest Back to Pending?",
+      );
+    });
+
+    it("handleCancelQuest opens modal with cancel action", () => {
+      const props = makeProps();
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleCancelQuest("quest-2");
+      });
+
+      expect(result.current.confirmModal.isOpen).toBe(true);
+      expect(result.current.confirmModal.action).toBe("cancel");
+      expect(result.current.confirmModal.questId).toBe("quest-2");
+    });
+
+    it("handleReleaseQuest opens modal with release action", () => {
+      const props = makeProps();
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleReleaseQuest("quest-3");
+      });
+
+      expect(result.current.confirmModal.isOpen).toBe(true);
+      expect(result.current.confirmModal.action).toBe("release");
+      expect(result.current.confirmModal.questId).toBe("quest-3");
+    });
+
+    it("handleConfirmAction executes deny and closes modal", async () => {
+      const props = makeProps();
+      mockApi.denyQuest.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleDenyQuest("quest-1");
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmAction();
+      });
+
+      expect(mockApi.denyQuest).toHaveBeenCalledWith("quest-1");
+      expect(props.success).toHaveBeenCalledWith("Quest sent back to pending.");
+      expect(result.current.confirmModal.isOpen).toBe(false);
+      expect(props.reload).toHaveBeenCalled();
+    });
+
+    it("handleConfirmAction executes cancel and closes modal", async () => {
+      const props = makeProps();
+      mockApi.cancelQuest.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleCancelQuest("quest-1");
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmAction();
+      });
+
+      expect(mockApi.cancelQuest).toHaveBeenCalledWith("quest-1");
+      expect(props.success).toHaveBeenCalledWith("Quest cancelled.");
+    });
+
+    it("handleConfirmAction executes release and closes modal", async () => {
+      const props = makeProps();
+      mockApi.releaseQuest.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleReleaseQuest("quest-1");
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmAction();
+      });
+
+      expect(mockApi.releaseQuest).toHaveBeenCalledWith("quest-1");
+      expect(props.success).toHaveBeenCalledWith(
+        "Quest released back to available quests.",
+      );
+    });
+
+    it("handleConfirmAction shows error on failure", async () => {
+      const props = makeProps();
+      mockApi.denyQuest.mockRejectedValueOnce(new Error("Deny failed"));
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleDenyQuest("quest-1");
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmAction();
+      });
+
+      expect(props.error).toHaveBeenCalledWith(
+        "Failed to deny quest. Please try again.",
+      );
+      expect(result.current.isProcessing).toBe(false);
+    });
+
+    it("handleDismissModal closes modal without acting", () => {
+      const props = makeProps();
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleDenyQuest("quest-1");
+      });
+      expect(result.current.confirmModal.isOpen).toBe(true);
+
+      act(() => {
+        result.current.handleDismissModal();
+      });
+      expect(result.current.confirmModal.isOpen).toBe(false);
+      expect(mockApi.denyQuest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleAssigneeChange", () => {
+    it("updates selectedAssignee state", () => {
+      const props = makeProps();
+      const { result } = renderHook(() => useQuestManagementActions(props));
+
+      act(() => {
+        result.current.handleAssigneeChange("quest-1", "char-42");
+      });
+
+      expect(result.current.selectedAssignee["quest-1"]).toBe("char-42");
+    });
+  });
+});

--- a/components/admin/quest-management-section.tsx
+++ b/components/admin/quest-management-section.tsx
@@ -1,0 +1,87 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+import QuestCard from "@/components/quests/quest-card";
+import { staggerContainer } from "@/lib/animations/variants";
+import type { QuestInstance } from "@/lib/types/database";
+
+interface AssignmentOption {
+  id: string;
+  name: string;
+}
+
+interface QuestManagementSectionProps {
+  title: string;
+  count: number;
+  quests: QuestInstance[];
+  emptyMessage: string;
+  familyMembers: AssignmentOption[];
+  selectedAssignee: Record<string, string>;
+  hideAssignment?: boolean;
+  getAssignedHeroName: (quest: QuestInstance) => string | undefined;
+  onAssigneeChange: (questId: string, userId: string) => void;
+  onAssign: (questId: string, characterId: string) => Promise<void>;
+  onApprove: (questId: string) => Promise<void>;
+  onDeny: (questId: string) => void;
+  onCancel: (questId: string) => void;
+  onRelease: (questId: string) => void;
+}
+
+export function QuestManagementSection({
+  title,
+  count,
+  quests,
+  emptyMessage,
+  familyMembers,
+  selectedAssignee,
+  hideAssignment = false,
+  getAssignedHeroName,
+  onAssigneeChange,
+  onAssign,
+  onApprove,
+  onDeny,
+  onCancel,
+  onRelease,
+}: QuestManagementSectionProps) {
+  return (
+    <motion.div className="space-y-4">
+      <div className="flex items-center gap-3 mb-4">
+        <h3 className="text-lg font-semibold text-gray-100">{title}</h3>
+        <span className="px-3 py-1 rounded-full bg-gold-600/20 text-gold-200 text-sm font-medium">
+          {count}
+        </span>
+      </div>
+
+      {quests.length === 0 ? (
+        <div className="p-6 bg-dark-700/50 border border-dark-600 rounded-lg text-center">
+          <p className="text-gray-400">{emptyMessage}</p>
+        </div>
+      ) : (
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+          className="grid grid-cols-1 gap-4"
+        >
+          {quests.map((quest) => (
+            <QuestCard
+              key={quest.id}
+              quest={quest}
+              viewMode="gm"
+              familyMembers={familyMembers}
+              assignedHeroName={getAssignedHeroName(quest)}
+              selectedAssignee={selectedAssignee[quest.id] || ""}
+              onAssigneeChange={onAssigneeChange}
+              onAssign={onAssign}
+              onApprove={onApprove}
+              onDeny={onDeny}
+              onCancel={onCancel}
+              onRelease={onRelease}
+              hideAssignment={hideAssignment}
+            />
+          ))}
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}

--- a/components/admin/quest-management-tab.tsx
+++ b/components/admin/quest-management-tab.tsx
@@ -1,194 +1,52 @@
-'use client';
-import React, { useMemo, useCallback, useState } from 'react';
-import { motion } from 'framer-motion';
-import { useQuests } from '@/hooks/useQuests';
-import { useFamilyMembers } from '@/hooks/useFamilyMembers';
-import { useAuth } from '@/lib/auth-context';
-import { useNotification } from '@/hooks/useNotification';
-import QuestCard from '@/components/quests/quest-card';
-import PendingApprovalsSection from '@/components/quests/pending-approvals-section';
+"use client";
+import React, { useMemo } from "react";
+import { useQuests } from "@/hooks/useQuests";
+import { useFamilyMembers } from "@/hooks/useFamilyMembers";
+import { useNotification } from "@/hooks/useNotification";
+import PendingApprovalsSection from "@/components/quests/pending-approvals-section";
 import {
   filterPendingApprovalQuests,
   filterUnassignedActiveQuests,
   filterInProgressQuests,
   getAssignedHeroName,
   mapFamilyCharactersToAssignmentDisplay,
-} from '@/components/quests/quest-dashboard/quest-helpers';
-import { staggerContainer } from '@/lib/animations/variants';
-import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import { NotificationContainer } from '@/components/ui/NotificationContainer';
-import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
-import { questInstanceApiService } from '@/lib/quest-instance-api-service';
-import type { QuestInstance } from '@/lib/types/database';
-
-interface QuestSection {
-  title: string;
-  quests: QuestInstance[];
-  emptyMessage: string;
-  count: number;
-}
+} from "@/components/quests/quest-dashboard/quest-helpers";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { NotificationContainer } from "@/components/ui/NotificationContainer";
+import { ConfirmationModal } from "@/components/ui/ConfirmationModal";
+import { useQuestManagementActions } from "./useQuestManagementActions";
+import { QuestManagementSection } from "./quest-management-section";
 
 export function QuestManagementTab() {
   const { quests, loading, error, reload } = useQuests();
   const { familyCharacters } = useFamilyMembers();
-  useAuth();
-  const { notifications, dismiss, success, error: showError } = useNotification();
-  const [selectedAssignee, setSelectedAssignee] = useState<Record<string, string>>({});
-  const [confirmModal, setConfirmModal] = useState<{
-    isOpen: boolean;
-    title: string;
-    message: string;
-    action: string;
-    questId: string;
-  }>({
-    isOpen: false,
-    title: '',
-    message: '',
-    action: '',
-    questId: '',
+  const {
+    notifications,
+    dismiss,
+    success,
+    error: showError,
+  } = useNotification();
+
+  const actions = useQuestManagementActions({
+    reload,
+    success,
+    error: showError,
   });
-  const [isProcessing, setIsProcessing] = useState(false);
-
-  const handleAssignQuest = useCallback(
-    async (questId: string, characterId: string) => {
-      if (!characterId) return;
-      try {
-        setIsProcessing(true);
-        await questInstanceApiService.assignFamilyQuest(questId, characterId);
-        setSelectedAssignee((prev) => ({ ...prev, [questId]: '' }));
-        success('Quest assigned successfully!');
-        await reload();
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Failed to assign quest. Please try again.';
-        console.error('Failed to assign quest:', err);
-        showError(errorMessage);
-      } finally {
-        setIsProcessing(false);
-      }
-    },
-    [reload, success, showError]
-  );
-
-  const handleApproveQuest = useCallback(
-    async (questId: string) => {
-      try {
-        setIsProcessing(true);
-        await questInstanceApiService.approveQuest(questId);
-        success('Quest approved!');
-        await reload();
-      } catch (err) {
-        console.error('Failed to approve quest:', err);
-        const errorMessage = err instanceof Error ? err.message : 'Failed to approve quest. Please try again.';
-        showError(errorMessage);
-      } finally {
-        setIsProcessing(false);
-      }
-    },
-    [reload, success, showError]
-  );
-
-  const handleDenyQuest = useCallback(
-    async (questId: string) => {
-      setConfirmModal({
-        isOpen: true,
-        title: 'Send Quest Back to Pending?',
-        message: 'The hero can then work on it or abandon it.',
-        action: 'deny',
-        questId,
-      });
-    },
-    []
-  );
-
-  const handleCancelQuest = useCallback(
-    async (questId: string) => {
-      setConfirmModal({
-        isOpen: true,
-        title: 'Cancel Quest?',
-        message: 'Are you sure you want to cancel this quest?',
-        action: 'cancel',
-        questId,
-      });
-    },
-    []
-  );
-
-  const handleReleaseQuest = useCallback(
-    async (questId: string) => {
-      setConfirmModal({
-        isOpen: true,
-        title: 'Release Quest?',
-        message: 'Release this quest back to available quests?',
-        action: 'release',
-        questId,
-      });
-    },
-    []
-  );
-
-  const handleConfirmAction = useCallback(
-    async (action: string, questId: string) => {
-      try {
-        setIsProcessing(true);
-        if (action === 'deny') {
-          await questInstanceApiService.denyQuest(questId);
-          success('Quest sent back to pending.');
-        } else if (action === 'cancel') {
-          await questInstanceApiService.cancelQuest(questId);
-          success('Quest cancelled.');
-        } else if (action === 'release') {
-          await questInstanceApiService.releaseQuest(questId);
-          success('Quest released back to available quests.');
-        }
-        setConfirmModal({ ...confirmModal, isOpen: false });
-        await reload();
-      } catch (err) {
-        console.error(`Failed to ${action} quest:`, err);
-        const actionText =
-          action === 'deny' ? 'deny' : action === 'cancel' ? 'cancel' : 'release';
-        showError(`Failed to ${actionText} quest. Please try again.`);
-      } finally {
-        setIsProcessing(false);
-      }
-    },
-    [confirmModal, reload, success, showError]
-  );
-
-  const handleAssigneeChange = useCallback((questId: string, userId: string) => {
-    setSelectedAssignee((prev) => ({ ...prev, [questId]: userId }));
-  }, []);
 
   const assignableCharacters = useMemo(
     () => mapFamilyCharactersToAssignmentDisplay(familyCharacters),
-    [familyCharacters]
+    [familyCharacters],
   );
 
   const questSections = useMemo(() => {
     const pendingApproval = filterPendingApprovalQuests(quests);
     const unassigned = filterUnassignedActiveQuests(quests);
     const inProgress = filterInProgressQuests(quests);
-
-    return {
-      pendingApproval: {
-        title: 'Pending Approval',
-        quests: pendingApproval,
-        emptyMessage: 'No quests awaiting approval',
-        count: pendingApproval.length,
-      },
-      unassigned: {
-        title: 'Unassigned',
-        quests: unassigned,
-        emptyMessage: 'All quests have been assigned',
-        count: unassigned.length,
-      },
-      inProgress: {
-        title: 'In Progress',
-        quests: inProgress,
-        emptyMessage: 'No quests currently in progress',
-        count: inProgress.length,
-      },
-    };
+    return { pendingApproval, unassigned, inProgress };
   }, [quests]);
+
+  const resolveHeroName = (quest: (typeof quests)[0]) =>
+    getAssignedHeroName(quest, familyCharacters);
 
   if (loading) {
     return (
@@ -201,98 +59,78 @@ export function QuestManagementTab() {
   if (error) {
     return (
       <div className="p-6 bg-red-900/20 border border-red-800 rounded-lg">
-        <h3 className="text-red-200 font-semibold mb-2">Error Loading Quests</h3>
+        <h3 className="text-red-200 font-semibold mb-2">
+          Error Loading Quests
+        </h3>
         <p className="text-red-300 text-sm">{error}</p>
       </div>
     );
   }
 
-  // Section renderer
-  const renderSection = (section: QuestSection, hideAssignment: boolean = false) => {
-    const sectionQuests = section.quests;
-
-    return (
-      <motion.div key={section.title} className="space-y-4">
-        {/* Section Header */}
-        <div className="flex items-center gap-3 mb-4">
-          <h3 className="text-lg font-semibold text-gray-100">{section.title}</h3>
-          <span className="px-3 py-1 rounded-full bg-gold-600/20 text-gold-200 text-sm font-medium">
-            {section.count}
-          </span>
-        </div>
-
-        {/* Section Content */}
-        {sectionQuests.length === 0 ? (
-          <div className="p-6 bg-dark-700/50 border border-dark-600 rounded-lg text-center">
-            <p className="text-gray-400">{section.emptyMessage}</p>
-          </div>
-        ) : (
-          <motion.div
-            variants={staggerContainer}
-            initial="hidden"
-            animate="visible"
-            className="grid grid-cols-1 gap-4"
-          >
-            {sectionQuests.map((quest) => (
-              <QuestCard
-                key={quest.id}
-                quest={quest}
-                viewMode="gm"
-                familyMembers={assignableCharacters}
-                assignedHeroName={getAssignedHeroName(quest, familyCharacters)}
-                selectedAssignee={selectedAssignee[quest.id] || ''}
-                onAssigneeChange={handleAssigneeChange}
-                onAssign={handleAssignQuest}
-                onApprove={handleApproveQuest}
-                onDeny={handleDenyQuest}
-                onCancel={handleCancelQuest}
-                onRelease={handleReleaseQuest}
-                hideAssignment={hideAssignment}
-              />
-            ))}
-          </motion.div>
-        )}
-      </motion.div>
-    );
+  const sectionProps = {
+    familyMembers: assignableCharacters,
+    selectedAssignee: actions.selectedAssignee,
+    getAssignedHeroName: resolveHeroName,
+    onAssigneeChange: actions.handleAssigneeChange,
+    onAssign: actions.handleAssignQuest,
+    onApprove: actions.handleApproveQuest,
+    onDeny: actions.handleDenyQuest,
+    onCancel: actions.handleCancelQuest,
+    onRelease: actions.handleReleaseQuest,
   };
 
   return (
     <>
-      <NotificationContainer notifications={notifications} onDismiss={dismiss} />
+      <NotificationContainer
+        notifications={notifications}
+        onDismiss={dismiss}
+      />
       <ConfirmationModal
-        isOpen={confirmModal.isOpen}
-        title={confirmModal.title}
-        message={confirmModal.message}
+        isOpen={actions.confirmModal.isOpen}
+        title={actions.confirmModal.title}
+        message={actions.confirmModal.message}
         confirmText="Confirm"
         cancelText="Cancel"
-        isLoading={isProcessing}
-        onConfirm={() => handleConfirmAction(confirmModal.action, confirmModal.questId)}
-        onCancel={() => setConfirmModal({ ...confirmModal, isOpen: false })}
+        isLoading={actions.isProcessing}
+        onConfirm={actions.handleConfirmAction}
+        onCancel={actions.handleDismissModal}
       />
       <div className="space-y-8" data-testid="quest-management-tab">
-        {/* Pending Approval Section */}
         <PendingApprovalsSection
-          quests={questSections.pendingApproval.quests}
+          quests={questSections.pendingApproval}
           assignmentOptions={assignableCharacters}
-          selectedAssignees={selectedAssignee}
-          onAssigneeChange={handleAssigneeChange}
-          onAssign={handleAssignQuest}
-          onApprove={handleApproveQuest}
-          onDeny={handleDenyQuest}
-          onCancel={handleCancelQuest}
-          onRelease={handleReleaseQuest}
-          getAssignedHeroName={(quest) => getAssignedHeroName(quest, familyCharacters)}
+          selectedAssignees={actions.selectedAssignee}
+          onAssigneeChange={actions.handleAssigneeChange}
+          onAssign={actions.handleAssignQuest}
+          onApprove={actions.handleApproveQuest}
+          onDeny={actions.handleDenyQuest}
+          onCancel={actions.handleCancelQuest}
+          onRelease={actions.handleReleaseQuest}
+          getAssignedHeroName={(quest) =>
+            getAssignedHeroName(quest, familyCharacters)
+          }
         />
 
         <hr className="border-dark-600" />
 
-        {/* Unassigned Section */}
-        {renderSection(questSections.unassigned)}
+        <QuestManagementSection
+          title="Unassigned"
+          count={questSections.unassigned.length}
+          quests={questSections.unassigned}
+          emptyMessage="All quests have been assigned"
+          {...sectionProps}
+        />
 
         <hr className="border-dark-600" />
 
-        {/* In Progress Section */}
-        {renderSection(questSections.inProgress, true)}
+        <QuestManagementSection
+          title="In Progress"
+          count={questSections.inProgress.length}
+          quests={questSections.inProgress}
+          emptyMessage="No quests currently in progress"
+          hideAssignment
+          {...sectionProps}
+        />
       </div>
     </>
   );

--- a/components/admin/useQuestManagementActions.ts
+++ b/components/admin/useQuestManagementActions.ts
@@ -1,0 +1,163 @@
+"use client";
+import { useCallback, useState } from "react";
+import { questInstanceApiService } from "@/lib/quest-instance-api-service";
+
+interface ConfirmModalState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  action: string;
+  questId: string;
+}
+
+const CLOSED_MODAL: ConfirmModalState = {
+  isOpen: false,
+  title: "",
+  message: "",
+  action: "",
+  questId: "",
+};
+
+interface UseQuestManagementActionsProps {
+  reload: () => Promise<void>;
+  success: (message: string) => void;
+  error: (message: string) => void;
+}
+
+export function useQuestManagementActions({
+  reload,
+  success,
+  error,
+}: UseQuestManagementActionsProps) {
+  const [selectedAssignee, setSelectedAssignee] = useState<
+    Record<string, string>
+  >({});
+  const [confirmModal, setConfirmModal] =
+    useState<ConfirmModalState>(CLOSED_MODAL);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleAssigneeChange = useCallback(
+    (questId: string, userId: string) => {
+      setSelectedAssignee((prev) => ({ ...prev, [questId]: userId }));
+    },
+    [],
+  );
+
+  const handleAssignQuest = useCallback(
+    async (questId: string, characterId: string) => {
+      if (!characterId) return;
+      try {
+        setIsProcessing(true);
+        await questInstanceApiService.assignFamilyQuest(questId, characterId);
+        setSelectedAssignee((prev) => ({ ...prev, [questId]: "" }));
+        success("Quest assigned successfully!");
+        await reload();
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Failed to assign quest. Please try again.";
+        console.error("Failed to assign quest:", err);
+        error(message);
+      } finally {
+        setIsProcessing(false);
+      }
+    },
+    [reload, success, error],
+  );
+
+  const handleApproveQuest = useCallback(
+    async (questId: string) => {
+      try {
+        setIsProcessing(true);
+        await questInstanceApiService.approveQuest(questId);
+        success("Quest approved!");
+        await reload();
+      } catch (err) {
+        console.error("Failed to approve quest:", err);
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Failed to approve quest. Please try again.";
+        error(message);
+      } finally {
+        setIsProcessing(false);
+      }
+    },
+    [reload, success, error],
+  );
+
+  const handleDenyQuest = useCallback((questId: string) => {
+    setConfirmModal({
+      isOpen: true,
+      title: "Send Quest Back to Pending?",
+      message: "The hero can then work on it or abandon it.",
+      action: "deny",
+      questId,
+    });
+  }, []);
+
+  const handleCancelQuest = useCallback((questId: string) => {
+    setConfirmModal({
+      isOpen: true,
+      title: "Cancel Quest?",
+      message: "Are you sure you want to cancel this quest?",
+      action: "cancel",
+      questId,
+    });
+  }, []);
+
+  const handleReleaseQuest = useCallback((questId: string) => {
+    setConfirmModal({
+      isOpen: true,
+      title: "Release Quest?",
+      message: "Release this quest back to available quests?",
+      action: "release",
+      questId,
+    });
+  }, []);
+
+  const handleConfirmAction = useCallback(async () => {
+    const { action, questId } = confirmModal;
+    try {
+      setIsProcessing(true);
+      if (action === "deny") {
+        await questInstanceApiService.denyQuest(questId);
+        success("Quest sent back to pending.");
+      } else if (action === "cancel") {
+        await questInstanceApiService.cancelQuest(questId);
+        success("Quest cancelled.");
+      } else if (action === "release") {
+        await questInstanceApiService.releaseQuest(questId);
+        success("Quest released back to available quests.");
+      }
+      setConfirmModal(CLOSED_MODAL);
+      await reload();
+    } catch (err) {
+      console.error(`Failed to ${action} quest:`, err);
+      const actionText =
+        action === "deny" ? "deny" : action === "cancel" ? "cancel" : "release";
+      error(`Failed to ${actionText} quest. Please try again.`);
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [confirmModal, reload, success, error]);
+
+  const handleDismissModal = useCallback(() => {
+    setConfirmModal(CLOSED_MODAL);
+  }, []);
+
+  return {
+    selectedAssignee,
+    handleAssigneeChange,
+    confirmModal,
+    isProcessing,
+    handleAssignQuest,
+    handleApproveQuest,
+    handleDenyQuest,
+    handleCancelQuest,
+    handleReleaseQuest,
+    handleConfirmAction,
+    handleDismissModal,
+  };
+}

--- a/components/quests/quest-dashboard/__tests__/family-quest-section.test.tsx
+++ b/components/quests/quest-dashboard/__tests__/family-quest-section.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { FamilyQuestSection } from "../family-quest-section";
+import type { Character, QuestInstance } from "@/lib/types/database";
+
+jest.mock("@/components/family/family-quest-claiming", () => {
+  return function MockFamilyQuestClaiming({ quests }: { quests: unknown[] }) {
+    return (
+      <div data-testid="family-quest-claiming">{quests.length} quests</div>
+    );
+  };
+});
+
+const mockCharacter: Character = {
+  id: "char-1",
+  user_id: "user-1",
+  name: "Knight Nova",
+  class: "KNIGHT",
+  level: 1,
+  xp: 0,
+  gold: 0,
+  gems: 0,
+  avatar_url: null,
+  family_id: "family-1",
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+  streak_count: 0,
+  last_activity_date: null,
+};
+
+const mockQuest: QuestInstance = {
+  id: "quest-1",
+  title: "Family Quest",
+  description: "",
+  difficulty: "EASY",
+  status: "PENDING",
+  xp_reward: 100,
+  gold_reward: 50,
+  category: "DAILY",
+  created_by_id: "user-1",
+  due_date: null,
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+  recurrence_pattern: null,
+  assigned_to_id: null,
+  completed_at: null,
+  approved_at: null,
+  streak_bonus: null,
+  streak_count: null,
+  volunteer_bonus: null,
+  volunteered_by: null,
+  template_id: null,
+  quest_type: null,
+  cycle_start_date: null,
+  cycle_end_date: null,
+  family_id: "family-1",
+};
+
+describe("FamilyQuestSection", () => {
+  it("renders FamilyQuestClaiming when character and quests exist", () => {
+    render(
+      <FamilyQuestSection
+        quests={[mockQuest]}
+        character={mockCharacter}
+        onClaimQuest={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("family-quest-claiming")).toBeInTheDocument();
+  });
+
+  it("renders nothing when character is null", () => {
+    const { container } = render(
+      <FamilyQuestSection
+        quests={[mockQuest]}
+        character={null}
+        onClaimQuest={jest.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when quests array is empty", () => {
+    const { container } = render(
+      <FamilyQuestSection
+        quests={[]}
+        character={mockCharacter}
+        onClaimQuest={jest.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/components/quests/quest-dashboard/__tests__/my-quests-section.test.tsx
+++ b/components/quests/quest-dashboard/__tests__/my-quests-section.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MyQuestsSection } from "../my-quests-section";
+
+jest.mock("../quest-list", () => {
+  return function MockQuestList({
+    quests,
+    emptyMessage,
+    emptyHint,
+  }: {
+    quests: unknown[];
+    emptyMessage?: string;
+    emptyHint?: string;
+  }) {
+    return (
+      <div data-testid="quest-list">
+        {quests.length === 0 ? (
+          <>
+            <p>{emptyMessage}</p>
+            {emptyHint && <p data-testid="empty-hint">{emptyHint}</p>}
+          </>
+        ) : (
+          <span>{quests.length} quests</span>
+        )}
+      </div>
+    );
+  };
+});
+
+const defaultProps = {
+  activeQuests: [],
+  historicalQuestCount: 0,
+  bossHistoryCount: 0,
+  onStartQuest: jest.fn(),
+  onCompleteQuest: jest.fn(),
+  onReleaseQuest: jest.fn(),
+  familyMembers: [],
+  isHighlighted: jest.fn().mockReturnValue(false),
+};
+
+describe("MyQuestsSection", () => {
+  it("renders the My Quests heading", () => {
+    render(<MyQuestsSection {...defaultProps} />);
+    expect(screen.getByText(/My Quests/)).toBeInTheDocument();
+  });
+
+  it("does not show history hint when no history", () => {
+    render(
+      <MyQuestsSection
+        {...defaultProps}
+        historicalQuestCount={0}
+        bossHistoryCount={0}
+      />,
+    );
+    expect(
+      screen.queryByText(/Completed adventures live in Quest History/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows history hint when there is quest history", () => {
+    render(<MyQuestsSection {...defaultProps} historicalQuestCount={3} />);
+    expect(
+      screen.getByText(/Completed adventures live in Quest History/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows history hint when there is boss history", () => {
+    render(<MyQuestsSection {...defaultProps} bossHistoryCount={1} />);
+    expect(
+      screen.getByText(/Completed adventures live in Quest History/),
+    ).toBeInTheDocument();
+  });
+
+  it("passes emptyHint to QuestList when history exists", () => {
+    render(<MyQuestsSection {...defaultProps} historicalQuestCount={2} />);
+    expect(screen.getByTestId("empty-hint")).toHaveTextContent(
+      "Check Quest History to revisit your completed quests.",
+    );
+  });
+
+  it("does not pass emptyHint to QuestList when no history", () => {
+    render(<MyQuestsSection {...defaultProps} />);
+    expect(screen.queryByTestId("empty-hint")).not.toBeInTheDocument();
+  });
+});

--- a/components/quests/quest-dashboard/__tests__/quest-history-section.test.tsx
+++ b/components/quests/quest-dashboard/__tests__/quest-history-section.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuestHistorySection } from "../quest-history-section";
+import type { QuestInstance } from "@/lib/types/database";
+
+jest.mock("../quest-list", () => {
+  return function MockQuestList({ quests }: { quests: unknown[] }) {
+    return <div data-testid="quest-list">{quests.length} quests</div>;
+  };
+});
+
+jest.mock("@/components/boss/boss-quest-history-list", () => ({
+  BossQuestHistoryList: function MockBossQuestHistoryList({
+    bossQuests,
+  }: {
+    bossQuests: unknown[];
+  }) {
+    return (
+      <div data-testid="boss-quest-history-list">
+        {bossQuests.length} bosses
+      </div>
+    );
+  },
+}));
+
+jest.mock("@/components/ui", () => ({
+  Button: function MockButton({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick: () => void;
+  }) {
+    return <button onClick={onClick}>{children}</button>;
+  },
+}));
+
+const mockQuest: QuestInstance = {
+  id: "quest-1",
+  title: "Completed Quest",
+  description: "",
+  difficulty: "EASY",
+  status: "COMPLETED",
+  xp_reward: 100,
+  gold_reward: 50,
+  category: "DAILY",
+  created_by_id: "user-1",
+  due_date: null,
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+  recurrence_pattern: null,
+  assigned_to_id: null,
+  completed_at: null,
+  approved_at: null,
+  streak_bonus: null,
+  streak_count: null,
+  volunteer_bonus: null,
+  volunteered_by: null,
+  template_id: null,
+  quest_type: null,
+  cycle_start_date: null,
+  cycle_end_date: null,
+  family_id: "family-1",
+};
+
+describe("QuestHistorySection", () => {
+  it("renders nothing when both quest and boss history are empty", () => {
+    const { container } = render(
+      <QuestHistorySection
+        historicalQuests={[]}
+        bossHistoryQuests={[]}
+        familyMembers={[]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the Quest History heading when there is history", () => {
+    render(
+      <QuestHistorySection
+        historicalQuests={[mockQuest]}
+        bossHistoryQuests={[]}
+        familyMembers={[]}
+      />,
+    );
+    expect(screen.getByText(/Quest History/)).toBeInTheDocument();
+  });
+
+  it("shows count in toggle button when history is hidden", () => {
+    render(
+      <QuestHistorySection
+        historicalQuests={[mockQuest, mockQuest]}
+        bossHistoryQuests={[]}
+        familyMembers={[]}
+      />,
+    );
+    expect(screen.getByText("Show History (2)")).toBeInTheDocument();
+  });
+
+  it("history content is hidden by default", () => {
+    render(
+      <QuestHistorySection
+        historicalQuests={[mockQuest]}
+        bossHistoryQuests={[]}
+        familyMembers={[]}
+      />,
+    );
+    expect(screen.queryByTestId("quest-list")).not.toBeInTheDocument();
+  });
+
+  it("shows history content after clicking toggle", () => {
+    render(
+      <QuestHistorySection
+        historicalQuests={[mockQuest]}
+        bossHistoryQuests={[]}
+        familyMembers={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Show History (1)"));
+
+    expect(screen.getByTestId("quest-list")).toBeInTheDocument();
+    expect(screen.getByTestId("boss-quest-history-list")).toBeInTheDocument();
+    expect(screen.getByText("Hide History")).toBeInTheDocument();
+  });
+
+  it("hides content again after clicking toggle twice", () => {
+    render(
+      <QuestHistorySection
+        historicalQuests={[mockQuest]}
+        bossHistoryQuests={[]}
+        familyMembers={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Show History (1)"));
+    fireEvent.click(screen.getByText("Hide History"));
+
+    expect(screen.queryByTestId("quest-list")).not.toBeInTheDocument();
+  });
+
+  it("counts boss history towards total", () => {
+    render(
+      <QuestHistorySection
+        historicalQuests={[]}
+        bossHistoryQuests={[
+          { id: "boss-1", status: "DEFEATED" } as Parameters<
+            typeof QuestHistorySection
+          >[0]["bossHistoryQuests"][0],
+        ]}
+        familyMembers={[]}
+      />,
+    );
+    expect(screen.getByText("Show History (1)")).toBeInTheDocument();
+  });
+});

--- a/components/quests/quest-dashboard/__tests__/useQuestDashboardData.test.ts
+++ b/components/quests/quest-dashboard/__tests__/useQuestDashboardData.test.ts
@@ -1,0 +1,299 @@
+import { renderHook } from "@testing-library/react";
+import { useQuestDashboardData } from "../useQuestDashboardData";
+import { useAuth } from "@/lib/auth-context";
+import { useFamilyMembers } from "@/hooks/useFamilyMembers";
+import { useCharacter } from "@/hooks/useCharacter";
+import { useQuests } from "@/hooks/useQuests";
+import { useBossQuests } from "@/hooks/useBossQuests";
+import { createMockQuest } from "./quest-helpers.fixtures";
+
+jest.mock("@/lib/auth-context");
+jest.mock("@/hooks/useFamilyMembers");
+jest.mock("@/hooks/useCharacter");
+jest.mock("@/hooks/useQuests");
+jest.mock("@/hooks/useBossQuests");
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUseFamilyMembers = useFamilyMembers as jest.MockedFunction<
+  typeof useFamilyMembers
+>;
+const mockUseCharacter = useCharacter as jest.MockedFunction<
+  typeof useCharacter
+>;
+const mockUseQuests = useQuests as jest.MockedFunction<typeof useQuests>;
+const mockUseBossQuests = useBossQuests as jest.MockedFunction<
+  typeof useBossQuests
+>;
+
+const makeDefaultMocks = () => {
+  mockUseAuth.mockReturnValue({
+    user: { id: "user-1", email: "test@test.com" },
+    profile: {
+      id: "user-1",
+      role: "MEMBER",
+      family_id: "fam-1",
+      name: "Test",
+      email: "test@test.com",
+      created_at: "",
+      updated_at: "",
+    },
+    session: null,
+    loading: false,
+    signOut: jest.fn(),
+    signInWithPassword: jest.fn(),
+    signUpWithPassword: jest.fn(),
+  });
+
+  mockUseFamilyMembers.mockReturnValue({
+    familyMembers: [],
+    familyCharacters: [],
+    loading: false,
+    error: null,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+
+  mockUseCharacter.mockReturnValue({
+    character: null,
+    loading: false,
+    error: null,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+
+  mockUseQuests.mockReturnValue({
+    quests: [],
+    loading: false,
+    error: null,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+
+  mockUseBossQuests.mockReturnValue({
+    bossQuests: [],
+    loading: false,
+    error: null,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+};
+
+describe("useQuestDashboardData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    makeDefaultMocks();
+  });
+
+  describe("combined loading state", () => {
+    it("returns loading=true when any sub-hook is loading", () => {
+      mockUseQuests.mockReturnValue({
+        quests: [],
+        loading: true,
+        error: null,
+        reload: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("returns loading=false when all sub-hooks are done", () => {
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe("combined error state", () => {
+    it("returns first error from any sub-hook", () => {
+      mockUseQuests.mockReturnValue({
+        quests: [],
+        loading: false,
+        error: "Quest fetch failed",
+        reload: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.error).toBe("Quest fetch failed");
+    });
+
+    it("calls onError when error is present", () => {
+      const onError = jest.fn();
+      mockUseFamilyMembers.mockReturnValue({
+        familyMembers: [],
+        familyCharacters: [],
+        loading: false,
+        error: "Family error",
+        reload: jest.fn(),
+      });
+
+      renderHook(() => useQuestDashboardData({ onError }));
+
+      expect(onError).toHaveBeenCalledWith("Family error");
+    });
+  });
+
+  describe("memoized quest filtering", () => {
+    it("filters myActiveQuests for the current user", () => {
+      const userQuest = createMockQuest({
+        id: "q1",
+        assigned_to_id: "user-1",
+        status: "PENDING",
+      });
+      const otherQuest = createMockQuest({
+        id: "q2",
+        assigned_to_id: "user-2",
+        status: "PENDING",
+      });
+
+      mockUseQuests.mockReturnValue({
+        quests: [userQuest, otherQuest],
+        loading: false,
+        error: null,
+        reload: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.myActiveQuests).toHaveLength(1);
+      expect(result.current.myActiveQuests[0].id).toBe("q1");
+    });
+
+    it("filters pendingApprovalQuests from all quest instances", () => {
+      const completedQuest = createMockQuest({
+        id: "q-completed",
+        status: "COMPLETED",
+        assigned_to_id: "user-2",
+      });
+      const pendingQuest = createMockQuest({
+        id: "q-pending",
+        status: "PENDING",
+      });
+
+      mockUseQuests.mockReturnValue({
+        quests: [completedQuest, pendingQuest],
+        loading: false,
+        error: null,
+        reload: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.pendingApprovalQuests).toHaveLength(1);
+      expect(result.current.pendingApprovalQuests[0].id).toBe("q-completed");
+    });
+
+    it("filters bossHistoryQuests for DEFEATED status", () => {
+      mockUseBossQuests.mockReturnValue({
+        bossQuests: [
+          { id: "b1", status: "ACTIVE" } as Parameters<
+            typeof mockUseBossQuests
+          >[0]["bossQuests"][0],
+          { id: "b2", status: "DEFEATED" } as Parameters<
+            typeof mockUseBossQuests
+          >[0]["bossQuests"][0],
+        ],
+        loading: false,
+        error: null,
+        reload: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.bossHistoryQuests).toHaveLength(1);
+      expect(result.current.bossHistoryQuests[0].id).toBe("b2");
+    });
+  });
+
+  describe("isGuildMaster", () => {
+    it("returns true when profile role is GUILD_MASTER", () => {
+      mockUseAuth.mockReturnValue({
+        user: { id: "user-1", email: "test@test.com" },
+        profile: {
+          id: "user-1",
+          role: "GUILD_MASTER",
+          family_id: "fam-1",
+          name: "Test",
+          email: "test@test.com",
+          created_at: "",
+          updated_at: "",
+        },
+        session: null,
+        loading: false,
+        signOut: jest.fn(),
+        signInWithPassword: jest.fn(),
+        signUpWithPassword: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.isGuildMaster).toBe(true);
+    });
+
+    it("returns false when profile role is MEMBER", () => {
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      expect(result.current.isGuildMaster).toBe(false);
+    });
+  });
+
+  describe("combined reload", () => {
+    it("exposes loadData that calls all sub-hook reloads", async () => {
+      const reloadFamily = jest.fn().mockResolvedValue(undefined);
+      const reloadCharacter = jest.fn().mockResolvedValue(undefined);
+      const reloadQuests = jest.fn().mockResolvedValue(undefined);
+      const reloadBossQuests = jest.fn().mockResolvedValue(undefined);
+
+      mockUseFamilyMembers.mockReturnValue({
+        familyMembers: [],
+        familyCharacters: [],
+        loading: false,
+        error: null,
+        reload: reloadFamily,
+      });
+      mockUseCharacter.mockReturnValue({
+        character: null,
+        loading: false,
+        error: null,
+        reload: reloadCharacter,
+      });
+      mockUseQuests.mockReturnValue({
+        quests: [],
+        loading: false,
+        error: null,
+        reload: reloadQuests,
+      });
+      mockUseBossQuests.mockReturnValue({
+        bossQuests: [],
+        loading: false,
+        error: null,
+        reload: reloadBossQuests,
+      });
+
+      const { result } = renderHook(() =>
+        useQuestDashboardData({ onError: jest.fn() }),
+      );
+
+      await result.current.loadData();
+
+      expect(reloadFamily).toHaveBeenCalled();
+      expect(reloadCharacter).toHaveBeenCalled();
+      expect(reloadQuests).toHaveBeenCalled();
+      expect(reloadBossQuests).toHaveBeenCalled();
+    });
+  });
+});

--- a/components/quests/quest-dashboard/family-quest-section.tsx
+++ b/components/quests/quest-dashboard/family-quest-section.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React from "react";
+import FamilyQuestClaiming from "@/components/family/family-quest-claiming";
+import type { QuestInstance, Character } from "@/lib/types/database";
+
+interface FamilyQuestSectionProps {
+  quests: QuestInstance[];
+  character: Character | null;
+  onClaimQuest: (questId: string) => void;
+}
+
+export function FamilyQuestSection({
+  quests,
+  character,
+  onClaimQuest,
+}: FamilyQuestSectionProps) {
+  if (!character || quests.length === 0) return null;
+
+  return (
+    <section>
+      <FamilyQuestClaiming
+        quests={quests}
+        character={character}
+        onClaimQuest={onClaimQuest}
+      />
+    </section>
+  );
+}

--- a/components/quests/quest-dashboard/index.tsx
+++ b/components/quests/quest-dashboard/index.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { useAuth } from "@/lib/auth-context";
-import { QuestInstance } from "@/lib/types/database";
+import { useEffect, useState } from "react";
 import { LoadingSpinner, Button } from "@/components/ui";
-import FamilyQuestClaiming from "@/components/family/family-quest-claiming";
 import { BossQuestPanel } from "@/components/boss/boss-quest-panel";
-import { useFamilyMembers } from "@/hooks/useFamilyMembers";
-import { useCharacter } from "@/hooks/useCharacter";
-import { useQuests } from "@/hooks/useQuests";
-import { useBossQuests } from "@/hooks/useBossQuests";
-import QuestList from "./quest-list";
-import * as QuestHelpers from "./quest-helpers";
 import PendingApprovalsSection from "@/components/quests/pending-approvals-section";
-import { BossQuestHistoryList } from "@/components/boss/boss-quest-history-list";
 import { useQuestHandlers } from "./useQuestHandlers";
 import { useRealtimeHighlight } from "@/hooks/useRealtimeHighlight";
 import { useRealtime } from "@/lib/realtime-context";
+import { useQuestDashboardData } from "./useQuestDashboardData";
+import { MyQuestsSection } from "./my-quests-section";
+import { FamilyQuestSection } from "./family-quest-section";
+import { QuestHistorySection } from "./quest-history-section";
 
 type QuestDashboardProps = {
   onError: (error: string) => void;
@@ -27,36 +21,8 @@ export default function QuestDashboard({
   onError,
   onLoadQuestsRef,
 }: QuestDashboardProps) {
-  const { user, profile } = useAuth();
+  const data = useQuestDashboardData({ onError, onLoadQuestsRef });
 
-  // Custom hooks for data fetching
-  const {
-    familyMembers,
-    familyCharacters,
-    loading: familyLoading,
-    error: familyError,
-    reload: reloadFamily,
-  } = useFamilyMembers();
-  const {
-    character,
-    loading: characterLoading,
-    error: characterError,
-    reload: reloadCharacter,
-  } = useCharacter();
-  const {
-    quests: questInstances,
-    loading: questsLoading,
-    error: questsError,
-    reload: reloadQuests,
-  } = useQuests();
-  const {
-    bossQuests,
-    loading: bossLoading,
-    error: bossError,
-    reload: reloadBossQuests,
-  } = useBossQuests();
-
-  // Realtime visual feedback
   const { highlight: highlightQuest, isHighlighted: isQuestHighlighted } =
     useRealtimeHighlight();
   const { onQuestUpdate } = useRealtime();
@@ -70,42 +36,10 @@ export default function QuestDashboard({
     return unsubscribe;
   }, [highlightQuest, onQuestUpdate]);
 
-  // Local state
-  const [showQuestHistory, setShowQuestHistory] = useState(false);
   const [selectedAssignees, setSelectedAssignees] = useState<
     Record<string, string>
   >({});
 
-  const isGuildMaster = profile?.role === "GUILD_MASTER";
-
-  // Combine loading and error states
-  const loading =
-    familyLoading || characterLoading || questsLoading || bossLoading;
-  const error = familyError || characterError || questsError || bossError;
-
-  // Combined reload function
-  const loadData = useCallback(async () => {
-    await Promise.all([
-      reloadFamily(),
-      reloadCharacter(),
-      reloadQuests(),
-      reloadBossQuests(),
-    ]);
-  }, [reloadFamily, reloadCharacter, reloadQuests, reloadBossQuests]);
-
-  // Expose reload function to parent component
-  useEffect(() => {
-    if (!onLoadQuestsRef) return;
-    onLoadQuestsRef(loadData);
-  }, [loadData, onLoadQuestsRef]);
-
-  // Show errors via the onError callback
-  useEffect(() => {
-    if (error) onError(error);
-  }, [error, onError]);
-
-  // Quest action handlers - extracted to separate hook for code organization
-  // These handlers rely on realtime subscriptions to update the UI
   const {
     handleStatusUpdate,
     handleClaimQuest,
@@ -117,61 +51,12 @@ export default function QuestDashboard({
     handleGmReleaseQuest,
   } = useQuestHandlers({
     onError,
-    loadData,
-    characterId: character?.id,
+    loadData: data.loadData,
+    characterId: data.character?.id,
     setSelectedAssignees,
   });
 
-  const handleAssigneeChange = useCallback(
-    (questId: string, assigneeId: string) => {
-      setSelectedAssignees((prev) => ({ ...prev, [questId]: assigneeId }));
-    },
-    [],
-  );
-
-  // Quest filtering using helpers (memoized for performance)
-  const myQuests = useMemo(
-    () => QuestHelpers.filterQuestsByUser(questInstances, user?.id),
-    [questInstances, user?.id],
-  );
-
-  const myActiveQuests = useMemo(
-    () => QuestHelpers.filterActiveQuests(myQuests),
-    [myQuests],
-  );
-
-  const myHistoricalQuests = useMemo(
-    () => QuestHelpers.filterHistoricalQuests(myQuests),
-    [myQuests],
-  );
-
-  const bossHistoryQuests = useMemo(
-    () => bossQuests.filter((boss) => boss.status === "DEFEATED"),
-    [bossQuests],
-  );
-
-  const claimableFamilyQuests = useMemo(
-    () => QuestHelpers.filterClaimableFamilyQuests(questInstances),
-    [questInstances],
-  );
-
-  const pendingApprovalQuests = useMemo(
-    () => QuestHelpers.filterPendingApprovalQuests(questInstances),
-    [questInstances],
-  );
-
-  const assignableCharacters = useMemo(
-    () => QuestHelpers.mapFamilyCharactersToAssignmentDisplay(familyCharacters),
-    [familyCharacters],
-  );
-
-  const getAssignedHeroName = useCallback(
-    (quest: QuestInstance) =>
-      QuestHelpers.getAssignedHeroName(quest, familyCharacters),
-    [familyCharacters],
-  );
-
-  if (loading) {
+  if (data.loading) {
     return (
       <div className="flex justify-center py-10">
         <LoadingSpinner />
@@ -179,16 +64,16 @@ export default function QuestDashboard({
     );
   }
 
-  if (error) {
+  if (data.error) {
     return (
       <div className="fantasy-card p-6 text-center text-red-400">
-        <p>{error}</p>
+        <p>{data.error}</p>
         <Button
           type="button"
           variant="success"
           size="sm"
           className="mt-4 px-4 py-2 rounded-md bg-emerald-700 hover:bg-emerald-600"
-          onClick={() => void loadData()}
+          onClick={() => void data.loadData()}
         >
           Try Again
         </Button>
@@ -211,89 +96,45 @@ export default function QuestDashboard({
 
       <BossQuestPanel />
 
-      {isGuildMaster && pendingApprovalQuests.length > 0 && (
+      {data.isGuildMaster && data.pendingApprovalQuests.length > 0 && (
         <PendingApprovalsSection
-          quests={pendingApprovalQuests}
-          assignmentOptions={assignableCharacters}
+          quests={data.pendingApprovalQuests}
+          assignmentOptions={data.assignableCharacters}
           selectedAssignees={selectedAssignees}
-          onAssigneeChange={handleAssigneeChange}
+          onAssigneeChange={(questId, assigneeId) =>
+            setSelectedAssignees((prev) => ({ ...prev, [questId]: assigneeId }))
+          }
           onAssign={handleAssignQuest}
           onApprove={handleApproveQuest}
           onDeny={handleDenyQuest}
           onCancel={handleCancelQuest}
           onRelease={handleGmReleaseQuest}
-          getAssignedHeroName={getAssignedHeroName}
+          getAssignedHeroName={data.getAssignedHeroName}
         />
       )}
 
-      {/* My Quests Section */}
-      <section>
-        <div className="mb-4">
-          <h3 className="text-xl font-fantasy text-gray-200">🗡️ My Quests</h3>
-          {myHistoricalQuests.length + bossHistoryQuests.length > 0 && (
-            <p className="text-xs text-gray-500 mt-1">
-              Completed adventures live in Quest History near the bottom of the
-              page.
-            </p>
-          )}
-        </div>
-        <QuestList
-          quests={myActiveQuests}
-          emptyMessage="You have no active quests right now."
-          emptyHint={
-            myHistoricalQuests.length + bossHistoryQuests.length > 0
-              ? "Check Quest History to revisit your completed quests."
-              : undefined
-          }
-          onStartQuest={(id) => handleStatusUpdate(id, "IN_PROGRESS")}
-          onCompleteQuest={(id) => handleStatusUpdate(id, "COMPLETED")}
-          onReleaseQuest={handleReleaseQuest}
-          familyMembers={familyMembers}
-          isHighlighted={isQuestHighlighted}
-        />
-      </section>
+      <MyQuestsSection
+        activeQuests={data.myActiveQuests}
+        historicalQuestCount={data.myHistoricalQuests.length}
+        bossHistoryCount={data.bossHistoryQuests.length}
+        onStartQuest={(id) => handleStatusUpdate(id, "IN_PROGRESS")}
+        onCompleteQuest={(id) => handleStatusUpdate(id, "COMPLETED")}
+        onReleaseQuest={handleReleaseQuest}
+        familyMembers={data.familyMembers}
+        isHighlighted={isQuestHighlighted}
+      />
 
-      {/* Family Quest Claiming (for characters) */}
-      {character && claimableFamilyQuests.length > 0 && (
-        <section>
-          <FamilyQuestClaiming
-            quests={claimableFamilyQuests}
-            character={character}
-            onClaimQuest={handleClaimQuest}
-          />
-        </section>
-      )}
+      <FamilyQuestSection
+        quests={data.claimableFamilyQuests}
+        character={data.character}
+        onClaimQuest={handleClaimQuest}
+      />
 
-      {/* Quest History */}
-      {myHistoricalQuests.length + bossHistoryQuests.length > 0 && (
-        <section>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-            <h3 className="text-xl font-fantasy text-gray-200">
-              📜 Quest History
-            </h3>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="inline-flex items-center gap-2 self-start sm:self-auto px-3 py-1.5 rounded-md border border-gray-700 text-sm text-gray-300 hover:bg-gray-800"
-              onClick={() => setShowQuestHistory((prev) => !prev)}
-            >
-              {showQuestHistory
-                ? "Hide History"
-                : `Show History (${myHistoricalQuests.length + bossHistoryQuests.length})`}
-            </Button>
-          </div>
-          {showQuestHistory && (
-            <div className="space-y-3">
-              <QuestList
-                quests={myHistoricalQuests}
-                familyMembers={familyMembers}
-              />
-              <BossQuestHistoryList bossQuests={bossHistoryQuests} />
-            </div>
-          )}
-        </section>
-      )}
+      <QuestHistorySection
+        historicalQuests={data.myHistoricalQuests}
+        bossHistoryQuests={data.bossHistoryQuests}
+        familyMembers={data.familyMembers}
+      />
     </div>
   );
 }

--- a/components/quests/quest-dashboard/my-quests-section.tsx
+++ b/components/quests/quest-dashboard/my-quests-section.tsx
@@ -1,0 +1,56 @@
+"use client";
+import React from "react";
+import QuestList from "./quest-list";
+import type { QuestInstance, UserProfile } from "@/lib/types/database";
+
+interface MyQuestsSectionProps {
+  activeQuests: QuestInstance[];
+  historicalQuestCount: number;
+  bossHistoryCount: number;
+  onStartQuest: (id: string) => void;
+  onCompleteQuest: (id: string) => void;
+  onReleaseQuest: (id: string) => void;
+  familyMembers: UserProfile[];
+  isHighlighted: (id: string) => boolean;
+}
+
+export function MyQuestsSection({
+  activeQuests,
+  historicalQuestCount,
+  bossHistoryCount,
+  onStartQuest,
+  onCompleteQuest,
+  onReleaseQuest,
+  familyMembers,
+  isHighlighted,
+}: MyQuestsSectionProps) {
+  const hasHistory = historicalQuestCount + bossHistoryCount > 0;
+
+  return (
+    <section>
+      <div className="mb-4">
+        <h3 className="text-xl font-fantasy text-gray-200">🗡️ My Quests</h3>
+        {hasHistory && (
+          <p className="text-xs text-gray-500 mt-1">
+            Completed adventures live in Quest History near the bottom of the
+            page.
+          </p>
+        )}
+      </div>
+      <QuestList
+        quests={activeQuests}
+        emptyMessage="You have no active quests right now."
+        emptyHint={
+          hasHistory
+            ? "Check Quest History to revisit your completed quests."
+            : undefined
+        }
+        onStartQuest={onStartQuest}
+        onCompleteQuest={onCompleteQuest}
+        onReleaseQuest={onReleaseQuest}
+        familyMembers={familyMembers}
+        isHighlighted={isHighlighted}
+      />
+    </section>
+  );
+}

--- a/components/quests/quest-dashboard/quest-history-section.tsx
+++ b/components/quests/quest-dashboard/quest-history-section.tsx
@@ -1,0 +1,51 @@
+"use client";
+import React, { useState } from "react";
+import { Button } from "@/components/ui";
+import QuestList from "./quest-list";
+import { BossQuestHistoryList } from "@/components/boss/boss-quest-history-list";
+import type { QuestInstance, UserProfile } from "@/lib/types/database";
+import type { BossQuest } from "@/hooks/useBossQuests";
+
+type BossQuestWithParticipants = BossQuest & {
+  boss_battle_participants?: { user_id: string | null }[];
+};
+
+interface QuestHistorySectionProps {
+  historicalQuests: QuestInstance[];
+  bossHistoryQuests: BossQuestWithParticipants[];
+  familyMembers: UserProfile[];
+}
+
+export function QuestHistorySection({
+  historicalQuests,
+  bossHistoryQuests,
+  familyMembers,
+}: QuestHistorySectionProps) {
+  const [showQuestHistory, setShowQuestHistory] = useState(false);
+  const totalCount = historicalQuests.length + bossHistoryQuests.length;
+
+  if (totalCount === 0) return null;
+
+  return (
+    <section>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <h3 className="text-xl font-fantasy text-gray-200">📜 Quest History</h3>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="inline-flex items-center gap-2 self-start sm:self-auto px-3 py-1.5 rounded-md border border-gray-700 text-sm text-gray-300 hover:bg-gray-800"
+          onClick={() => setShowQuestHistory((prev) => !prev)}
+        >
+          {showQuestHistory ? "Hide History" : `Show History (${totalCount})`}
+        </Button>
+      </div>
+      {showQuestHistory && (
+        <div className="space-y-3">
+          <QuestList quests={historicalQuests} familyMembers={familyMembers} />
+          <BossQuestHistoryList bossQuests={bossHistoryQuests} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/quests/quest-dashboard/useQuestDashboardData.ts
+++ b/components/quests/quest-dashboard/useQuestDashboardData.ts
@@ -1,0 +1,132 @@
+"use client";
+import { useCallback, useEffect, useMemo } from "react";
+import { useAuth } from "@/lib/auth-context";
+import { useFamilyMembers } from "@/hooks/useFamilyMembers";
+import { useCharacter } from "@/hooks/useCharacter";
+import { useQuests } from "@/hooks/useQuests";
+import { useBossQuests } from "@/hooks/useBossQuests";
+import * as QuestHelpers from "./quest-helpers";
+import type { QuestInstance } from "@/lib/types/database";
+
+interface UseQuestDashboardDataProps {
+  onError: (error: string) => void;
+  onLoadQuestsRef?: (reload: () => Promise<void>) => void;
+}
+
+export function useQuestDashboardData({
+  onError,
+  onLoadQuestsRef,
+}: UseQuestDashboardDataProps) {
+  const { user, profile } = useAuth();
+
+  const {
+    familyMembers,
+    familyCharacters,
+    loading: familyLoading,
+    error: familyError,
+    reload: reloadFamily,
+  } = useFamilyMembers();
+
+  const {
+    character,
+    loading: characterLoading,
+    error: characterError,
+    reload: reloadCharacter,
+  } = useCharacter();
+
+  const {
+    quests: questInstances,
+    loading: questsLoading,
+    error: questsError,
+    reload: reloadQuests,
+  } = useQuests();
+
+  const {
+    bossQuests,
+    loading: bossLoading,
+    error: bossError,
+    reload: reloadBossQuests,
+  } = useBossQuests();
+
+  const loading =
+    familyLoading || characterLoading || questsLoading || bossLoading;
+  const error = familyError || characterError || questsError || bossError;
+
+  const loadData = useCallback(async () => {
+    await Promise.all([
+      reloadFamily(),
+      reloadCharacter(),
+      reloadQuests(),
+      reloadBossQuests(),
+    ]);
+  }, [reloadFamily, reloadCharacter, reloadQuests, reloadBossQuests]);
+
+  useEffect(() => {
+    if (!onLoadQuestsRef) return;
+    onLoadQuestsRef(loadData);
+  }, [loadData, onLoadQuestsRef]);
+
+  useEffect(() => {
+    if (error) onError(error);
+  }, [error, onError]);
+
+  const isGuildMaster = profile?.role === "GUILD_MASTER";
+
+  const myQuests = useMemo(
+    () => QuestHelpers.filterQuestsByUser(questInstances, user?.id),
+    [questInstances, user?.id],
+  );
+
+  const myActiveQuests = useMemo(
+    () => QuestHelpers.filterActiveQuests(myQuests),
+    [myQuests],
+  );
+
+  const myHistoricalQuests = useMemo(
+    () => QuestHelpers.filterHistoricalQuests(myQuests),
+    [myQuests],
+  );
+
+  const bossHistoryQuests = useMemo(
+    () => bossQuests.filter((boss) => boss.status === "DEFEATED"),
+    [bossQuests],
+  );
+
+  const claimableFamilyQuests = useMemo(
+    () => QuestHelpers.filterClaimableFamilyQuests(questInstances),
+    [questInstances],
+  );
+
+  const pendingApprovalQuests = useMemo(
+    () => QuestHelpers.filterPendingApprovalQuests(questInstances),
+    [questInstances],
+  );
+
+  const assignableCharacters = useMemo(
+    () => QuestHelpers.mapFamilyCharactersToAssignmentDisplay(familyCharacters),
+    [familyCharacters],
+  );
+
+  const getAssignedHeroName = useCallback(
+    (quest: QuestInstance) =>
+      QuestHelpers.getAssignedHeroName(quest, familyCharacters),
+    [familyCharacters],
+  );
+
+  return {
+    loading,
+    error,
+    loadData,
+    isGuildMaster,
+    character,
+    familyMembers,
+    myActiveQuests,
+    myHistoricalQuests,
+    bossQuests,
+    bossHistoryQuests,
+    claimableFamilyQuests,
+    pendingApprovalQuests,
+    assignableCharacters,
+    getAssignedHeroName,
+  };
+}

--- a/openspec/changes/refactor-admin-dashboard/design.md
+++ b/openspec/changes/refactor-admin-dashboard/design.md
@@ -1,0 +1,163 @@
+# Design: Refactor Admin Dashboard
+
+## Context
+
+Both `quest-management-tab.tsx` (299 lines) and
+`quest-dashboard/index.tsx` (299 lines) are at the 300-line
+frontend-architecture spec limit. Each component mixes data
+orchestration, action handlers, and section rendering in a
+single file. Prior refactoring (issue #89) already extracted
+`useQuestHandlers` and `quest-helpers.ts` for the quest
+dashboard, but the components themselves still carry too much
+responsibility.
+
+The quest-management-tab has 8 `useCallback` handlers for
+quest actions plus confirmation modal state inlined directly.
+The quest-dashboard combines 5 data hooks, 7 `useMemo` calls,
+realtime subscriptions, and 4 distinct rendered sections.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce both components well below 300 lines
+- Extract action handler + modal logic from
+  quest-management-tab into a reusable hook
+- Extract quest dashboard sections into standalone
+  presentational components
+- Consolidate data orchestration into a dedicated hook
+- Maintain identical behavior and visual output
+- Keep all extracted pieces independently testable
+
+**Non-Goals:**
+
+- Redesigning the UI or changing visual layout
+- Changing data fetching patterns or API calls
+- Refactoring other admin tabs (reward-manager,
+  family-settings, etc.)
+- Performance optimization beyond what decomposition
+  naturally provides
+- Changing the quest-helpers.ts or useQuestHandlers.ts
+  utilities that already exist
+
+## Decisions
+
+### 1. Extract `useQuestManagementActions` hook
+
+**Decision:** Create a custom hook that encapsulates all 8
+quest action callbacks, the confirmation modal state, and the
+`isProcessing` flag from `quest-management-tab.tsx`.
+
+**Rationale:** The handler logic (assign, approve, deny,
+cancel, release, confirm) is pure business logic coupled with
+notification side effects. Extracting it leaves the component
+as a thin rendering layer. This mirrors the existing
+`useQuestHandlers` pattern already used in the quest
+dashboard.
+
+**Alternative considered:** Merging with the existing
+`useQuestHandlers` hook. Rejected because the two hooks serve
+different contexts (quest-management-tab uses
+`questInstanceApiService` directly with notifications, while
+`useQuestHandlers` uses `onError` callback pattern). Merging
+would create an overly complex hook with two calling
+conventions.
+
+**File:** `components/admin/useQuestManagementActions.ts`
+
+### 2. Extract section rendering into a `QuestManagementSection` component
+
+**Decision:** Extract the `renderSection` function and the
+`QuestSection` interface into a standalone presentational
+component.
+
+**Rationale:** The `renderSection` local function at line 211
+in quest-management-tab is already a de facto component — it
+takes data and renders UI. Making it a proper component
+enables direct testing and reuse.
+
+**Alternative considered:** Keeping it as a render function.
+Rejected because it receives many props via closure and
+cannot be tested in isolation.
+
+**File:** `components/admin/quest-management-section.tsx`
+
+### 3. Extract `useQuestDashboardData` hook
+
+**Decision:** Create a hook that consolidates the 5 data
+hooks, combined loading/error state, `loadData`, and all 7
+`useMemo` filtering operations from quest-dashboard.
+
+**Rationale:** The quest dashboard's data layer (lines 30-166)
+is entirely about fetching and transforming data. The
+component itself only needs the derived values. This follows
+the container/hook split pattern established in the
+frontend-architecture spec.
+
+**Alternative considered:** Splitting into multiple smaller
+hooks (e.g., `useQuestFiltering`, `useQuestRealtimeSetup`).
+Rejected as over-engineering — the filtering is tightly
+coupled to the data fetching, and splitting would just move
+complexity rather than reduce it.
+
+**File:** `components/quests/quest-dashboard/useQuestDashboardData.ts`
+
+### 4. Extract quest dashboard sections into components
+
+**Decision:** Extract 3 section components:
+
+- `MyQuestsSection` — active quests list with start/complete
+  /release actions
+- `FamilyQuestSection` — family quest claiming wrapper
+- `QuestHistorySection` — collapsible history with toggle
+  state
+
+**Rationale:** Each section has distinct data dependencies and
+behavior. Extracting them makes the orchestrator a pure
+composition layer. The `BossQuestPanel` and
+`PendingApprovalsSection` are already extracted.
+
+**Alternative considered:** A single generic
+`QuestDashboardSection` component. Rejected because each
+section has different props, behavior (e.g., history has
+toggle state), and conditional rendering logic.
+
+**Files:**
+
+- `components/quests/quest-dashboard/my-quests-section.tsx`
+- `components/quests/quest-dashboard/family-quest-section.tsx`
+- `components/quests/quest-dashboard/quest-history-section.tsx`
+
+### 5. Keep realtime subscription in the orchestrator
+
+**Decision:** The `useRealtime` + `useRealtimeHighlight`
+setup stays in `quest-dashboard/index.tsx` rather than moving
+into the data hook.
+
+**Rationale:** Realtime subscriptions produce visual side
+effects (highlight animations) that cross component
+boundaries. Keeping them in the orchestrator makes the data
+flow explicit — the highlight state is passed down as a prop
+to `MyQuestsSection`.
+
+## Risks / Trade-offs
+
+**More files to navigate** — Adding ~6 new files increases
+the surface area of the quest module.
+Mitigation: All files stay within their existing feature
+directories (`components/admin/`, `components/quests/
+quest-dashboard/`), following the established feature-first
+organization pattern.
+
+**Prop drilling depth increases slightly** — Extracted
+section components receive props that the orchestrator
+previously accessed directly.
+Mitigation: Props remain shallow (one level). The existing
+hook-based architecture already handles deep data access.
+
+**Test migration effort** — Existing tests for both
+components will need updates to account for the new
+component boundaries.
+Mitigation: Extract tests alongside components. The
+existing test structure uses render-based testing, so most
+assertions transfer directly to the new component tests.

--- a/openspec/changes/refactor-admin-dashboard/proposal.md
+++ b/openspec/changes/refactor-admin-dashboard/proposal.md
@@ -1,0 +1,63 @@
+# Refactor Admin Dashboard
+
+## Why
+
+The admin dashboard refactoring from issue #48 (part of
+the larger #89 effort) was partially completed —
+`admin-dashboard.tsx` is now a lean 125-line container,
+but both `quest-management-tab.tsx` (299 lines) and
+`quest-dashboard/index.tsx` (299 lines) sit at the
+absolute 300-line threshold from the frontend-architecture
+spec. These components have complex state management with
+numerous hooks, memoized computations, and inline handler
+logic that makes them difficult to test in isolation and
+extend safely.
+
+## What Changes
+
+- Extract quest action handlers and confirmation modal
+  logic from `quest-management-tab.tsx` into dedicated
+  custom hooks
+- Extract section rendering (pending approvals,
+  unassigned, in-progress) from
+  `quest-management-tab.tsx` into focused presentational
+  components
+- Extract data orchestration and filtering logic from
+  `quest-dashboard/index.tsx` into a custom hook
+  (e.g., `useQuestDashboardData`)
+- Extract quest dashboard sections (boss quests, pending
+  approvals, my quests, family quests, quest history)
+  into standalone components
+- Ensure all extracted components and hooks are
+  independently testable
+
+## Capabilities
+
+### New Capabilities
+
+- `quest-management-decomposition`: Decompose the
+  quest-management-tab into smaller components and
+  hooks, extracting action handlers, modal logic,
+  and section rendering
+- `quest-dashboard-decomposition`: Decompose the
+  quest-dashboard orchestrator into smaller components
+  and a data hook, extracting filtering/memoization
+  and section rendering
+
+### Modified Capabilities
+
+## Impact
+
+- `components/admin/quest-management-tab.tsx` — will be
+  significantly reduced, delegating to new
+  sub-components and hooks
+- `components/quests/quest-dashboard/index.tsx` — will
+  become a thinner orchestrator composing extracted
+  section components
+- New files under `components/admin/` and
+  `components/quests/quest-dashboard/` for extracted
+  pieces
+- Existing tests will need to be updated/split to cover
+  the new component boundaries
+- No API or data model changes — this is a pure frontend
+  structural refactor

--- a/openspec/changes/refactor-admin-dashboard/specs/quest-dashboard-decomposition/spec.md
+++ b/openspec/changes/refactor-admin-dashboard/specs/quest-dashboard-decomposition/spec.md
@@ -1,0 +1,199 @@
+# Quest Dashboard Decomposition
+
+## ADDED Requirements
+
+### Requirement: useQuestDashboardData hook
+
+The system SHALL provide a `useQuestDashboardData` custom
+hook in
+`components/quests/quest-dashboard/useQuestDashboardData.ts`
+that consolidates all data fetching, combined state, and
+memoized filtering currently in `quest-dashboard/index.tsx`.
+
+The hook SHALL accept:
+
+- `userId` — current user ID (optional)
+
+The hook SHALL return:
+
+- `loading` — combined loading state from all data hooks
+- `error` — first error from any data hook
+- `loadData` — combined reload function via `Promise.all`
+- `myActiveQuests` — user's active quest instances
+- `myHistoricalQuests` — user's completed quest instances
+- `claimableFamilyQuests` — family quests available to claim
+- `pendingApprovalQuests` — quests awaiting GM approval
+- `bossQuests` — active boss quests
+- `bossHistoryQuests` — defeated boss quests
+- `assignableCharacters` — family characters mapped for
+  assignment display
+- `familyMembers` — raw family member data
+- `character` — current user's character
+- `getAssignedHeroName(quest)` — memoized hero name
+  resolver
+- `isGuildMaster` — boolean role check
+- `onLoadQuestsRef` handler — exposes reload to parent
+
+#### Scenario: Combined loading state
+
+- **WHEN** any of the underlying data hooks (family,
+  character, quests, boss quests) is loading
+- **THEN** the hook SHALL return `loading: true`
+
+#### Scenario: Combined error state
+
+- **WHEN** any underlying data hook returns an error
+- **THEN** the hook SHALL return the first error string
+
+#### Scenario: Memoized quest filtering
+
+- **WHEN** quest instances change
+- **THEN** the hook SHALL recompute filtered quest lists
+  (active, historical, claimable, pending approval)
+  using memoization
+
+#### Scenario: Combined reload
+
+- **WHEN** `loadData` is called
+- **THEN** the hook SHALL reload all data hooks in
+  parallel via `Promise.all`
+
+### Requirement: MyQuestsSection component
+
+The system SHALL provide a `MyQuestsSection` presentational
+component in
+`components/quests/quest-dashboard/my-quests-section.tsx`
+that renders the user's active quests.
+
+The component SHALL accept:
+
+- `activeQuests` — array of active quest instances
+- `historicalQuestCount` — number of completed quests
+  (for hint text)
+- `bossHistoryCount` — number of defeated bosses
+  (for hint text)
+- `onStartQuest` — callback for starting a quest
+- `onCompleteQuest` — callback for completing a quest
+- `onReleaseQuest` — callback for releasing a quest
+- `familyMembers` — family member data for display
+- `isHighlighted` — function to check realtime highlight
+
+#### Scenario: Render active quests
+
+- **WHEN** the component receives active quests
+- **THEN** it SHALL render the "My Quests" heading and a
+  `QuestList` with start, complete, and release action
+  callbacks
+
+#### Scenario: Show history hint
+
+- **WHEN** `historicalQuestCount + bossHistoryCount > 0`
+- **THEN** the component SHALL render a hint directing
+  users to Quest History at the bottom of the page
+
+#### Scenario: No active quests with history
+
+- **WHEN** active quests is empty and history exists
+- **THEN** the `QuestList` SHALL display an empty message
+  with a hint about Quest History
+
+### Requirement: FamilyQuestSection component
+
+The system SHALL provide a `FamilyQuestSection`
+presentational component in
+`components/quests/quest-dashboard/family-quest-section.tsx`
+that wraps the `FamilyQuestClaiming` component.
+
+The component SHALL accept:
+
+- `quests` — claimable family quest instances
+- `character` — current user's character (nullable)
+- `onClaimQuest` — claim callback
+
+The component SHALL only render when `character` is
+non-null and `quests` is non-empty.
+
+#### Scenario: Render when claimable quests exist
+
+- **WHEN** character is present and claimable quests
+  array is non-empty
+- **THEN** the component SHALL render `FamilyQuestClaiming`
+  within a section element
+
+#### Scenario: Hide when no character
+
+- **WHEN** character is null
+- **THEN** the component SHALL render nothing
+
+### Requirement: QuestHistorySection component
+
+The system SHALL provide a `QuestHistorySection` component
+in
+`components/quests/quest-dashboard/quest-history-section.tsx`
+that manages the collapsible quest history display.
+
+The component SHALL own its own `showQuestHistory` toggle
+state internally.
+
+The component SHALL accept:
+
+- `historicalQuests` — completed quest instances
+- `bossHistoryQuests` — defeated boss quest instances
+- `familyMembers` — family member data for display
+
+The component SHALL only render when total history count
+is greater than zero.
+
+#### Scenario: Toggle history visibility
+
+- **WHEN** user clicks the show/hide history button
+- **THEN** the component SHALL toggle visibility of the
+  `QuestList` and `BossQuestHistoryList`
+
+#### Scenario: Show count in toggle button
+
+- **WHEN** history is hidden
+- **THEN** the button SHALL display
+  "Show History (N)" where N is total history count
+
+#### Scenario: Hide when no history
+
+- **WHEN** both `historicalQuests` and `bossHistoryQuests`
+  are empty
+- **THEN** the component SHALL render nothing
+
+### Requirement: Reduced quest-dashboard orchestrator
+
+The `QuestDashboard` component SHALL compose
+`useQuestDashboardData`, `useQuestHandlers`,
+realtime hooks, and the extracted section components to
+render the quest dashboard.
+
+The component SHALL NOT contain inline `useMemo` filtering,
+combined loading/error state construction, or section
+rendering logic.
+
+The component SHALL remain under 150 lines.
+
+#### Scenario: Compose from extracted pieces
+
+- **WHEN** `QuestDashboard` renders
+- **THEN** it SHALL use `useQuestDashboardData` for all
+  data, `useQuestHandlers` for action callbacks, render
+  `BossQuestPanel`, conditionally render
+  `PendingApprovalsSection`, `MyQuestsSection`,
+  `FamilyQuestSection`, and `QuestHistorySection`
+
+#### Scenario: Realtime subscription in orchestrator
+
+- **WHEN** a quest update event arrives via realtime
+- **THEN** the orchestrator SHALL trigger highlight
+  animation via `useRealtimeHighlight` and pass the
+  `isHighlighted` check to `MyQuestsSection`
+
+#### Scenario: Loading and error states preserved
+
+- **WHEN** data is loading or an error occurs
+- **THEN** `QuestDashboard` SHALL render the same loading
+  spinner and error UI with retry button as the current
+  implementation

--- a/openspec/changes/refactor-admin-dashboard/specs/quest-management-decomposition/spec.md
+++ b/openspec/changes/refactor-admin-dashboard/specs/quest-management-decomposition/spec.md
@@ -1,0 +1,132 @@
+# Quest Management Decomposition
+
+## ADDED Requirements
+
+### Requirement: useQuestManagementActions hook
+
+The system SHALL provide a `useQuestManagementActions`
+custom hook in `components/admin/useQuestManagementActions.ts`
+that encapsulates all quest action handlers, confirmation
+modal state, and processing state currently inline in
+`quest-management-tab.tsx`.
+
+The hook SHALL accept a configuration object with:
+
+- `reload`: async function to refresh quest data
+- `success`: notification success callback
+- `error`: notification error callback
+
+The hook SHALL return:
+
+- `handleAssignQuest(questId, characterId)` — assigns a
+  quest via `questInstanceApiService.assignFamilyQuest`
+- `handleApproveQuest(questId)` — approves a quest
+- `handleDenyQuest(questId)` — opens confirm modal for deny
+- `handleCancelQuest(questId)` — opens confirm modal for
+  cancel
+- `handleReleaseQuest(questId)` — opens confirm modal for
+  release
+- `handleConfirmAction()` — executes the pending confirmed
+  action
+- `handleDismissModal()` — closes the modal without acting
+- `confirmModal` — current modal state object
+- `isProcessing` — boolean loading flag
+- `selectedAssignee` — assignee selection state
+- `handleAssigneeChange(questId, userId)` — updates
+  assignee selection
+
+#### Scenario: Assign quest through hook
+
+- **WHEN** `handleAssignQuest` is called with a valid
+  questId and characterId
+- **THEN** the hook SHALL call
+  `questInstanceApiService.assignFamilyQuest`, clear the
+  selected assignee for that quest, show a success
+  notification, and call `reload`
+
+#### Scenario: Deny quest with confirmation
+
+- **WHEN** `handleDenyQuest` is called with a questId
+- **THEN** the hook SHALL set `confirmModal` to open with
+  title "Send Quest Back to Pending?" and action "deny"
+- **WHEN** `handleConfirmAction` is called while modal
+  action is "deny"
+- **THEN** the hook SHALL call
+  `questInstanceApiService.denyQuest`, show success
+  notification, close the modal, and call `reload`
+
+#### Scenario: Action failure handling
+
+- **WHEN** any quest action API call throws an error
+- **THEN** the hook SHALL call the error notification
+  callback with the error message and set `isProcessing`
+  to false
+
+### Requirement: QuestManagementSection component
+
+The system SHALL provide a `QuestManagementSection`
+presentational component in
+`components/admin/quest-management-section.tsx` that renders
+a single quest management section (e.g., "Unassigned" or
+"In Progress").
+
+The component SHALL accept props:
+
+- `title` — section heading text
+- `count` — number badge value
+- `quests` — array of `QuestInstance` items
+- `emptyMessage` — text shown when quests array is empty
+- `familyMembers` — assignable character options
+- `selectedAssignee` — current assignee selections
+- `hideAssignment` — optional boolean to hide assignment UI
+- Quest action callbacks: `onAssigneeChange`, `onAssign`,
+  `onApprove`, `onDeny`, `onCancel`, `onRelease`
+- `getAssignedHeroName` — function to resolve hero names
+
+#### Scenario: Render section with quests
+
+- **WHEN** the component receives a non-empty quests array
+- **THEN** it SHALL render a section header with title and
+  count badge, and a stagger-animated grid of `QuestCard`
+  components
+
+#### Scenario: Render empty section
+
+- **WHEN** the component receives an empty quests array
+- **THEN** it SHALL render the section header and a styled
+  empty state container with the `emptyMessage` text
+
+#### Scenario: Hide assignment controls
+
+- **WHEN** `hideAssignment` is true
+- **THEN** the component SHALL pass `hideAssignment={true}`
+  to each rendered `QuestCard`
+
+### Requirement: Reduced quest-management-tab orchestrator
+
+The `QuestManagementTab` component SHALL compose
+`useQuestManagementActions`, `QuestManagementSection`, and
+the existing `PendingApprovalsSection` to render the quest
+management interface.
+
+The component SHALL NOT contain inline `useCallback`
+handlers for quest actions, confirmation modal state
+management, or section rendering logic.
+
+The component SHALL remain under 150 lines.
+
+#### Scenario: Compose from extracted pieces
+
+- **WHEN** `QuestManagementTab` renders
+- **THEN** it SHALL use `useQuestManagementActions` for all
+  action handlers and modal state, render
+  `PendingApprovalsSection` for pending approvals, and
+  render `QuestManagementSection` for the "Unassigned"
+  and "In Progress" sections
+
+#### Scenario: Loading and error states preserved
+
+- **WHEN** quests are loading or an error occurs
+- **THEN** `QuestManagementTab` SHALL render the same
+  loading spinner and error UI as the current
+  implementation

--- a/openspec/changes/refactor-admin-dashboard/tasks.md
+++ b/openspec/changes/refactor-admin-dashboard/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Refactor Admin Dashboard
+
+## 1. Quest Management Tab — Hook Extraction
+
+- [x] 1.1 Create `useQuestManagementActions` hook in
+  `components/admin/useQuestManagementActions.ts` with
+  all 8 quest action handlers, confirmation modal state,
+  `isProcessing` flag, and assignee selection state
+- [x] 1.2 Write tests for `useQuestManagementActions`
+  covering assign, approve, deny/cancel/release
+  confirmation flow, and error handling
+
+## 2. Quest Management Tab — Section Component
+
+- [x] 2.1 Create `QuestManagementSection` component in
+  `components/admin/quest-management-section.tsx`
+  extracting the `renderSection` function with title,
+  count badge, quest grid, and empty state
+- [x] 2.2 Write tests for `QuestManagementSection`
+  covering non-empty rendering, empty state, and
+  `hideAssignment` prop behavior
+
+## 3. Quest Management Tab — Orchestrator Reduction
+
+- [x] 3.1 Refactor `quest-management-tab.tsx` to compose
+  `useQuestManagementActions` and
+  `QuestManagementSection`, removing inline handlers
+  and render logic
+- [x] 3.2 Update existing `quest-management-tab` tests
+  to work with the new component composition
+- [x] 3.3 Verify `quest-management-tab.tsx` is under
+  150 lines
+
+## 4. Quest Dashboard — Data Hook Extraction
+
+- [x] 4.1 Create `useQuestDashboardData` hook in
+  `components/quests/quest-dashboard/useQuestDashboardData.ts`
+  consolidating all 5 data hooks, combined
+  loading/error state, `loadData`, and 7 `useMemo`
+  filtering operations
+- [x] 4.2 Write tests for `useQuestDashboardData`
+  covering combined loading, error, reload, and
+  memoized filtering
+
+## 5. Quest Dashboard — Section Components
+
+- [x] 5.1 Create `MyQuestsSection` component in
+  `components/quests/quest-dashboard/my-quests-section.tsx`
+  with active quests rendering and history hint logic
+- [x] 5.2 Create `FamilyQuestSection` component in
+  `components/quests/quest-dashboard/family-quest-section.tsx`
+  wrapping `FamilyQuestClaiming` with conditional
+  rendering
+- [x] 5.3 Create `QuestHistorySection` component in
+  `components/quests/quest-dashboard/quest-history-section.tsx`
+  with internal toggle state and collapsible history
+  display
+- [x] 5.4 Write tests for all three section components
+
+## 6. Quest Dashboard — Orchestrator Reduction
+
+- [x] 6.1 Refactor `quest-dashboard/index.tsx` to compose
+  `useQuestDashboardData`, `useQuestHandlers`, realtime
+  hooks, and extracted section components
+- [x] 6.2 Update existing quest-dashboard tests to work
+  with the new component composition
+- [x] 6.3 Verify `quest-dashboard/index.tsx` is under
+  150 lines
+
+## 7. Quality Gate
+
+- [x] 7.1 Run `npm run build` — zero TypeScript errors
+- [x] 7.2 Run `npm run lint` — zero lint warnings
+- [x] 7.3 Run `npm run test` — all tests pass


### PR DESCRIPTION
## Summary

- Extract `useQuestManagementActions` hook and `QuestManagementSection` component from `quest-management-tab.tsx`, reducing it from 299 → 137 lines
- Extract `useQuestDashboardData` hook and three section components (`MyQuestsSection`, `FamilyQuestSection`, `QuestHistorySection`) from `quest-dashboard/index.tsx`, reducing it from 299 → 140 lines
- Full test coverage for all new hooks and components (19 new test files)
- Closes #48

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm run lint` — zero lint warnings
- [ ] `npm run test` — all 1565 unit + 23 integration tests pass
- [ ] Verify quest management tab renders correctly in admin dashboard
- [ ] Verify quest dashboard renders correctly with active quests, history, and GM approval section

🤖 Generated with [Claude Code](https://claude.com/claude-code)