### PR TITLE
feat: Achievement unlock evaluation engine (#136)

### DIFF
--- a/lib/__tests__/achievement-progress-service.cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.cascade.test.ts
@@ -109,7 +109,7 @@ describe("AchievementProgressService - cascade integration", () => {
       }),
     };
 
-    const orig = write.from;
+    const origImpl = write.from.getMockImplementation()!;
     write.from.mockImplementation((table: string) => {
       if (table === "character_achievements") {
         return {
@@ -118,7 +118,7 @@ describe("AchievementProgressService - cascade integration", () => {
           select: charAchChain.select,
         };
       }
-      return orig(table);
+      return origImpl(table);
     });
 
     const readClient = makeReadClient({

--- a/lib/__tests__/achievement-progress-service.cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.cascade.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for cascade fix (P1: revert, P2: persist, P3: xp_earned evaluation)
+ * Validates that the cascade logic doesn't break existing tests.
+ */
+
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import { makeWriteMocks, CHAR_ID, USER_ID } from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+const QUEST = {
+  id: "ach-quest",
+  criteria_type: "quest_complete",
+  criteria_config: { threshold: 5 },
+  xp_reward: 60,
+  gold_reward: 0,
+};
+
+const LEVEL = {
+  id: "ach-level",
+  criteria_type: "level_reached",
+  criteria_config: { threshold: 2 },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+
+function makeQuestChain(count: number): MockChain {
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        or: jest.fn().mockResolvedValue({ count, error: null }),
+      }),
+    }),
+  };
+}
+
+function makeCharChain(stats: { xp: number; gold: number; level: number }) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      return {
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: n === 1 ? { user_id: USER_ID, user_profiles: null } : stats,
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+describe("AchievementProgressService - cascade integration", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("handles level-up cascade without error", async () => {
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST.id],
+      rpcReturn: { xp: 100, gold: 0, level: 1 },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: QUEST.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: LEVEL.id }],
+        error: null,
+      });
+
+    let n = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        n++;
+        if (n === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: QUEST.id },
+                { achievement_id: LEVEL.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: QUEST.id, unlocked_at: null },
+                { achievement_id: LEVEL.id, unlocked_at: null },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const orig = write.from;
+    write.from.mockImplementation((table: string) => {
+      if (table === "character_achievements") {
+        return {
+          upsert: write.upsert,
+          update: write.charAchUpdate,
+          select: charAchChain.select,
+        };
+      }
+      return orig(table);
+    });
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 40,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([QUEST, LEVEL]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    // P2: Cascade should complete without throwing
+    await expect(
+      svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/__tests__/achievement-progress-service.compound-progress.test.ts
+++ b/lib/__tests__/achievement-progress-service.compound-progress.test.ts
@@ -1,0 +1,225 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeDataResult,
+  makeUpsertResult,
+  makeReadClient,
+  CHARACTER_ID,
+  USER_ID,
+} from "./achievement-progress-service.fixtures";
+
+const mockWriteClient = {
+  from: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+describe("AchievementProgressService - compound progress shape", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // 3.2 Compound progress JSONB shape — mixed results
+  it("upserts compound JSONB shape with per-condition results and top-level met", async () => {
+    // Sub-evaluators: quest_complete returns 7, level_reached returns 2
+    // Uses backfill path (no existing records) so "compound" is included via ALL_CRITERIA_TYPES
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 7, error: null }),
+        }),
+      }),
+    };
+    const charChain = makeDataResult({
+      user_id: USER_ID,
+      xp: 0,
+      level: 2,
+      honor_points: 0,
+    });
+    const achievementsChain = makeDataResult([
+      {
+        id: "ach-compound",
+        criteria_type: "compound",
+        criteria_config: {
+          evaluation_strategy: "compound",
+          operator: "AND",
+          conditions: [
+            { criteria_type: "quest_complete", threshold: 5 },
+            { criteria_type: "level_reached", threshold: 3 },
+          ],
+        },
+        xp_reward: 100,
+        gold_reward: 50,
+      },
+    ]);
+    // Return [] to trigger full backfill (ALL_CRITERIA_TYPES including "compound")
+    const charAchChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          data: [],
+          error: null,
+        }),
+      }),
+    };
+    const writeUpsert = makeUpsertResult();
+
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: achievementsChain as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: questChain,
+    });
+    // write client: upsert only (unlock eval will fail silently in try/catch)
+    mockWriteClient.from.mockReturnValue(writeUpsert);
+
+    const service = new AchievementProgressService(readClient as never);
+    await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
+
+    const upsertCall = writeUpsert.upsert.mock.calls[0][0];
+    expect(upsertCall).toHaveLength(1);
+    const progress = upsertCall[0].progress;
+
+    // Should be compound shape, not { current, threshold }
+    expect(progress).toHaveProperty("conditions");
+    expect(progress).toHaveProperty("met");
+    expect(Array.isArray(progress.conditions)).toBe(true);
+    expect(progress.conditions).toHaveLength(2);
+
+    // quest_complete: current 7 >= threshold 5 → met: true
+    const questCondition = progress.conditions.find(
+      (c: { criteria_type: string }) => c.criteria_type === "quest_complete",
+    );
+    expect(questCondition?.current).toBe(7);
+    expect(questCondition?.threshold).toBe(5);
+    expect(questCondition?.met).toBe(true);
+
+    // level_reached: current 2 < threshold 3 → met: false
+    const levelCondition = progress.conditions.find(
+      (c: { criteria_type: string }) => c.criteria_type === "level_reached",
+    );
+    expect(levelCondition?.met).toBe(false);
+
+    // AND with one unmet → top-level met: false
+    expect(progress.met).toBe(false);
+  });
+
+  // 3.2 All conditions met → met: true
+  it("upserts compound JSONB with met: true when all AND conditions are met", async () => {
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 7, error: null }),
+        }),
+      }),
+    };
+    const charChain = makeDataResult({
+      user_id: USER_ID,
+      xp: 0,
+      level: 4,
+      honor_points: 0,
+    });
+    const achievementsChain = makeDataResult([
+      {
+        id: "ach-compound",
+        criteria_type: "compound",
+        criteria_config: {
+          evaluation_strategy: "compound",
+          operator: "AND",
+          conditions: [
+            { criteria_type: "quest_complete", threshold: 5 },
+            { criteria_type: "level_reached", threshold: 3 },
+          ],
+        },
+        xp_reward: 100,
+        gold_reward: 50,
+      },
+    ]);
+    // Return [] to trigger full backfill
+    const charAchChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    };
+    const writeUpsert = makeUpsertResult();
+
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: achievementsChain as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: questChain,
+    });
+    mockWriteClient.from.mockReturnValue(writeUpsert);
+
+    const service = new AchievementProgressService(readClient as never);
+    await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
+
+    const upsertCall = writeUpsert.upsert.mock.calls[0][0];
+    const progress = upsertCall[0].progress;
+
+    expect(progress.met).toBe(true);
+    expect(progress.conditions.every((c: { met: boolean }) => c.met)).toBe(
+      true,
+    );
+  });
+
+  // 4.3 Reward fields are present in fetched achievement data
+  it("includes xp_reward and gold_reward fields in the achievements SELECT query", async () => {
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const charChain = makeDataResult({ user_id: USER_ID });
+    const achievementSelectSpy = jest.fn().mockReturnValue({
+      is: jest.fn().mockResolvedValue({
+        data: [
+          {
+            id: "ach-001",
+            name: "Quest Master",
+            criteria_type: "quest_complete",
+            criteria_config: { threshold: 5 },
+            xp_reward: 100,
+            gold_reward: 50,
+          },
+        ],
+        error: null,
+      }),
+    });
+    const achievementsChain = { select: achievementSelectSpy };
+    const charAchChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          data: [{ achievement_id: "ach-001" }],
+          error: null,
+        }),
+      }),
+    };
+    const writeUpsert = makeUpsertResult();
+
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: achievementsChain as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: questChain,
+    });
+    mockWriteClient.from.mockReturnValue(writeUpsert);
+
+    const service = new AchievementProgressService(readClient as never);
+    await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
+
+    // Verify the SELECT string includes reward fields
+    expect(achievementSelectSpy).toHaveBeenCalledWith(
+      expect.stringContaining("xp_reward"),
+    );
+    expect(achievementSelectSpy).toHaveBeenCalledWith(
+      expect.stringContaining("gold_reward"),
+    );
+    expect(achievementSelectSpy).toHaveBeenCalledWith(
+      expect.stringContaining("name"),
+    );
+  });
+});

--- a/lib/__tests__/achievement-progress-service.compound-progress.test.ts
+++ b/lib/__tests__/achievement-progress-service.compound-progress.test.ts
@@ -16,6 +16,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService - compound progress shape", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.evaluators-compound.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-compound.test.ts
@@ -1,0 +1,162 @@
+import { createCompoundEvaluator } from "../achievement-progress/compound-evaluator";
+import type { EvaluatorFn } from "../achievement-progress/types";
+
+const CHARACTER_ID = "char-001";
+const USER_ID = "user-001";
+
+function makeMockClient() {
+  return {} as never;
+}
+
+// 2.5 Compound evaluator tests
+describe("createCompoundEvaluator", () => {
+  it("delegates to sub-evaluators for each condition", async () => {
+    const questEvaluator = jest
+      .fn<ReturnType<EvaluatorFn>, Parameters<EvaluatorFn>>()
+      .mockResolvedValue({ current: 7 });
+    const levelEvaluator = jest
+      .fn<ReturnType<EvaluatorFn>, Parameters<EvaluatorFn>>()
+      .mockResolvedValue({ current: 4 });
+
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: questEvaluator,
+      level_reached: levelEvaluator,
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 5 },
+        { criteria_type: "level_reached", threshold: 3 },
+      ],
+    });
+
+    expect(questEvaluator).toHaveBeenCalledTimes(1);
+    expect(levelEvaluator).toHaveBeenCalledTimes(1);
+    expect(result.compoundConditions).toHaveLength(2);
+    expect(result.compoundMet).toBe(true);
+  });
+
+  it("returns compoundMet false when AND has one unmet condition", async () => {
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: jest.fn().mockResolvedValue({ current: 7 }),
+      level_reached: jest.fn().mockResolvedValue({ current: 2 }),
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 5 },
+        { criteria_type: "level_reached", threshold: 3 },
+      ],
+    });
+
+    expect(result.compoundMet).toBe(false);
+    expect(result.compoundConditions![0].met).toBe(true);
+    expect(result.compoundConditions![1].met).toBe(false);
+  });
+
+  it("defaults operator to AND when absent", async () => {
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: jest.fn().mockResolvedValue({ current: 3 }),
+      level_reached: jest.fn().mockResolvedValue({ current: 1 }),
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 5 },
+        { criteria_type: "level_reached", threshold: 3 },
+      ],
+    });
+
+    // AND with both unmet → false
+    expect(result.compoundMet).toBe(false);
+  });
+
+  it("handles OR: returns compoundMet true when one condition is met", async () => {
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: jest.fn().mockResolvedValue({ current: 2 }),
+      boss_defeated: jest.fn().mockResolvedValue({ current: 5 }),
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "OR",
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 10 },
+        { criteria_type: "boss_defeated", threshold: 3 },
+      ],
+    });
+
+    expect(result.compoundMet).toBe(true);
+  });
+
+  it("handles boolean sub-condition", async () => {
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: jest.fn().mockResolvedValue({ current: 7 }),
+      class_change: jest.fn().mockResolvedValue({ current: 1 }),
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 5 },
+        { criteria_type: "class_change", boolean: true },
+      ],
+    });
+
+    expect(result.compoundMet).toBe(true);
+    expect(result.compoundConditions![1].met).toBe(true);
+  });
+
+  it("handles unknown sub-condition: logs warning and treats as not met", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: jest.fn().mockResolvedValue({ current: 7 }),
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 5 },
+        { criteria_type: "nonexistent_type", threshold: 1 },
+      ],
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Unknown sub-condition criteria type: nonexistent_type",
+      ),
+    );
+    expect(result.compoundMet).toBe(false);
+    expect(result.compoundConditions![1].met).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns current as count of met conditions", async () => {
+    const registry: Record<string, EvaluatorFn> = {
+      quest_complete: jest.fn().mockResolvedValue({ current: 7 }),
+      level_reached: jest.fn().mockResolvedValue({ current: 4 }),
+      boss_defeated: jest.fn().mockResolvedValue({ current: 1 }),
+    };
+
+    const evaluator = createCompoundEvaluator(() => registry);
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+      conditions: [
+        { criteria_type: "quest_complete", threshold: 5 },
+        { criteria_type: "level_reached", threshold: 3 },
+        { criteria_type: "boss_defeated", threshold: 3 }, // not met: 1 < 3
+      ],
+    });
+
+    expect(result.current).toBe(2); // two conditions met
+  });
+});

--- a/lib/__tests__/achievement-progress-service.evaluators-compound.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-compound.test.ts
@@ -140,6 +140,29 @@ describe("createCompoundEvaluator", () => {
     warnSpy.mockRestore();
   });
 
+  it("returns compoundMet false for empty conditions array", async () => {
+    const evaluator = createCompoundEvaluator(() => ({}));
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+      conditions: [],
+    });
+
+    expect(result.compoundMet).toBe(false);
+    expect(result.current).toBe(0);
+    expect(result.compoundConditions).toEqual([]);
+  });
+
+  it("returns compoundMet false for missing conditions (defaults to [])", async () => {
+    const evaluator = createCompoundEvaluator(() => ({}));
+    const result = await evaluator(makeMockClient(), CHARACTER_ID, USER_ID, {
+      operator: "AND",
+    });
+
+    expect(result.compoundMet).toBe(false);
+    expect(result.current).toBe(0);
+    expect(result.compoundConditions).toEqual([]);
+  });
+
   it("returns current as count of met conditions", async () => {
     const registry: Record<string, EvaluatorFn> = {
       quest_complete: jest.fn().mockResolvedValue({ current: 7 }),

--- a/lib/__tests__/achievement-progress-service.evaluators-difficulty-boss.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-difficulty-boss.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService evaluators", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.evaluators-gold-reward.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-gold-reward.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService evaluators", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.evaluators-honor.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-honor.test.ts
@@ -16,6 +16,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService evaluators", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.evaluators-quest.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-quest.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService evaluators", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.evaluators-spending.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-spending.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService evaluators", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.evaluators-stats.test.ts
+++ b/lib/__tests__/achievement-progress-service.evaluators-stats.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService evaluators", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -255,18 +255,12 @@ describe("AchievementProgressService - rollback compensation", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    // Fix P2: cascade revert uses upsert with prior progress (null = not existed)
-    expect(write.upsert).toHaveBeenNthCalledWith(
-      3,
-      [
-        {
-          character_id: CHAR_ID,
-          achievement_id: xpEarnedAch.id,
-          progress: null,
-        },
-      ],
-      { onConflict: "character_id,achievement_id" },
-    );
+    // P2 fix: brand-new cascade rows are deleted, not upserted with null
+    expect(write.upsert).toHaveBeenCalledTimes(2); // no 3rd upsert
+    expect(write.cascadeDelete).toHaveBeenCalled();
+    expect(write.cascadeDeleteIn).toHaveBeenCalledWith("achievement_id", [
+      xpEarnedAch.id,
+    ]);
   });
 
   it("detects revert failure when Supabase returns { error } not throw", async () => {

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -25,7 +25,7 @@ const LEVEL_UP_ACHIEVEMENT = {
 };
 const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
 
-describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () => {
+describe("AchievementProgressService - rollback compensation", () => {
   let consoleSpy: jest.SpyInstance;
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -50,16 +50,8 @@ describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () 
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenNthCalledWith(
-      1,
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 60, p_gold: 0 },
-    );
-    expect(mockWriteClient.rpc).toHaveBeenNthCalledWith(
-      2,
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: -60, p_gold: 0 },
-    );
+    // Fix P1: stats rollback uses direct UPDATE (xp: 100-60=40, gold: 0-0=0)
+    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
   });
 
   it("reverts stats and level when cascade upsert fails", async () => {
@@ -140,20 +132,18 @@ describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () 
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenNthCalledWith(
-      2,
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: -60, p_gold: 0 },
-    );
+    // Fix P1: level rollback still uses direct UPDATE with prevLevel=1
     expect(write.statsUpdate).toHaveBeenCalledWith({ level: 1 });
+    // Fix P1: stats rollback uses direct UPDATE (xp: 100-60=40, gold: 0-0=0)
+    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
   });
 
-  it("logs critical error if stats revert RPC fails", async () => {
+  it("logs critical error if stats revert UPDATE fails", async () => {
     const write = makeWriteMocks({
       unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
       rpcReturn: LEVEL_UP_RPC_RETURN,
       levelUpdateError: "trigger-rollback",
-      rpcCompensationError: "stats-revert-fail",
+      statsRevertError: "stats-revert-fail",
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -220,6 +210,14 @@ describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () 
             }),
           };
         }
+        if (charAchN === 3) {
+          // Fix P2: cascade snapshot read — no prior progress for xpEarnedAch
+          return {
+            eq: jest.fn().mockReturnValue({
+              in: jest.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          };
+        }
         // depth=1 recursive fetch fails → triggers outer catch
         return {
           eq: jest.fn().mockReturnValue({
@@ -257,9 +255,18 @@ describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () 
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.inForCascadeRevert).toHaveBeenCalledWith("achievement_id", [
-      xpEarnedAch.id,
-    ]);
+    // Fix P2: cascade revert uses upsert with prior progress (null = not existed)
+    expect(write.upsert).toHaveBeenNthCalledWith(
+      3,
+      [
+        {
+          character_id: CHAR_ID,
+          achievement_id: xpEarnedAch.id,
+          progress: null,
+        },
+      ],
+      { onConflict: "character_id,achievement_id" },
+    );
   });
 
   it("detects revert failure when Supabase returns { error } not throw", async () => {

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -170,6 +170,98 @@ describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () 
     );
   });
 
+  it("reverts cascade progress rows when recursive unlock fails after upsert succeeds", async () => {
+    const questAch = {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 50,
+      gold_reward: 0,
+    };
+    const xpEarnedAch = {
+      id: "ach-xp",
+      name: "XP Earner",
+      criteria_type: "xp_earned",
+      criteria_config: { threshold: 100 },
+      xp_reward: 0,
+      gold_reward: 0,
+    };
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      levelSelectRows: [], // no level-up
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: questAch.id },
+                { achievement_id: xpEarnedAch.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        if (charAchN === 2) {
+          return {
+            eq: jest.fn().mockReturnValue({
+              in: jest.fn().mockResolvedValue({
+                data: [{ achievement_id: questAch.id, unlocked_at: null }],
+                error: null,
+              }),
+            }),
+          };
+        }
+        // depth=1 recursive fetch fails → triggers outer catch
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: "recursive-fetch-fail" },
+            }),
+          }),
+        };
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_id: USER_ID, user_profiles: null },
+              error: null,
+            }),
+          }),
+        }),
+      } as unknown as MockChain,
+      achievements: makeDataResult([
+        questAch,
+        xpEarnedAch,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+          }),
+        }),
+      } as unknown as MockChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.inForCascadeRevert).toHaveBeenCalledWith("achievement_id", [
+      xpEarnedAch.id,
+    ]);
+  });
+
   it("detects revert failure when Supabase returns { error } not throw", async () => {
     const write = makeWriteMocks({
       unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -1,0 +1,194 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeUnlockReadClient,
+  DEFAULT_ACHIEVEMENT,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+// prevXp=40, award xp=60 → new xp=100 >= level-2 threshold (50) → level-up triggered
+const LEVEL_UP_ACHIEVEMENT = {
+  ...DEFAULT_ACHIEVEMENT,
+  xp_reward: 60,
+  gold_reward: 0,
+};
+const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+
+describe("AchievementProgressService - rollback compensation (P1/P2 fixes)", () => {
+  let consoleSpy: jest.SpyInstance;
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it("reverts stats when level update fails after RPC succeeds", async () => {
+    const write = makeWriteMocks({
+      unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      levelUpdateError: "level-update-fail",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: LEVEL_UP_ACHIEVEMENT,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenNthCalledWith(
+      1,
+      "fn_increment_character_stats",
+      { p_character_id: CHAR_ID, p_xp: 60, p_gold: 0 },
+    );
+    expect(mockWriteClient.rpc).toHaveBeenNthCalledWith(
+      2,
+      "fn_increment_character_stats",
+      { p_character_id: CHAR_ID, p_xp: -60, p_gold: 0 },
+    );
+  });
+
+  it("reverts stats and level when cascade upsert fails", async () => {
+    const questAch = {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 60,
+      gold_reward: 0,
+    };
+    const levelAch = {
+      id: "ach-level",
+      name: "Level Up!",
+      criteria_type: "level_reached",
+      criteria_config: { threshold: 2 },
+      xp_reward: 0,
+      gold_reward: 0,
+    };
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      cascadeUpsertError: "cascade-fail",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: questAch.id },
+                { achievement_id: levelAch.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: questAch.id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+    const charChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_id: USER_ID, user_profiles: null },
+            error: null,
+          }),
+        }),
+      }),
+    };
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([
+        questAch,
+        levelAch,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenNthCalledWith(
+      2,
+      "fn_increment_character_stats",
+      { p_character_id: CHAR_ID, p_xp: -60, p_gold: 0 },
+    );
+    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 1 });
+  });
+
+  it("logs critical error if stats revert RPC fails", async () => {
+    const write = makeWriteMocks({
+      unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      levelUpdateError: "trigger-rollback",
+      rpcCompensationError: "stats-revert-fail",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: LEVEL_UP_ACHIEVEMENT,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Critical: failed to revert stats after reward failure:",
+      expect.objectContaining({ message: "stats-revert-fail" }),
+    );
+  });
+
+  it("detects revert failure when Supabase returns { error } not throw", async () => {
+    const write = makeWriteMocks({
+      unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      levelUpdateError: "trigger-rollback",
+      revertUnlockError: "RLS",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: LEVEL_UP_ACHIEVEMENT,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Critical: failed to revert unlock after reward failure:",
+      expect.objectContaining({ message: "RLS" }),
+    );
+  });
+});

--- a/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests that when stats rollback fails (concurrent write), the rollback
+ * preserves consistency by skipping level revert and cascade progress revert.
+ * Without these guards, a failed stats rollback would leave the character
+ * with high XP/gold at a low level, or with stale cascade progress.
+ */
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import { makeWriteMocks, CHAR_ID, USER_ID } from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+
+function makeQuestLevelAchievements() {
+  return {
+    questAch: {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 60,
+      gold_reward: 0,
+    },
+    levelAch: {
+      id: "ach-level",
+      name: "Level Reached",
+      criteria_type: "level_reached",
+      criteria_config: { threshold: 2 },
+      xp_reward: 0,
+      gold_reward: 0,
+    },
+  };
+}
+
+function makeSimpleCharAchChain(questAchId: string, levelAchId: string) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      if (n === 1)
+        return {
+          eq: jest.fn().mockResolvedValue({
+            data: [
+              { achievement_id: questAchId },
+              { achievement_id: levelAchId },
+            ],
+            error: null,
+          }),
+        };
+      return {
+        eq: jest.fn().mockReturnValue({
+          in: jest.fn().mockResolvedValue({
+            data: [{ achievement_id: questAchId, unlocked_at: null }],
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+function makeQuestReadClient(
+  questAchId: string,
+  levelAchId: string,
+  achievements: unknown[],
+  charAchChain: unknown,
+) {
+  return makeReadClient({
+    characters: {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_id: USER_ID, user_profiles: null },
+            error: null,
+          }),
+        }),
+      }),
+    } as unknown as MockChain,
+    achievements: makeDataResult(achievements) as unknown as MockChain,
+    character_achievements: charAchChain,
+    quest_instances: {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    } as unknown as MockChain,
+  });
+}
+
+describe("AchievementProgressService - rollback consistency on stats failure", () => {
+  let consoleSpy: jest.SpyInstance;
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it("skips level rollback when stats rollback fails (concurrent write)", async () => {
+    const { questAch, levelAch } = makeQuestLevelAchievements();
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      cascadeUpsertError: "cascade-fail",
+      statsRevertError: "concurrent-write",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    const readClient = makeQuestReadClient(
+      questAch.id,
+      levelAch.id,
+      [questAch, levelAch],
+      makeSimpleCharAchChain(questAch.id, levelAch.id),
+    );
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Stats rollback was attempted
+    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
+    // Level rollback must NOT have been called
+    expect(write.levelRevertEq2).not.toHaveBeenCalled();
+    // unlocked_at must NOT be cleared (achievements stay locked-in)
+    expect(write.inForRevert).not.toHaveBeenCalled();
+  });
+
+  it("skips cascade progress rollback when stats rollback fails", async () => {
+    const questAch = {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 50,
+      gold_reward: 0,
+    };
+    const xpEarnedAch = {
+      id: "ach-xp",
+      name: "XP Earner",
+      criteria_type: "xp_earned",
+      criteria_config: { threshold: 100 },
+      xp_reward: 0,
+      gold_reward: 0,
+    };
+    const priorProgress = { current: 90, threshold: 100 };
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      levelSelectRows: [],
+      cascadeUpsertError: "cascade-fail",
+      statsRevertError: "concurrent-write",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1)
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: questAch.id },
+                { achievement_id: xpEarnedAch.id },
+              ],
+              error: null,
+            }),
+          };
+        if (charAchN === 2)
+          return {
+            eq: jest.fn().mockReturnValue({
+              in: jest.fn().mockResolvedValue({
+                data: [{ achievement_id: questAch.id, unlocked_at: null }],
+                error: null,
+              }),
+            }),
+          };
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: xpEarnedAch.id, progress: priorProgress },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+    const readClient = makeQuestReadClient(
+      questAch.id,
+      xpEarnedAch.id,
+      [questAch, xpEarnedAch],
+      charAchChain,
+    );
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Stats rollback failed, so cascade progress must NOT be reverted.
+    // Only 2 upserts: initial progress + cascade (no 3rd revert upsert).
+    expect(write.upsert).toHaveBeenCalledTimes(2);
+    // No phantom row deletion either
+    expect(write.cascadeDelete).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
@@ -1,16 +1,16 @@
 /**
- * Tests that when stats rollback fails (concurrent write), the rollback
- * preserves consistency by skipping level revert and cascade progress revert.
- * Without these guards, a failed stats rollback would leave the character
- * with high XP/gold at a low level, or with stale cascade progress.
+ * Tests that rollback preserves consistency when stats compensation fails:
+ * - Zero-row stats rollback (concurrent write) is treated as failure
+ * - Level, unlocked_at, and cascade progress are all skipped when stats fail
+ * - Cascade snapshot read failure aborts before corrupting rollback state
  */
 import { AchievementProgressService } from "../achievement-progress-service";
+import { makeWriteMocks, CHAR_ID } from "./unlock-evaluation-fixtures";
 import {
-  makeReadClient,
-  makeDataResult,
-} from "./achievement-progress-service.fixtures";
-import type { MockChain } from "./achievement-progress-service.fixtures";
-import { makeWriteMocks, CHAR_ID, USER_ID } from "./unlock-evaluation-fixtures";
+  makeQuestLevelAchievements,
+  makeDualCharAchChain,
+  makeMultiAchReadClient,
+} from "./unlock-multi-ach-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
@@ -18,83 +18,6 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
-
-function makeQuestLevelAchievements() {
-  return {
-    questAch: {
-      id: "ach-quest",
-      name: "Quest Master",
-      criteria_type: "quest_complete",
-      criteria_config: { threshold: 5 },
-      xp_reward: 60,
-      gold_reward: 0,
-    },
-    levelAch: {
-      id: "ach-level",
-      name: "Level Reached",
-      criteria_type: "level_reached",
-      criteria_config: { threshold: 2 },
-      xp_reward: 0,
-      gold_reward: 0,
-    },
-  };
-}
-
-function makeSimpleCharAchChain(questAchId: string, levelAchId: string) {
-  let n = 0;
-  return {
-    select: jest.fn().mockImplementation(() => {
-      n++;
-      if (n === 1)
-        return {
-          eq: jest.fn().mockResolvedValue({
-            data: [
-              { achievement_id: questAchId },
-              { achievement_id: levelAchId },
-            ],
-            error: null,
-          }),
-        };
-      return {
-        eq: jest.fn().mockReturnValue({
-          in: jest.fn().mockResolvedValue({
-            data: [{ achievement_id: questAchId, unlocked_at: null }],
-            error: null,
-          }),
-        }),
-      };
-    }),
-  };
-}
-
-function makeQuestReadClient(
-  questAchId: string,
-  levelAchId: string,
-  achievements: unknown[],
-  charAchChain: unknown,
-) {
-  return makeReadClient({
-    characters: {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data: { user_id: USER_ID, user_profiles: null },
-            error: null,
-          }),
-        }),
-      }),
-    } as unknown as MockChain,
-    achievements: makeDataResult(achievements) as unknown as MockChain,
-    character_achievements: charAchChain,
-    quest_instances: {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    } as unknown as MockChain,
-  });
-}
 
 describe("AchievementProgressService - rollback consistency on stats failure", () => {
   let consoleSpy: jest.SpyInstance;
@@ -116,21 +39,15 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
-
-    const readClient = makeQuestReadClient(
-      questAch.id,
-      levelAch.id,
+    const readClient = makeMultiAchReadClient(
       [questAch, levelAch],
-      makeSimpleCharAchChain(questAch.id, levelAch.id),
+      makeDualCharAchChain(questAch.id, levelAch.id),
     );
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Stats rollback was attempted
     expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
-    // Level rollback must NOT have been called
     expect(write.levelRevertEq2).not.toHaveBeenCalled();
-    // unlocked_at must NOT be cleared (achievements stay locked-in)
     expect(write.inForRevert).not.toHaveBeenCalled();
   });
 
@@ -143,7 +60,7 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
       xp_reward: 50,
       gold_reward: 0,
     };
-    const xpEarnedAch = {
+    const xpAch = {
       id: "ach-xp",
       name: "XP Earner",
       criteria_type: "xp_earned",
@@ -151,7 +68,6 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
       xp_reward: 0,
       gold_reward: 0,
     };
-    const priorProgress = { current: 90, threshold: 100 };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
       rpcReturn: { xp: 50, gold: 0, level: 1 },
@@ -162,21 +78,21 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
 
-    let charAchN = 0;
+    let n = 0;
     const charAchChain = {
       select: jest.fn().mockImplementation(() => {
-        charAchN++;
-        if (charAchN === 1)
+        n++;
+        if (n === 1)
           return {
             eq: jest.fn().mockResolvedValue({
               data: [
                 { achievement_id: questAch.id },
-                { achievement_id: xpEarnedAch.id },
+                { achievement_id: xpAch.id },
               ],
               error: null,
             }),
           };
-        if (charAchN === 2)
+        if (n === 2)
           return {
             eq: jest.fn().mockReturnValue({
               in: jest.fn().mockResolvedValue({
@@ -189,7 +105,10 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
           eq: jest.fn().mockReturnValue({
             in: jest.fn().mockResolvedValue({
               data: [
-                { achievement_id: xpEarnedAch.id, progress: priorProgress },
+                {
+                  achievement_id: xpAch.id,
+                  progress: { current: 90, threshold: 100 },
+                },
               ],
               error: null,
             }),
@@ -197,19 +116,104 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
         };
       }),
     };
-    const readClient = makeQuestReadClient(
-      questAch.id,
-      xpEarnedAch.id,
-      [questAch, xpEarnedAch],
-      charAchChain,
+    const readClient = makeMultiAchReadClient([questAch, xpAch], charAchChain);
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.upsert).toHaveBeenCalledTimes(2);
+    expect(write.cascadeDelete).not.toHaveBeenCalled();
+  });
+
+  it("treats zero-row stats rollback as failed compensation", async () => {
+    const { questAch, levelAch } = makeQuestLevelAchievements();
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      cascadeUpsertError: "cascade-fail",
+      statsRevertZeroRows: true,
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const readClient = makeMultiAchReadClient(
+      [questAch, levelAch],
+      makeDualCharAchChain(questAch.id, levelAch.id),
     );
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Stats rollback failed, so cascade progress must NOT be reverted.
-    // Only 2 upserts: initial progress + cascade (no 3rd revert upsert).
+    expect(write.levelRevertEq2).not.toHaveBeenCalled();
+    expect(write.inForRevert).not.toHaveBeenCalled();
     expect(write.upsert).toHaveBeenCalledTimes(2);
-    // No phantom row deletion either
     expect(write.cascadeDelete).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("zero rows"),
+    );
+  });
+
+  it("throws when cascade snapshot read fails instead of silently continuing", async () => {
+    const questAch = {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 50,
+      gold_reward: 0,
+    };
+    const xpAch = {
+      id: "ach-xp",
+      name: "XP Earner",
+      criteria_type: "xp_earned",
+      criteria_config: { threshold: 100 },
+      xp_reward: 0,
+      gold_reward: 0,
+    };
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      levelSelectRows: [],
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    let n = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        n++;
+        if (n === 1)
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: questAch.id },
+                { achievement_id: xpAch.id },
+              ],
+              error: null,
+            }),
+          };
+        if (n === 2)
+          return {
+            eq: jest.fn().mockReturnValue({
+              in: jest.fn().mockResolvedValue({
+                data: [{ achievement_id: questAch.id, unlocked_at: null }],
+                error: null,
+              }),
+            }),
+          };
+        // cascade snapshot read FAILS
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: "transient-read-failure" },
+            }),
+          }),
+        };
+      }),
+    };
+    const readClient = makeMultiAchReadClient([questAch, xpAch], charAchChain);
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // The throw triggers the catch block which rolls back stats
+    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 0, gold: 0 });
   });
 });

--- a/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
@@ -1,0 +1,265 @@
+/**
+ * P1/P2 rollback guard tests — three new scenarios added in the fix:
+ *   P1a: level rollback carries an optimistic-lock eq("level", appliedLevel)
+ *   P1b: stats rollback uses a conditional SET, not a negative RPC increment
+ *   P2:  cascade rollback restores pre-existing progress, not null
+ */
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeUnlockReadClient,
+  DEFAULT_ACHIEVEMENT,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+const LEVEL_UP_ACHIEVEMENT = {
+  ...DEFAULT_ACHIEVEMENT,
+  xp_reward: 60,
+  gold_reward: 0,
+};
+// RPC returns xp=100, gold=0, level=1 after the +60 xp increment
+const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+
+function makeQuestLevelAchievements() {
+  return {
+    questAch: {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 60,
+      gold_reward: 0,
+    },
+    levelAch: {
+      id: "ach-level",
+      name: "Level Reached",
+      criteria_type: "level_reached",
+      criteria_config: { threshold: 2 },
+      xp_reward: 0,
+      gold_reward: 0,
+    },
+  };
+}
+
+function makeSimpleCharAchChain(questAchId: string, levelAchId: string) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      if (n === 1)
+        return {
+          eq: jest.fn().mockResolvedValue({
+            data: [
+              { achievement_id: questAchId },
+              { achievement_id: levelAchId },
+            ],
+            error: null,
+          }),
+        };
+      return {
+        eq: jest.fn().mockReturnValue({
+          in: jest.fn().mockResolvedValue({
+            data: [{ achievement_id: questAchId, unlocked_at: null }],
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+describe("AchievementProgressService - rollback guard fixes (P1/P2)", () => {
+  let consoleSpy: jest.SpyInstance;
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it("P1 level guard: rollback UPDATE carries eq(level, appliedLevel) to skip stale reverts", async () => {
+    const { questAch, levelAch } = makeQuestLevelAchievements();
+    // cascade upsert fails after level-up was successfully written (appliedLevel=2)
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN,
+      cascadeUpsertError: "cascade-fail",
+      // levelSelectRows defaults to [{ level: 2 }] → appliedLevel = 2
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    const readClient = makeReadClient({
+      characters: {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_id: USER_ID, user_profiles: null },
+              error: null,
+            }),
+          }),
+        }),
+      } as unknown as MockChain,
+      achievements: makeDataResult([
+        questAch,
+        levelAch,
+      ]) as unknown as MockChain,
+      character_achievements: makeSimpleCharAchChain(questAch.id, levelAch.id),
+      quest_instances: {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+          }),
+        }),
+      } as unknown as MockChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // The second .eq() in the level-rollback chain must carry the value we
+    // wrote so a concurrent advance is not silently reversed.
+    expect(write.levelRevertEq2).toHaveBeenCalledWith("level", 2);
+  });
+
+  it("P1 stats guard: rollback uses conditional SET, not a negative RPC increment", async () => {
+    // level update fails → stats were applied (capturedNewStats={xp:100,gold:0})
+    const write = makeWriteMocks({
+      unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
+      rpcReturn: LEVEL_UP_RPC_RETURN, // totalXp=60
+      levelUpdateError: "level-update-fail",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: LEVEL_UP_ACHIEVEMENT,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Must NOT call RPC a second time (no negative increment)
+    expect(mockWriteClient.rpc).toHaveBeenCalledTimes(1);
+    // Must call characters.update with the computed previous values
+    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 }); // 100-60, 0-0
+    // Optimistic-lock guards match the captured post-increment snapshot
+    expect(write.statsRevertEq2).toHaveBeenCalledWith("xp", 100);
+    expect(write.statsRevertEq3).toHaveBeenCalledWith("gold", 0);
+  });
+
+  it("P2 cascade restore: rollback restores pre-existing progress instead of writing null", async () => {
+    const questAch = {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 50,
+      gold_reward: 0,
+    };
+    const xpEarnedAch = {
+      id: "ach-xp",
+      name: "XP Earner",
+      criteria_type: "xp_earned",
+      criteria_config: { threshold: 100 },
+      xp_reward: 0,
+      gold_reward: 0,
+    };
+    const priorProgress = { current: 90, threshold: 100 };
+    const write = makeWriteMocks({
+      unlockedIds: [questAch.id],
+      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      levelSelectRows: [],
+      cascadeUpsertError: "cascade-fail",
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1)
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: questAch.id },
+                { achievement_id: xpEarnedAch.id },
+              ],
+              error: null,
+            }),
+          };
+        if (charAchN === 2)
+          return {
+            eq: jest.fn().mockReturnValue({
+              in: jest.fn().mockResolvedValue({
+                data: [{ achievement_id: questAch.id, unlocked_at: null }],
+                error: null,
+              }),
+            }),
+          };
+        // charAchN === 3: cascade snapshot — xpEarnedAch has prior progress
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: xpEarnedAch.id, progress: priorProgress },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_id: USER_ID, user_profiles: null },
+              error: null,
+            }),
+          }),
+        }),
+      } as unknown as MockChain,
+      achievements: makeDataResult([
+        questAch,
+        xpEarnedAch,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+          }),
+        }),
+      } as unknown as MockChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Cascade revert upsert must restore prior progress, not null
+    expect(write.upsert).toHaveBeenNthCalledWith(
+      3,
+      [
+        {
+          character_id: CHAR_ID,
+          achievement_id: xpEarnedAch.id,
+          progress: priorProgress,
+        },
+      ],
+      { onConflict: "character_id,achievement_id" },
+    );
+  });
+});

--- a/lib/__tests__/achievement-progress-service.service-backfill.test.ts
+++ b/lib/__tests__/achievement-progress-service.service-backfill.test.ts
@@ -13,6 +13,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService - service level", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.service-integrity.test.ts
+++ b/lib/__tests__/achievement-progress-service.service-integrity.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService - service level", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.service-routing.test.ts
+++ b/lib/__tests__/achievement-progress-service.service-routing.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService - service level", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.service-upsert.test.ts
+++ b/lib/__tests__/achievement-progress-service.service-upsert.test.ts
@@ -17,6 +17,11 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  ...jest.requireActual("@/lib/achievement-progress/unlock-engine"),
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("AchievementProgressService - service level", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
@@ -67,6 +67,22 @@ function makeCharChain(secondCallStats: {
   };
 }
 
+const COMPOUND_ACH = {
+  id: "ach-compound",
+  name: "Quest & Ascend Master",
+  criteria_type: "compound",
+  criteria_config: {
+    operator: "AND",
+    evaluation_strategy: "compound",
+    conditions: [
+      { criteria_type: "quest_complete", threshold: 5 },
+      { criteria_type: "level_reached", threshold: 3 },
+    ],
+  },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+
 describe("AchievementProgressService - level-up cascade (7.3)", () => {
   afterEach(() => jest.clearAllMocks());
 
@@ -164,5 +180,74 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
     expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("7.3b cascades to unlock compound achievement with level_reached sub-condition after level-up", async () => {
+    // Character at level 2 with 5 quests done.
+    // Quest achievement (xp_reward: 60) unlocks → level-up to 3.
+    // Compound achievement (quest_complete >= 5 AND level_reached >= 3) should also unlock in cascade.
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST_ACH.id, COMPOUND_ACH.id],
+      rpcReturn: { xp: 260, gold: 0, level: 2 },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: QUEST_ACH.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: COMPOUND_ACH.id }],
+        error: null,
+      });
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: QUEST_ACH.id },
+                { achievement_id: COMPOUND_ACH.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        const id = charAchN === 2 ? QUEST_ACH.id : COMPOUND_ACH.id;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 260,
+        gold: 0,
+        level: 3,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        QUEST_ACH,
+        COMPOUND_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Unlock called twice: quest_complete then compound in cascade
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
   });
 });

--- a/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
@@ -11,7 +11,7 @@ import {
   USER_ID,
 } from "./unlock-evaluation-fixtures";
 
-const mockWriteClient = { from: jest.fn() };
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
@@ -71,8 +71,23 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("7.3 cascades to unlock level_reached achievement after XP-triggered level-up", async () => {
-    const write = makeWriteMocks();
+    // prevXp=40, award xp=60 → new xp=100 → level 2; cascade unlocks LEVEL_ACH
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST_ACH.id],
+      rpcReturn: { xp: 100, gold: 0, level: 1 },
+    });
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    // First IS NULL update unlocks QUEST_ACH; cascade update unlocks LEVEL_ACH
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: QUEST_ACH.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: LEVEL_ACH.id }],
+        error: null,
+      });
 
     let charAchN = 0;
     const charAchChain = {
@@ -123,9 +138,13 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
   });
 
   it("7.3 no cascade when XP reward does not trigger level-up", async () => {
-    const write = makeWriteMocks();
-    mockWriteClient.from.mockImplementation(write.from);
     const noLevelUpAch = { ...QUEST_ACH, xp_reward: 10 };
+    const write = makeWriteMocks({
+      unlockedIds: [noLevelUpAch.id],
+      rpcReturn: { xp: 10, gold: 0, level: 1 },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
 
     const readClient = makeReadClient({
       characters: makeCharChain({

--- a/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
@@ -1,0 +1,149 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeCharAchChain,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+const QUEST_ACH = {
+  id: "ach-quest",
+  name: "Quest Master",
+  criteria_type: "quest_complete",
+  criteria_config: { threshold: 5 },
+  xp_reward: 60, // triggers level-up from level 1 with 40 XP
+  gold_reward: 0,
+};
+const LEVEL_ACH = {
+  id: "ach-level",
+  name: "Ascending",
+  criteria_type: "level_reached",
+  criteria_config: { threshold: 2 },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+
+function makeQuestChain(count: number): MockChain {
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        or: jest.fn().mockResolvedValue({ count, error: null }),
+      }),
+    }),
+  };
+}
+
+function makeCharChain(secondCallStats: {
+  xp: number;
+  gold: number;
+  level: number;
+}) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      return {
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data:
+              n === 1
+                ? { user_id: USER_ID, user_profiles: null }
+                : secondCallStats,
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+describe("AchievementProgressService - level-up cascade (7.3)", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("7.3 cascades to unlock level_reached achievement after XP-triggered level-up", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: QUEST_ACH.id },
+                { achievement_id: LEVEL_ACH.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        const id = charAchN === 2 ? QUEST_ACH.id : LEVEL_ACH.id;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 40,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        QUEST_ACH,
+        LEVEL_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Unlock called twice: quest_complete then level cascade
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("7.3 no cascade when XP reward does not trigger level-up", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const noLevelUpAch = { ...QUEST_ACH, xp_reward: 10 };
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 0,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        noLevelUpAch,
+        LEVEL_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(noLevelUpAch.id, null),
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
@@ -1,0 +1,287 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeCharAchChain,
+  makeUnlockReadClient,
+  DEFAULT_ACHIEVEMENT,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("5.5 sets unlocked_at when criteria newly met and unlocked_at is null", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.charAchUpdate).toHaveBeenCalled();
+  });
+
+  it("5.5 skips unlock when achievement already has unlocked_at set", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const readClient = makeUnlockReadClient({
+      questCount: 10,
+      unlockedAt: "2026-01-01T00:00:00Z",
+      achievement: { xp_reward: 50, gold_reward: 25 },
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+  });
+
+  it("5.5 skips unlock when progress is below threshold", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const readClient = makeUnlockReadClient({
+      questCount: 3,
+      unlockedAt: null,
+      achievement: {
+        criteria_config: { threshold: 10 },
+        xp_reward: 50,
+        gold_reward: 25,
+      },
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+  });
+
+  it("5.5 unlocks compound achievement when top-level met flag is true", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const charChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: {
+              user_id: USER_ID,
+              user_profiles: null,
+              xp: 0,
+              level: 3,
+              honor_points: 0,
+            },
+            error: null,
+          }),
+        }),
+      }),
+    };
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achId = "ach-compound";
+    const achievementsChain = makeDataResult([
+      {
+        id: achId,
+        name: "All Rounder",
+        criteria_type: "compound",
+        criteria_config: {
+          evaluation_strategy: "compound",
+          operator: "AND",
+          conditions: [
+            { criteria_type: "quest_complete", threshold: 3 },
+            { criteria_type: "level_reached", threshold: 2 },
+          ],
+        },
+        xp_reward: 0,
+        gold_reward: 0,
+      },
+    ]);
+    // Empty first call triggers backfill (ALL_CRITERIA_TYPES including "compound")
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return { eq: jest.fn().mockResolvedValue({ data: [], error: null }) };
+        }
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: achId, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: achievementsChain as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.charAchUpdate).toHaveBeenCalled();
+  });
+
+  it("5.6 IS NULL filter is applied on unlock update for concurrency safety", async () => {
+    const isNull = jest.fn().mockResolvedValue({ error: null });
+    const inFn = jest.fn().mockReturnValue({ is: isNull });
+    const eqFn = jest.fn().mockReturnValue({ in: inFn });
+    const charAchUpdate = jest.fn().mockReturnValue({ eq: eqFn });
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    mockWriteClient.from.mockImplementation((t: string) => {
+      if (t === "character_achievements")
+        return { upsert, update: charAchUpdate };
+      return { upsert };
+    });
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: { xp_reward: 0, gold_reward: 0 },
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(isNull).toHaveBeenCalledWith("unlocked_at", null);
+  });
+});
+
+describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  function setupRewardTest(charStats: {
+    xp: number;
+    gold: number;
+    level: number;
+  }) {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    let charCallCount = 0;
+    const charChain = {
+      select: jest.fn().mockImplementation(() => {
+        charCallCount++;
+        return {
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data:
+                charCallCount === 1
+                  ? { user_id: USER_ID, user_profiles: null }
+                  : charStats,
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+    return { write, charChain };
+  }
+
+  it("6.6 increments character xp and gold on single unlock", async () => {
+    const { write, charChain } = setupRewardTest({
+      xp: 100,
+      gold: 50,
+      level: 1,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([
+        DEFAULT_ACHIEVEMENT,
+      ]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.statsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ xp: 150, gold: 75 }),
+    );
+  });
+
+  it("6.6 skips character stats update when total rewards are zero", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: { xp_reward: 0, gold_reward: 0 },
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.7 includes level in update when XP reward triggers level-up", async () => {
+    // Level 1 with 40 XP + 60 XP = 100 >= 50*(2-1)^2=50 → level 2
+    const { write, charChain } = setupRewardTest({ xp: 40, gold: 0, level: 1 });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achievement = {
+      ...DEFAULT_ACHIEVEMENT,
+      xp_reward: 60,
+      gold_reward: 0,
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([achievement]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(achievement.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.statsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ xp: 100, level: 2 }),
+    );
+  });
+
+  it("6.7 does not include level when XP reward does not trigger level-up", async () => {
+    // Level 1 with 0 XP + 10 XP = 10 < 50 → stays level 1
+    const { write, charChain } = setupRewardTest({ xp: 0, gold: 0, level: 1 });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achievement = {
+      ...DEFAULT_ACHIEVEMENT,
+      xp_reward: 10,
+      gold_reward: 0,
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([achievement]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(achievement.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    const updateArg = write.statsUpdate.mock.calls[0]?.[0];
+    expect(updateArg).toBeDefined();
+    expect(updateArg).not.toHaveProperty("level");
+  });
+});

--- a/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
@@ -13,7 +13,7 @@ import {
   USER_ID,
 } from "./unlock-evaluation-fixtures";
 
-const mockWriteClient = { from: jest.fn() };
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
@@ -24,6 +24,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
   it("5.5 sets unlocked_at when criteria newly met and unlocked_at is null", async () => {
     const write = makeWriteMocks();
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
     const readClient = makeUnlockReadClient({
       questCount: 5,
       unlockedAt: null,
@@ -36,6 +37,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
   it("5.5 skips unlock when achievement already has unlocked_at set", async () => {
     const write = makeWriteMocks();
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
     const readClient = makeUnlockReadClient({
       questCount: 10,
       unlockedAt: "2026-01-01T00:00:00Z",
@@ -49,6 +51,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
   it("5.5 skips unlock when progress is below threshold", async () => {
     const write = makeWriteMocks();
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
     const readClient = makeUnlockReadClient({
       questCount: 3,
       unlockedAt: null,
@@ -64,8 +67,10 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
   });
 
   it("5.5 unlocks compound achievement when top-level met flag is true", async () => {
-    const write = makeWriteMocks();
+    const achId = "ach-compound";
+    const write = makeWriteMocks({ unlockedIds: [achId] });
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
     const charChain = {
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -89,7 +94,6 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
         }),
       }),
     };
-    const achId = "ach-compound";
     const achievementsChain = makeDataResult([
       {
         id: achId,
@@ -137,7 +141,10 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
   });
 
   it("5.6 IS NULL filter is applied on unlock update for concurrency safety", async () => {
-    const isNull = jest.fn().mockResolvedValue({ error: null });
+    const selectAfterIs = jest
+      .fn()
+      .mockResolvedValue({ data: [], error: null });
+    const isNull = jest.fn().mockReturnValue({ select: selectAfterIs });
     const inFn = jest.fn().mockReturnValue({ is: isNull });
     const eqFn = jest.fn().mockReturnValue({ in: inFn });
     const charAchUpdate = jest.fn().mockReturnValue({ eq: eqFn });
@@ -146,6 +153,9 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
       if (t === "character_achievements")
         return { upsert, update: charAchUpdate };
       return { upsert };
+    });
+    mockWriteClient.rpc.mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
     });
     const readClient = makeUnlockReadClient({
       questCount: 5,
@@ -161,38 +171,33 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
 describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
   afterEach(() => jest.clearAllMocks());
 
-  function setupRewardTest(charStats: {
+  function setupRewardTest(rpcReturn: {
     xp: number;
     gold: number;
     level: number;
   }) {
-    const write = makeWriteMocks();
+    const write = makeWriteMocks({ rpcReturn });
     mockWriteClient.from.mockImplementation(write.from);
-    let charCallCount = 0;
+    mockWriteClient.rpc.mockImplementation(write.rpc);
     const charChain = {
-      select: jest.fn().mockImplementation(() => {
-        charCallCount++;
-        return {
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data:
-                charCallCount === 1
-                  ? { user_id: USER_ID, user_profiles: null }
-                  : charStats,
-              error: null,
-            }),
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_id: USER_ID, user_profiles: null },
+            error: null,
           }),
-        };
+        }),
       }),
     };
     return { write, charChain };
   }
 
   it("6.6 increments character xp and gold on single unlock", async () => {
+    // prevXp=100, award (50,25); already level 2 (needs 200 for L3) → new xp=150, no level-up
     const { write, charChain } = setupRewardTest({
-      xp: 100,
-      gold: 50,
-      level: 1,
+      xp: 150,
+      gold: 75,
+      level: 2,
     });
     const questChain: MockChain = {
       select: jest.fn().mockReturnValue({
@@ -211,9 +216,11 @@ describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.statsUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ xp: 150, gold: 75 }),
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_increment_character_stats",
+      { p_character_id: CHAR_ID, p_xp: 50, p_gold: 25 },
     );
+    expect(write.statsUpdate).not.toHaveBeenCalled();
   });
 
   it("6.6 skips character stats update when total rewards are zero", async () => {
@@ -230,8 +237,13 @@ describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
   });
 
   it("6.7 includes level in update when XP reward triggers level-up", async () => {
-    // Level 1 with 40 XP + 60 XP = 100 >= 50*(2-1)^2=50 → level 2
-    const { write, charChain } = setupRewardTest({ xp: 40, gold: 0, level: 1 });
+    // prevXp=40, award xp=60 → new xp=100; 100 >= 50*(2-1)^2=50 → level 2
+    // RPC returns new totals with level still at 1 (level update is separate)
+    const { write, charChain } = setupRewardTest({
+      xp: 100,
+      gold: 0,
+      level: 1,
+    });
     const questChain: MockChain = {
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -252,14 +264,16 @@ describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.statsUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ xp: 100, level: 2 }),
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_increment_character_stats",
+      { p_character_id: CHAR_ID, p_xp: 60, p_gold: 0 },
     );
+    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 2 });
   });
 
-  it("6.7 does not include level when XP reward does not trigger level-up", async () => {
-    // Level 1 with 0 XP + 10 XP = 10 < 50 → stays level 1
-    const { write, charChain } = setupRewardTest({ xp: 0, gold: 0, level: 1 });
+  it("6.7 does not update level when XP reward does not trigger level-up", async () => {
+    // prevXp=0, award xp=10 → new xp=10 < 50; stays level 1 → no level update
+    const { write, charChain } = setupRewardTest({ xp: 10, gold: 0, level: 1 });
     const questChain: MockChain = {
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -280,8 +294,7 @@ describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    const updateArg = write.statsUpdate.mock.calls[0]?.[0];
-    expect(updateArg).toBeDefined();
-    expect(updateArg).not.toHaveProperty("level");
+    expect(mockWriteClient.rpc).toHaveBeenCalled();
+    expect(write.statsUpdate).not.toHaveBeenCalled();
   });
 });

--- a/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
@@ -1,0 +1,215 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeCharAchChain,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+const BASE_ACH = {
+  id: "ach-quest",
+  name: "Quest Master",
+  criteria_type: "quest_complete",
+  criteria_config: { threshold: 5 },
+  xp_reward: 50,
+  gold_reward: 25,
+};
+
+function makeQuestChain(count: number): MockChain {
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        or: jest.fn().mockResolvedValue({ count, error: null }),
+      }),
+    }),
+  };
+}
+
+function makeCharChain(secondCallStats?: {
+  xp: number;
+  gold: number;
+  level: number;
+}) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      return {
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data:
+              n === 1 || !secondCallStats
+                ? { user_id: USER_ID, user_profiles: null }
+                : secondCallStats,
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1, 9.2)", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  // 8.4 complete flow
+  it("8.4 upserts progress, sets unlocked_at, and grants rewards in one call", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 0,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([BASE_ACH]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(BASE_ACH.id, null),
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.upsert).toHaveBeenCalled();
+    expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(write.statsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ xp: 50, gold: 25 }),
+    );
+  });
+
+  // 8.5 non-blocking unlock failure
+  it("8.5 unlock evaluation failure is logged and does not cause updateProgress to throw", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    const failUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        in: jest.fn().mockReturnValue({
+          is: jest.fn().mockResolvedValue({ error: { message: "DB failure" } }),
+        }),
+      }),
+    });
+    mockWriteClient.from.mockImplementation((t: string) => {
+      if (t === "character_achievements") return { upsert, update: failUpdate };
+      return { upsert };
+    });
+
+    const readClient = makeReadClient({
+      characters: makeDataResult({ user_id: USER_ID }) as unknown as MockChain,
+      achievements: makeDataResult([BASE_ACH]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(BASE_ACH.id, null),
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await expect(
+      svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" }),
+    ).resolves.not.toThrow();
+
+    expect(upsert).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unlock evaluation failed"),
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+
+  // 9.1 idempotency: duplicate calls
+  it("9.1 duplicate updateProgress produces no additional unlocks or rewards", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+
+    let charN = 0;
+    const charChain = {
+      select: jest.fn().mockImplementation(() => {
+        charN++;
+        return {
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data:
+                charN === 1 || charN === 3
+                  ? { user_id: USER_ID, user_profiles: null }
+                  : { xp: 0, gold: 0, level: 1 },
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1 || charAchN === 3) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: BASE_ACH.id }],
+              error: null,
+            }),
+          };
+        }
+        const alreadyUnlocked = charAchN > 2;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [
+                {
+                  achievement_id: BASE_ACH.id,
+                  unlocked_at: alreadyUnlocked ? "2026-01-01T00:00:00Z" : null,
+                },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([BASE_ACH]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    expect(write.statsUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  // 9.2 already-unlocked is no-op
+  it("9.2 re-evaluation of already-unlocked achievement is a no-op", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+
+    const readClient = makeReadClient({
+      characters: makeDataResult({ user_id: USER_ID }) as unknown as MockChain,
+      achievements: makeDataResult([BASE_ACH]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(
+        BASE_ACH.id,
+        "2026-01-01T00:00:00Z",
+      ),
+      quest_instances: makeQuestChain(10),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
@@ -11,7 +11,7 @@ import {
   USER_ID,
 } from "./unlock-evaluation-fixtures";
 
-const mockWriteClient = { from: jest.fn() };
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
@@ -35,26 +35,15 @@ function makeQuestChain(count: number): MockChain {
   };
 }
 
-function makeCharChain(secondCallStats?: {
-  xp: number;
-  gold: number;
-  level: number;
-}) {
-  let n = 0;
+function makeCharChain() {
   return {
-    select: jest.fn().mockImplementation(() => {
-      n++;
-      return {
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data:
-              n === 1 || !secondCallStats
-                ? { user_id: USER_ID, user_profiles: null }
-                : secondCallStats,
-            error: null,
-          }),
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { user_id: USER_ID, user_profiles: null },
+          error: null,
         }),
-      };
+      }),
     }),
   };
 }
@@ -64,15 +53,15 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
 
   // 8.4 complete flow
   it("8.4 upserts progress, sets unlocked_at, and grants rewards in one call", async () => {
-    const write = makeWriteMocks();
+    const write = makeWriteMocks({
+      unlockedIds: [BASE_ACH.id],
+      rpcReturn: { xp: 50, gold: 25, level: 1 },
+    });
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
 
     const readClient = makeReadClient({
-      characters: makeCharChain({
-        xp: 0,
-        gold: 0,
-        level: 1,
-      }) as unknown as MockChain,
+      characters: makeCharChain() as unknown as MockChain,
       achievements: makeDataResult([BASE_ACH]) as unknown as MockChain,
       character_achievements: makeCharAchChain(BASE_ACH.id, null),
       quest_instances: makeQuestChain(5),
@@ -83,8 +72,9 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
 
     expect(write.upsert).toHaveBeenCalled();
     expect(write.charAchUpdate).toHaveBeenCalled();
-    expect(write.statsUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ xp: 50, gold: 25 }),
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_increment_character_stats",
+      { p_character_id: CHAR_ID, p_xp: 50, p_gold: 25 },
     );
   });
 
@@ -95,7 +85,12 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     const failUpdate = jest.fn().mockReturnValue({
       eq: jest.fn().mockReturnValue({
         in: jest.fn().mockReturnValue({
-          is: jest.fn().mockResolvedValue({ error: { message: "DB failure" } }),
+          is: jest.fn().mockReturnValue({
+            select: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: "DB failure" },
+            }),
+          }),
         }),
       }),
     });
@@ -126,26 +121,13 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
 
   // 9.1 idempotency: duplicate calls
   it("9.1 duplicate updateProgress produces no additional unlocks or rewards", async () => {
-    const write = makeWriteMocks();
+    // BASE_ACH: xp_reward=50; prevXp=0+50=50 >= 50*(2-1)^2=50 → level 2 on first call
+    const write = makeWriteMocks({
+      unlockedIds: [BASE_ACH.id],
+      rpcReturn: { xp: 50, gold: 25, level: 1 },
+    });
     mockWriteClient.from.mockImplementation(write.from);
-
-    let charN = 0;
-    const charChain = {
-      select: jest.fn().mockImplementation(() => {
-        charN++;
-        return {
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data:
-                charN === 1 || charN === 3
-                  ? { user_id: USER_ID, user_profiles: null }
-                  : { xp: 0, gold: 0, level: 1 },
-              error: null,
-            }),
-          }),
-        };
-      }),
-    };
+    mockWriteClient.rpc.mockImplementation(write.rpc);
 
     let charAchN = 0;
     const charAchChain = {
@@ -177,7 +159,7 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     };
 
     const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
+      characters: makeCharChain() as unknown as MockChain,
       achievements: makeDataResult([BASE_ACH]) as unknown as MockChain,
       character_achievements: charAchChain,
       quest_instances: makeQuestChain(5),
@@ -187,6 +169,8 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
+    // First call: unlocks achievement (charAchUpdate once) and updates level (statsUpdate once)
+    // Second call: already locked → no update
     expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
     expect(write.statsUpdate).toHaveBeenCalledTimes(1);
   });
@@ -195,6 +179,7 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
   it("9.2 re-evaluation of already-unlocked achievement is a no-op", async () => {
     const write = makeWriteMocks();
     mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
 
     const readClient = makeReadClient({
       characters: makeDataResult({ user_id: USER_ID }) as unknown as MockChain,

--- a/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
@@ -1,0 +1,292 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeCharAchChain,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+const QUEST_ACH = {
+  id: "ach-quest",
+  name: "Quest Master",
+  criteria_type: "quest_complete",
+  criteria_config: { threshold: 5 },
+  xp_reward: 60,
+  gold_reward: 0,
+};
+const LEVEL_ACH = {
+  id: "ach-level",
+  name: "Ascending",
+  criteria_type: "level_reached",
+  criteria_config: { threshold: 2 },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+const XP_COMPOUND_ACH = {
+  id: "ach-xp-compound",
+  name: "XP Collector",
+  criteria_type: "compound",
+  criteria_config: {
+    operator: "AND",
+    evaluation_strategy: "compound",
+    conditions: [{ criteria_type: "xp_earned", threshold: 10 }],
+  },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+const DEDUP_COMPOUND_ACH = {
+  id: "ach-dedup-compound",
+  name: "XP and Level",
+  criteria_type: "compound",
+  criteria_config: {
+    operator: "AND",
+    evaluation_strategy: "compound",
+    conditions: [
+      { criteria_type: "xp_earned", threshold: 100 },
+      { criteria_type: "level_reached", threshold: 2 },
+    ],
+  },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+
+function makeQuestChain(count: number): MockChain {
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        or: jest.fn().mockResolvedValue({ count, error: null }),
+      }),
+    }),
+  };
+}
+
+/** Two-state char chain: n=1 → user context, n>=2 → stats. */
+function makeCharChain(stats: { xp: number; gold: number; level: number }) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      return {
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: n === 1 ? { user_id: USER_ID, user_profiles: null } : stats,
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+describe("AchievementProgressService - P1/P2 cascade fixes", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("[P2] cascades to unlock compound achievement with xp_earned sub-condition after XP reward (no level-up)", async () => {
+    // xp_reward: 10 — no level-up. Compound with xp_earned >= 10 is NOT met at
+    // initial eval (xp=0) but IS met after XP reward (xp=10).
+    const XP_QUEST = { ...QUEST_ACH, id: "ach-xp-quest", xp_reward: 10 };
+    const write = makeWriteMocks({
+      unlockedIds: [XP_QUEST.id],
+      rpcReturn: { xp: 10, gold: 0, level: 1 },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: XP_QUEST.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: XP_COMPOUND_ACH.id }],
+        error: null,
+      });
+
+    // n=1 → context, n=2 → initial xp_earned eval (xp=0, not met),
+    // n=3 → cascade xp_earned eval (xp=10, met).
+    let charN = 0;
+    const charChain = {
+      select: jest.fn().mockImplementation(() => {
+        charN++;
+        return {
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data:
+                charN === 1
+                  ? { user_id: USER_ID, user_profiles: null }
+                  : charN === 2
+                    ? { xp: 0, gold: 0, level: 1 }
+                    : { xp: 10, gold: 0, level: 1 },
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: XP_QUEST.id },
+                { achievement_id: XP_COMPOUND_ACH.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        const id = charAchN === 2 ? XP_QUEST.id : XP_COMPOUND_ACH.id;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([
+        XP_QUEST,
+        XP_COMPOUND_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("[P1] does not cascade level_reached achievement when concurrent write loses level race", async () => {
+    // levelSelectRows: [] → no rows updated → levelApplied=false → no cascade.
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST_ACH.id],
+      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      levelSelectRows: [],
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    write.selectAfterIs.mockResolvedValueOnce({
+      data: [{ achievement_id: QUEST_ACH.id }],
+      error: null,
+    });
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 40,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        QUEST_ACH,
+        LEVEL_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(QUEST_ACH.id, null),
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Only one unlock: QUEST_ACH. No cascade for LEVEL_ACH since race was lost.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    // Verify the .lt().select() chain was invoked (level update attempted)
+    expect(write.statsSelect).toHaveBeenCalledTimes(1);
+    // statsSelect resolved with empty data → levelApplied=false
+    await expect(
+      write.statsSelect.mock.results[0].value,
+    ).resolves.toMatchObject({ data: [] });
+  });
+
+  it("[P2] evaluates compound achievement with both xp_earned and level_reached exactly once on XP+level-up", async () => {
+    // DEDUP_COMPOUND_ACH has both sub-condition types. The Set-based dedup
+    // must ensure the compound evaluator runs exactly once even though both
+    // xp and level-up triggers fire.
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST_ACH.id],
+      rpcReturn: { xp: 100, gold: 0, level: 1 },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: QUEST_ACH.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: DEDUP_COMPOUND_ACH.id }],
+        error: null,
+      });
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: QUEST_ACH.id },
+                { achievement_id: DEDUP_COMPOUND_ACH.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        const id = charAchN === 2 ? QUEST_ACH.id : DEDUP_COMPOUND_ACH.id;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 100,
+        gold: 0,
+        level: 2,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        QUEST_ACH,
+        DEDUP_COMPOUND_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Cascade upsert (write.upsert call 2) must contain exactly one row.
+    expect(write.upsert).toHaveBeenCalledTimes(2);
+    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{
+      achievement_id: string;
+    }>;
+    expect(cascadeRows).toHaveLength(1);
+    expect(cascadeRows[0].achievement_id).toBe(DEDUP_COMPOUND_ACH.id);
+  });
+});

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -26,10 +26,26 @@ export const DEFAULT_ACHIEVEMENT: UnlockTestAchievement = {
   gold_reward: 25,
 };
 
+export type WriteMocksOptions = {
+  /** Achievement IDs to return as actually-unlocked from the IS NULL update. */
+  unlockedIds?: string[];
+  /** Stats the RPC mock should return after the atomic increment. */
+  rpcReturn?: { xp: number; gold: number; level: number };
+};
+
 /** Build mock write client mocks for unlock evaluation tests */
-export function makeWriteMocks() {
+export function makeWriteMocks(options?: WriteMocksOptions) {
+  const {
+    unlockedIds = [DEFAULT_ACHIEVEMENT.id],
+    rpcReturn = { xp: 150, gold: 75, level: 1 },
+  } = options ?? {};
+
   const upsert = jest.fn().mockResolvedValue({ error: null });
-  const isNull = jest.fn().mockResolvedValue({ error: null });
+  const selectAfterIs = jest.fn().mockResolvedValue({
+    data: unlockedIds.map((id) => ({ achievement_id: id })),
+    error: null,
+  });
+  const isNull = jest.fn().mockReturnValue({ select: selectAfterIs });
   const inFn = jest.fn().mockReturnValue({ is: isNull });
   const eqUpdate = jest.fn().mockReturnValue({ in: inFn });
   const charAchUpdate = jest.fn().mockReturnValue({ eq: eqUpdate });
@@ -41,7 +57,20 @@ export function makeWriteMocks() {
     if (table === "characters") return { update: statsUpdate };
     return { upsert };
   });
-  return { upsert, isNull, inFn, charAchUpdate, statsUpdate, from };
+  const rpcSingle = jest
+    .fn()
+    .mockResolvedValue({ data: rpcReturn, error: null });
+  const rpc = jest.fn().mockReturnValue({ single: rpcSingle });
+  return {
+    upsert,
+    selectAfterIs,
+    isNull,
+    inFn,
+    charAchUpdate,
+    statsUpdate,
+    from,
+    rpc,
+  };
 }
 
 /** Build charAchChain that returns unlocked_at state on second call */

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -45,6 +45,8 @@ export type WriteMocksOptions = {
   rpcCompensationError?: string;
   /** If set, the unlocked_at revert update resolves with this error message. */
   revertUnlockError?: string;
+  /** If set, the cascade progress revert update resolves with this error. */
+  cascadeProgressRevertError?: string;
 };
 
 /** Build mock write client mocks for unlock evaluation tests */
@@ -57,6 +59,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     cascadeUpsertError,
     rpcCompensationError,
     revertUnlockError,
+    cascadeProgressRevertError,
   } = options ?? {};
 
   // Upsert: first call = initial progress upsert (always succeeds), subsequent = cascade
@@ -84,9 +87,21 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
   });
   const eqForRevert = jest.fn().mockReturnValue({ in: inForRevert });
 
-  // charAchUpdate routes by payload: unlocked_at=null means revert, otherwise lock
+  // Cascade progress revert chain: .update({progress:null}).eq().in()
+  const inForCascadeRevert = jest.fn().mockResolvedValue({
+    error: cascadeProgressRevertError
+      ? { message: cascadeProgressRevertError }
+      : null,
+  });
+  const eqForCascadeRevert = jest.fn().mockReturnValue({
+    in: inForCascadeRevert,
+  });
+
+  // charAchUpdate routes by payload
   const charAchUpdate = jest.fn().mockImplementation((payload: unknown) => {
     const p = payload as Record<string, unknown>;
+    if ("progress" in p && p.progress === null)
+      return { eq: eqForCascadeRevert };
     return "unlocked_at" in p && p.unlocked_at === null
       ? { eq: eqForRevert }
       : { eq: eqForLock };
@@ -137,6 +152,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     isNull,
     inForLock,
     inForRevert,
+    inForCascadeRevert,
     charAchUpdate,
     statsUpdate,
     statsEq,

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -33,6 +33,12 @@ export type WriteMocksOptions = {
   rpcReturn?: { xp: number; gold: number; level: number };
   /** If set, the characters level update resolves with this error message. */
   levelUpdateError?: string;
+  /**
+   * Rows returned from the level UPDATE ... RETURNING select.
+   * Defaults to [{ level: 2 }] (update applied). Pass [] to simulate a
+   * concurrent race where this caller's write was a no-op (levelApplied=false).
+   */
+  levelSelectRows?: Array<{ level: number }>;
   /** If set, the second (cascade) upsert resolves with this error message. */
   cascadeUpsertError?: string;
   /** If set, the second RPC call (stats compensation) resolves with this error. */
@@ -47,6 +53,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     unlockedIds = [DEFAULT_ACHIEVEMENT.id],
     rpcReturn = { xp: 150, gold: 75, level: 1 },
     levelUpdateError,
+    levelSelectRows,
     cascadeUpsertError,
     rpcCompensationError,
     revertUnlockError,
@@ -85,8 +92,22 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
       : { eq: eqForLock };
   });
 
-  const statsEq = jest.fn().mockResolvedValue({
+  // Forward path: .update().eq().lt().select() — resolves to { data, error }
+  // Revert path:  .update().eq()              — awaited directly to { error }
+  // Both call statsUpdate then statsEq; differentiate by call count.
+  const statsSelectData = levelUpdateError
+    ? null
+    : (levelSelectRows ?? [{ level: 2 }]);
+  const statsSelect = jest.fn().mockResolvedValue({
+    data: statsSelectData,
     error: levelUpdateError ? { message: levelUpdateError } : null,
+  });
+  const statsLt = jest.fn().mockReturnValue({ select: statsSelect });
+  let statsEqCallCount = 0;
+  const statsEq = jest.fn().mockImplementation(() => {
+    statsEqCallCount++;
+    if (statsEqCallCount === 1) return { lt: statsLt }; // forward path
+    return Promise.resolve({ error: null }); // revert path
   });
   const statsUpdate = jest.fn().mockReturnValue({ eq: statsEq });
 
@@ -119,6 +140,8 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     charAchUpdate,
     statsUpdate,
     statsEq,
+    statsLt,
+    statsSelect,
     from,
     rpc,
     rpcSingle,

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -31,6 +31,14 @@ export type WriteMocksOptions = {
   unlockedIds?: string[];
   /** Stats the RPC mock should return after the atomic increment. */
   rpcReturn?: { xp: number; gold: number; level: number };
+  /** If set, the characters level update resolves with this error message. */
+  levelUpdateError?: string;
+  /** If set, the second (cascade) upsert resolves with this error message. */
+  cascadeUpsertError?: string;
+  /** If set, the second RPC call (stats compensation) resolves with this error. */
+  rpcCompensationError?: string;
+  /** If set, the unlocked_at revert update resolves with this error message. */
+  revertUnlockError?: string;
 };
 
 /** Build mock write client mocks for unlock evaluation tests */
@@ -38,38 +46,82 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
   const {
     unlockedIds = [DEFAULT_ACHIEVEMENT.id],
     rpcReturn = { xp: 150, gold: 75, level: 1 },
+    levelUpdateError,
+    cascadeUpsertError,
+    rpcCompensationError,
+    revertUnlockError,
   } = options ?? {};
 
-  const upsert = jest.fn().mockResolvedValue({ error: null });
+  // Upsert: first call = initial progress upsert (always succeeds), subsequent = cascade
+  let upsertCallCount = 0;
+  const upsert = jest.fn().mockImplementation(() => {
+    upsertCallCount++;
+    if (upsertCallCount === 1) return Promise.resolve({ error: null });
+    return Promise.resolve({
+      error: cascadeUpsertError ? { message: cascadeUpsertError } : null,
+    });
+  });
+
+  // Lock chain: .update().eq().in().is().select() → data
   const selectAfterIs = jest.fn().mockResolvedValue({
     data: unlockedIds.map((id) => ({ achievement_id: id })),
     error: null,
   });
   const isNull = jest.fn().mockReturnValue({ select: selectAfterIs });
-  const inFn = jest.fn().mockReturnValue({ is: isNull });
-  const eqUpdate = jest.fn().mockReturnValue({ in: inFn });
-  const charAchUpdate = jest.fn().mockReturnValue({ eq: eqUpdate });
-  const statsEq = jest.fn().mockResolvedValue({ error: null });
+  const inForLock = jest.fn().mockReturnValue({ is: isNull });
+  const eqForLock = jest.fn().mockReturnValue({ in: inForLock });
+
+  // Revert chain: .update().eq().in() → awaited directly
+  const inForRevert = jest.fn().mockResolvedValue({
+    error: revertUnlockError ? { message: revertUnlockError } : null,
+  });
+  const eqForRevert = jest.fn().mockReturnValue({ in: inForRevert });
+
+  // charAchUpdate routes by payload: unlocked_at=null means revert, otherwise lock
+  const charAchUpdate = jest.fn().mockImplementation((payload: unknown) => {
+    const p = payload as Record<string, unknown>;
+    return "unlocked_at" in p && p.unlocked_at === null
+      ? { eq: eqForRevert }
+      : { eq: eqForLock };
+  });
+
+  const statsEq = jest.fn().mockResolvedValue({
+    error: levelUpdateError ? { message: levelUpdateError } : null,
+  });
   const statsUpdate = jest.fn().mockReturnValue({ eq: statsEq });
+
   const from = jest.fn((table: string) => {
     if (table === "character_achievements")
       return { upsert, update: charAchUpdate };
     if (table === "characters") return { update: statsUpdate };
     return { upsert };
   });
-  const rpcSingle = jest
-    .fn()
-    .mockResolvedValue({ data: rpcReturn, error: null });
+
+  // RPC: first call = stats increment, second = compensation (reverse)
+  let rpcSingleCallCount = 0;
+  const rpcSingle = jest.fn().mockImplementation(() => {
+    rpcSingleCallCount++;
+    if (rpcSingleCallCount === 1)
+      return Promise.resolve({ data: rpcReturn, error: null });
+    return Promise.resolve({
+      data: null,
+      error: rpcCompensationError ? { message: rpcCompensationError } : null,
+    });
+  });
   const rpc = jest.fn().mockReturnValue({ single: rpcSingle });
+
   return {
     upsert,
     selectAfterIs,
     isNull,
-    inFn,
+    inForLock,
+    inForRevert,
     charAchUpdate,
     statsUpdate,
+    statsEq,
     from,
     rpc,
+    rpcSingle,
   };
 }
 

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -41,11 +41,14 @@ export type WriteMocksOptions = {
   levelSelectRows?: Array<{ level: number }>;
   /** If set, the second (cascade) upsert resolves with this error message. */
   cascadeUpsertError?: string;
-  /** If set, the second RPC call (stats compensation) resolves with this error. */
-  rpcCompensationError?: string;
+  /**
+   * If set, the stats rollback UPDATE resolves with this error message.
+   * (Replaces the old rpcCompensationError now that rollback uses a direct SET.)
+   */
+  statsRevertError?: string;
   /** If set, the unlocked_at revert update resolves with this error message. */
   revertUnlockError?: string;
-  /** If set, the cascade progress revert update resolves with this error. */
+  /** If set, the cascade progress revert upsert resolves with this error. */
   cascadeProgressRevertError?: string;
 };
 
@@ -57,18 +60,25 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     levelUpdateError,
     levelSelectRows,
     cascadeUpsertError,
-    rpcCompensationError,
+    statsRevertError,
     revertUnlockError,
     cascadeProgressRevertError,
   } = options ?? {};
 
-  // Upsert: first call = initial progress upsert (always succeeds), subsequent = cascade
+  // Upsert: call 1 = initial progress, call 2 = cascade, call 3+ = cascade revert
   let upsertCallCount = 0;
   const upsert = jest.fn().mockImplementation(() => {
     upsertCallCount++;
     if (upsertCallCount === 1) return Promise.resolve({ error: null });
+    if (upsertCallCount === 2)
+      return Promise.resolve({
+        error: cascadeUpsertError ? { message: cascadeUpsertError } : null,
+      });
+    // call 3+ = cascade revert upsert (Fix P2)
     return Promise.resolve({
-      error: cascadeUpsertError ? { message: cascadeUpsertError } : null,
+      error: cascadeProgressRevertError
+        ? { message: cascadeProgressRevertError }
+        : null,
     });
   });
 
@@ -87,29 +97,18 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
   });
   const eqForRevert = jest.fn().mockReturnValue({ in: inForRevert });
 
-  // Cascade progress revert chain: .update({progress:null}).eq().in()
-  const inForCascadeRevert = jest.fn().mockResolvedValue({
-    error: cascadeProgressRevertError
-      ? { message: cascadeProgressRevertError }
-      : null,
-  });
-  const eqForCascadeRevert = jest.fn().mockReturnValue({
-    in: inForCascadeRevert,
-  });
-
-  // charAchUpdate routes by payload
+  // charAchUpdate routes by payload — cascade revert now goes through upsert
   const charAchUpdate = jest.fn().mockImplementation((payload: unknown) => {
     const p = payload as Record<string, unknown>;
-    if ("progress" in p && p.progress === null)
-      return { eq: eqForCascadeRevert };
     return "unlocked_at" in p && p.unlocked_at === null
       ? { eq: eqForRevert }
       : { eq: eqForLock };
   });
 
-  // Forward path: .update().eq().lt().select() — resolves to { data, error }
-  // Revert path:  .update().eq()              — awaited directly to { error }
-  // Both call statsUpdate then statsEq; differentiate by call count.
+  // characters.update paths:
+  //   Forward level:  .update({level}).eq("id").lt().select() → { data, error }
+  //   Level rollback: .update({level}).eq("id").eq("level")   → { error }  (Fix P1)
+  //   Stats rollback: .update({xp,gold}).eq("id").eq("xp").eq("gold") → { error }  (Fix P1)
   const statsSelectData = levelUpdateError
     ? null
     : (levelSelectRows ?? [{ level: 2 }]);
@@ -118,13 +117,32 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     error: levelUpdateError ? { message: levelUpdateError } : null,
   });
   const statsLt = jest.fn().mockReturnValue({ select: statsSelect });
-  let statsEqCallCount = 0;
-  const statsEq = jest.fn().mockImplementation(() => {
-    statsEqCallCount++;
-    if (statsEqCallCount === 1) return { lt: statsLt }; // forward path
-    return Promise.resolve({ error: null }); // revert path
+  const levelForwardEq = jest.fn().mockReturnValue({ lt: statsLt });
+
+  // Level rollback chain (Fix P1): .eq("id").eq("level") → await
+  const levelRevertEq2 = jest.fn().mockResolvedValue({ error: null });
+  const levelRevertEq1 = jest.fn().mockReturnValue({ eq: levelRevertEq2 });
+
+  // Stats rollback chain (Fix P1): .eq("id").eq("xp").eq("gold") → await
+  const statsRevertEq3 = jest.fn().mockResolvedValue({
+    error: statsRevertError ? { message: statsRevertError } : null,
   });
-  const statsUpdate = jest.fn().mockReturnValue({ eq: statsEq });
+  const statsRevertEq2 = jest.fn().mockReturnValue({ eq: statsRevertEq3 });
+  const statsRevertEq1 = jest.fn().mockReturnValue({ eq: statsRevertEq2 });
+
+  let levelUpdateCallCount = 0;
+  const statsUpdate = jest.fn().mockImplementation((payload: unknown) => {
+    const p = payload as Record<string, unknown>;
+    if ("xp" in p || "gold" in p) {
+      // Stats rollback path
+      return { eq: statsRevertEq1 };
+    }
+    // Level update path (forward on call 1, rollback on call 2+)
+    levelUpdateCallCount++;
+    return levelUpdateCallCount === 1
+      ? { eq: levelForwardEq }
+      : { eq: levelRevertEq1 };
+  });
 
   const from = jest.fn((table: string) => {
     if (table === "character_achievements")
@@ -133,17 +151,10 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     return { upsert };
   });
 
-  // RPC: first call = stats increment, second = compensation (reverse)
-  let rpcSingleCallCount = 0;
-  const rpcSingle = jest.fn().mockImplementation(() => {
-    rpcSingleCallCount++;
-    if (rpcSingleCallCount === 1)
-      return Promise.resolve({ data: rpcReturn, error: null });
-    return Promise.resolve({
-      data: null,
-      error: rpcCompensationError ? { message: rpcCompensationError } : null,
-    });
-  });
+  // RPC: only the forward increment; compensation is now a direct UPDATE (Fix P1)
+  const rpcSingle = jest
+    .fn()
+    .mockResolvedValue({ data: rpcReturn, error: null });
   const rpc = jest.fn().mockReturnValue({ single: rpcSingle });
 
   return {
@@ -152,12 +163,15 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     isNull,
     inForLock,
     inForRevert,
-    inForCascadeRevert,
     charAchUpdate,
     statsUpdate,
-    statsEq,
     statsLt,
     statsSelect,
+    levelRevertEq1,
+    levelRevertEq2,
+    statsRevertEq1,
+    statsRevertEq2,
+    statsRevertEq3,
     from,
     rpc,
     rpcSingle,

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared test fixtures for unlock evaluation tests.
+ * Provides compact mock builders to keep test files under the 300-line limit.
+ */
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import { makeDataResult } from "./achievement-progress-service.fixtures";
+
+export const CHAR_ID = "char-001";
+export const USER_ID = "user-001";
+
+export type UnlockTestAchievement = {
+  id: string;
+  name: string;
+  criteria_type: string;
+  criteria_config: Record<string, unknown>;
+  xp_reward: number;
+  gold_reward: number;
+};
+
+export const DEFAULT_ACHIEVEMENT: UnlockTestAchievement = {
+  id: "ach-001",
+  name: "Quest Master",
+  criteria_type: "quest_complete",
+  criteria_config: { threshold: 5 },
+  xp_reward: 50,
+  gold_reward: 25,
+};
+
+/** Build mock write client mocks for unlock evaluation tests */
+export function makeWriteMocks() {
+  const upsert = jest.fn().mockResolvedValue({ error: null });
+  const isNull = jest.fn().mockResolvedValue({ error: null });
+  const inFn = jest.fn().mockReturnValue({ is: isNull });
+  const eqUpdate = jest.fn().mockReturnValue({ in: inFn });
+  const charAchUpdate = jest.fn().mockReturnValue({ eq: eqUpdate });
+  const statsEq = jest.fn().mockResolvedValue({ error: null });
+  const statsUpdate = jest.fn().mockReturnValue({ eq: statsEq });
+  const from = jest.fn((table: string) => {
+    if (table === "character_achievements")
+      return { upsert, update: charAchUpdate };
+    if (table === "characters") return { update: statsUpdate };
+    return { upsert };
+  });
+  return { upsert, isNull, inFn, charAchUpdate, statsUpdate, from };
+}
+
+/** Build charAchChain that returns unlocked_at state on second call */
+export function makeCharAchChain(
+  achievementId: string,
+  unlockedAt: string | null,
+) {
+  let callCount = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          eq: jest.fn().mockResolvedValue({
+            data: [{ achievement_id: achievementId }],
+            error: null,
+          }),
+        };
+      }
+      return {
+        eq: jest.fn().mockReturnValue({
+          in: jest.fn().mockResolvedValue({
+            data: [{ achievement_id: achievementId, unlocked_at: unlockedAt }],
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+/** Build read client for simple single-achievement unlock tests */
+export function makeUnlockReadClient(options: {
+  questCount?: number;
+  unlockedAt?: string | null;
+  achievementId?: string;
+  achievement?: Partial<UnlockTestAchievement>;
+  charStats?: { xp: number; gold: number; level: number };
+}) {
+  const {
+    questCount = 5,
+    unlockedAt = null,
+    achievementId = DEFAULT_ACHIEVEMENT.id,
+    achievement = DEFAULT_ACHIEVEMENT,
+    charStats,
+  } = options;
+  const merged = { ...DEFAULT_ACHIEVEMENT, ...achievement };
+
+  const questChain: MockChain = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        or: jest.fn().mockResolvedValue({ count: questCount, error: null }),
+      }),
+    }),
+  };
+
+  const charCallCount = { n: 0 };
+  const charChain = {
+    select: jest.fn().mockImplementation(() => {
+      charCallCount.n++;
+      if (charCallCount.n === 1 || !charStats) {
+        return {
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_id: USER_ID, user_profiles: null },
+              error: null,
+            }),
+          }),
+        };
+      }
+      return {
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: charStats,
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+
+  const achievementsChain = makeDataResult([merged]);
+  const charAchChain = makeCharAchChain(achievementId, unlockedAt);
+
+  return {
+    from: jest.fn((table: string) => {
+      if (table === "characters") return charChain;
+      if (table === "achievements")
+        return achievementsChain as unknown as MockChain;
+      if (table === "character_achievements") return charAchChain;
+      if (table === "quest_instances") return questChain;
+      throw new Error(`Unexpected table in unlock test: ${table}`);
+    }),
+  };
+}

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -46,6 +46,8 @@ export type WriteMocksOptions = {
    * (Replaces the old rpcCompensationError now that rollback uses a direct SET.)
    */
   statsRevertError?: string;
+  /** If true, the stats rollback UPDATE matches zero rows (concurrent write). */
+  statsRevertZeroRows?: boolean;
   /** If set, the unlocked_at revert update resolves with this error message. */
   revertUnlockError?: string;
   /** If set, the cascade progress revert upsert resolves with this error. */
@@ -63,6 +65,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     levelSelectRows,
     cascadeUpsertError,
     statsRevertError,
+    statsRevertZeroRows,
     revertUnlockError,
     cascadeProgressRevertError,
     cascadeDeleteError,
@@ -126,10 +129,14 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
   const levelRevertEq2 = jest.fn().mockResolvedValue({ error: null });
   const levelRevertEq1 = jest.fn().mockReturnValue({ eq: levelRevertEq2 });
 
-  // Stats rollback chain (Fix P1): .eq("id").eq("xp").eq("gold") → await
-  const statsRevertEq3 = jest.fn().mockResolvedValue({
+  // Stats rollback chain (Fix P1): .eq("id").eq("xp").eq("gold").select("id")
+  const statsRevertSelect = jest.fn().mockResolvedValue({
+    data: statsRevertError || statsRevertZeroRows ? [] : [{ id: "char-001" }],
     error: statsRevertError ? { message: statsRevertError } : null,
   });
+  const statsRevertEq3 = jest
+    .fn()
+    .mockReturnValue({ select: statsRevertSelect });
   const statsRevertEq2 = jest.fn().mockReturnValue({ eq: statsRevertEq3 });
   const statsRevertEq1 = jest.fn().mockReturnValue({ eq: statsRevertEq2 });
 
@@ -182,6 +189,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     statsRevertEq1,
     statsRevertEq2,
     statsRevertEq3,
+    statsRevertSelect,
     cascadeDelete,
     cascadeDeleteEq,
     cascadeDeleteIn,

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -50,6 +50,8 @@ export type WriteMocksOptions = {
   revertUnlockError?: string;
   /** If set, the cascade progress revert upsert resolves with this error. */
   cascadeProgressRevertError?: string;
+  /** If set, the phantom-row delete resolves with this error message. */
+  cascadeDeleteError?: string;
 };
 
 /** Build mock write client mocks for unlock evaluation tests */
@@ -63,6 +65,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     statsRevertError,
     revertUnlockError,
     cascadeProgressRevertError,
+    cascadeDeleteError,
   } = options ?? {};
 
   // Upsert: call 1 = initial progress, call 2 = cascade, call 3+ = cascade revert
@@ -144,9 +147,16 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
       : { eq: levelRevertEq1 };
   });
 
+  // Phantom-row delete chain (P2): .delete().eq("character_id").in("achievement_id")
+  const cascadeDeleteIn = jest.fn().mockResolvedValue({
+    error: cascadeDeleteError ? { message: cascadeDeleteError } : null,
+  });
+  const cascadeDeleteEq = jest.fn().mockReturnValue({ in: cascadeDeleteIn });
+  const cascadeDelete = jest.fn().mockReturnValue({ eq: cascadeDeleteEq });
+
   const from = jest.fn((table: string) => {
     if (table === "character_achievements")
-      return { upsert, update: charAchUpdate };
+      return { upsert, update: charAchUpdate, delete: cascadeDelete };
     if (table === "characters") return { update: statsUpdate };
     return { upsert };
   });
@@ -172,6 +182,9 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     statsRevertEq1,
     statsRevertEq2,
     statsRevertEq3,
+    cascadeDelete,
+    cascadeDeleteEq,
+    cascadeDeleteIn,
     from,
     rpc,
     rpcSingle,

--- a/lib/__tests__/unlock-evaluator.test.ts
+++ b/lib/__tests__/unlock-evaluator.test.ts
@@ -1,0 +1,239 @@
+import {
+  evaluateThreshold,
+  evaluateBoolean,
+  evaluateCompound,
+  evaluateCriteriaMet,
+} from "../achievement-progress/unlock-evaluator";
+
+// ─── 1.6 Threshold strategy ───────────────────────────────────────────────────
+
+describe("evaluateThreshold", () => {
+  it("returns true when current equals threshold (met-at)", () => {
+    expect(
+      evaluateThreshold({ current: 10, threshold: 10 }, { threshold: 10 }),
+    ).toBe(true);
+  });
+
+  it("returns true when current exceeds threshold (met-above)", () => {
+    expect(
+      evaluateThreshold({ current: 15, threshold: 10 }, { threshold: 10 }),
+    ).toBe(true);
+  });
+
+  it("returns false when current is below threshold (not-met-below)", () => {
+    expect(
+      evaluateThreshold({ current: 7, threshold: 10 }, { threshold: 10 }),
+    ).toBe(false);
+  });
+
+  it("returns true when threshold is zero and current is zero", () => {
+    expect(
+      evaluateThreshold({ current: 0, threshold: 0 }, { threshold: 0 }),
+    ).toBe(true);
+  });
+
+  it("defaults threshold to 0 when absent from criteriaConfig", () => {
+    expect(evaluateThreshold({ current: 0, threshold: 0 }, {})).toBe(true);
+  });
+});
+
+// ─── 1.7 Boolean strategy ─────────────────────────────────────────────────────
+
+describe("evaluateBoolean", () => {
+  it("returns true with positive value (truthy)", () => {
+    expect(evaluateBoolean({ current: 1, threshold: 0 })).toBe(true);
+  });
+
+  it("returns true with large value", () => {
+    expect(evaluateBoolean({ current: 5, threshold: 0 })).toBe(true);
+  });
+
+  it("returns false with zero (falsy)", () => {
+    expect(evaluateBoolean({ current: 0, threshold: 0 })).toBe(false);
+  });
+});
+
+// ─── 1.8 Compound strategy ────────────────────────────────────────────────────
+
+describe("evaluateCompound", () => {
+  it("returns true when top-level met flag is true (AND all met)", () => {
+    expect(
+      evaluateCompound({
+        conditions: [
+          {
+            criteria_type: "quest_complete",
+            current: 7,
+            threshold: 5,
+            met: true,
+          },
+          {
+            criteria_type: "level_reached",
+            current: 4,
+            threshold: 3,
+            met: true,
+          },
+        ],
+        met: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when top-level met flag is false (AND partial)", () => {
+    expect(
+      evaluateCompound({
+        conditions: [
+          {
+            criteria_type: "quest_complete",
+            current: 7,
+            threshold: 5,
+            met: true,
+          },
+          {
+            criteria_type: "level_reached",
+            current: 2,
+            threshold: 3,
+            met: false,
+          },
+        ],
+        met: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when OR compound has one condition met", () => {
+    expect(
+      evaluateCompound({
+        conditions: [
+          {
+            criteria_type: "quest_complete",
+            current: 2,
+            threshold: 10,
+            met: false,
+          },
+          {
+            criteria_type: "boss_defeated",
+            current: 5,
+            threshold: 3,
+            met: true,
+          },
+        ],
+        met: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when OR compound has no conditions met", () => {
+    expect(
+      evaluateCompound({
+        conditions: [
+          {
+            criteria_type: "quest_complete",
+            current: 2,
+            threshold: 10,
+            met: false,
+          },
+          {
+            criteria_type: "boss_defeated",
+            current: 1,
+            threshold: 3,
+            met: false,
+          },
+        ],
+        met: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for compound with boolean sub-condition met", () => {
+    expect(
+      evaluateCompound({
+        conditions: [
+          {
+            criteria_type: "quest_complete",
+            current: 7,
+            threshold: 5,
+            met: true,
+          },
+          {
+            criteria_type: "class_change",
+            current: 1,
+            threshold: 0,
+            met: true,
+          },
+        ],
+        met: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+// ─── 1.9 Strategy dispatch ────────────────────────────────────────────────────
+
+describe("evaluateCriteriaMet", () => {
+  it("defaults to threshold strategy when evaluation_strategy is absent", () => {
+    // current >= threshold → met
+    expect(
+      evaluateCriteriaMet({ current: 10, threshold: 10 }, { threshold: 10 }),
+    ).toBe(true);
+    // current < threshold → not met
+    expect(
+      evaluateCriteriaMet({ current: 5, threshold: 10 }, { threshold: 10 }),
+    ).toBe(false);
+  });
+
+  it("uses threshold strategy when explicitly set", () => {
+    expect(
+      evaluateCriteriaMet(
+        { current: 10, threshold: 10 },
+        { threshold: 10, evaluation_strategy: "threshold" },
+      ),
+    ).toBe(true);
+  });
+
+  it("uses boolean strategy when set", () => {
+    expect(
+      evaluateCriteriaMet(
+        { current: 1, threshold: 0 },
+        { evaluation_strategy: "boolean" },
+      ),
+    ).toBe(true);
+    expect(
+      evaluateCriteriaMet(
+        { current: 0, threshold: 0 },
+        { evaluation_strategy: "boolean" },
+      ),
+    ).toBe(false);
+  });
+
+  it("uses compound strategy when set", () => {
+    expect(
+      evaluateCriteriaMet(
+        {
+          conditions: [
+            {
+              criteria_type: "quest_complete",
+              current: 7,
+              threshold: 5,
+              met: true,
+            },
+          ],
+          met: true,
+        },
+        { evaluation_strategy: "compound" },
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to threshold and logs warning for unknown strategy", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const result = evaluateCriteriaMet(
+      { current: 10, threshold: 5 },
+      { threshold: 5, evaluation_strategy: "unknown_strategy" },
+    );
+    expect(result).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unknown evaluation strategy"),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/lib/__tests__/unlock-multi-ach-fixtures.ts
+++ b/lib/__tests__/unlock-multi-ach-fixtures.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared fixtures for multi-achievement rollback tests.
+ * Provides helpers for scenarios with two+ achievements (e.g. quest + level).
+ */
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import { makeDataResult } from "./achievement-progress-service.fixtures";
+import { USER_ID } from "./unlock-evaluation-fixtures";
+
+/** Two achievements: quest_complete (with XP reward) + level_reached */
+export function makeQuestLevelAchievements() {
+  return {
+    questAch: {
+      id: "ach-quest",
+      name: "Quest Master",
+      criteria_type: "quest_complete",
+      criteria_config: { threshold: 5 },
+      xp_reward: 60,
+      gold_reward: 0,
+    },
+    levelAch: {
+      id: "ach-level",
+      name: "Level Reached",
+      criteria_type: "level_reached",
+      criteria_config: { threshold: 2 },
+      xp_reward: 0,
+      gold_reward: 0,
+    },
+  };
+}
+
+/** CharAch chain returning two achievement IDs, then unlocked_at=null for the first */
+export function makeDualCharAchChain(questAchId: string, secondAchId: string) {
+  let n = 0;
+  return {
+    select: jest.fn().mockImplementation(() => {
+      n++;
+      if (n === 1)
+        return {
+          eq: jest.fn().mockResolvedValue({
+            data: [
+              { achievement_id: questAchId },
+              { achievement_id: secondAchId },
+            ],
+            error: null,
+          }),
+        };
+      return {
+        eq: jest.fn().mockReturnValue({
+          in: jest.fn().mockResolvedValue({
+            data: [{ achievement_id: questAchId, unlocked_at: null }],
+            error: null,
+          }),
+        }),
+      };
+    }),
+  };
+}
+
+/** Build read client for multi-achievement unlock tests */
+export function makeMultiAchReadClient(
+  achievements: unknown[],
+  charAchChain: unknown,
+) {
+  return {
+    from: jest.fn((table: string) => {
+      if (table === "characters")
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { user_id: USER_ID, user_profiles: null },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      if (table === "achievements")
+        return makeDataResult(achievements) as unknown as MockChain;
+      if (table === "character_achievements") return charAchChain;
+      if (table === "quest_instances")
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+            }),
+          }),
+        };
+      throw new Error(`Unexpected table in unlock test: ${table}`);
+    }),
+  };
+}

--- a/lib/achievement-progress-service.ts
+++ b/lib/achievement-progress-service.ts
@@ -192,6 +192,7 @@ export class AchievementProgressService {
       const allAchievementsMap = new Map(achievements.map((a) => [a.id, a]));
       await runUnlockEvaluation(
         characterId,
+        userId,
         upsertRows,
         allAchievementsMap,
         this.readClient,

--- a/lib/achievement-progress-service.ts
+++ b/lib/achievement-progress-service.ts
@@ -6,11 +6,17 @@ import {
   ALL_CRITERIA_TYPES,
   EVALUATOR_REGISTRY,
 } from "./achievement-progress/evaluators";
+import {
+  runUnlockEvaluation,
+  buildProgressValue,
+} from "./achievement-progress/unlock-engine";
 import type {
   AchievementEvent,
   AchievementProgressRecord,
+  AchievementProgressValue,
   CriteriaConfig,
 } from "./achievement-progress/types";
+import type { FetchedAchievement } from "./achievement-progress/unlock-engine";
 
 export type {
   AchievementEventType,
@@ -63,10 +69,14 @@ export class AchievementProgressService {
     };
   }
 
-  private async fetchAchievements(familyId: string | null) {
+  private async fetchAchievements(
+    familyId: string | null,
+  ): Promise<FetchedAchievement[]> {
     let query = this.readClient
       .from("achievements")
-      .select("id, criteria_type, criteria_config");
+      .select(
+        "id, name, criteria_type, criteria_config, xp_reward, gold_reward",
+      );
 
     if (familyId) {
       query = query.or(`family_id.eq.${familyId},family_id.is.null`);
@@ -80,7 +90,7 @@ export class AchievementProgressService {
       throw new Error(`Failed to fetch achievements: ${error.message}`);
     }
 
-    return data ?? [];
+    return (data ?? []) as FetchedAchievement[];
   }
 
   private async fetchExistingAchievementIds(
@@ -107,15 +117,17 @@ export class AchievementProgressService {
     const achievements = await this.fetchAchievements(familyId);
     const existingAchievementIds =
       await this.fetchExistingAchievementIds(characterId);
+    // Backfill when any achievement row is missing, not just on zero rows.
+    // This handles both first-call and post-deployment cases where new
+    // achievements are added after a character's initial backfill.
     const needsBackfill = achievements.some(
       (a) => !existingAchievementIds.has(a.id),
     );
 
     const criteriaTypesToEvaluate = needsBackfill
-      ? ALL_CRITERIA_TYPES.slice() // full backfill
+      ? ALL_CRITERIA_TYPES.slice()
       : (EVENT_CRITERIA_MAP[event.type] ?? []);
 
-    // Warn about achievements with unrecognized criteria types
     for (const a of achievements) {
       if (!EVALUATOR_REGISTRY[a.criteria_type]) {
         console.warn(
@@ -124,7 +136,6 @@ export class AchievementProgressService {
       }
     }
 
-    // Filter achievements to the relevant criteria types
     const relevantAchievements = achievements.filter(
       (a) =>
         criteriaTypesToEvaluate.includes(a.criteria_type) &&
@@ -133,11 +144,10 @@ export class AchievementProgressService {
 
     if (relevantAchievements.length === 0) return;
 
-    // Run evaluators for each relevant achievement
     const upsertRows: {
       character_id: string;
       achievement_id: string;
-      progress: { current: number; threshold: number };
+      progress: AchievementProgressValue;
     }[] = [];
 
     for (const achievement of relevantAchievements) {
@@ -156,20 +166,16 @@ export class AchievementProgressService {
         userId,
         config,
       );
-      const threshold = config?.threshold ?? 0;
 
       upsertRows.push({
         character_id: characterId,
         achievement_id: achievement.id,
-        progress: { current: result.current, threshold },
+        progress: buildProgressValue(achievement.criteria_type, result, config),
       });
     }
 
     if (upsertRows.length === 0) return;
 
-    // Deliberately omit unlocked_at from upsertRows so Supabase only updates
-    // character_id, achievement_id, and progress on conflict, preserving any
-    // existing unlocked_at timestamp.
     const { error } = await this.writeClient
       .from("character_achievements")
       .upsert(upsertRows, {
@@ -179,6 +185,23 @@ export class AchievementProgressService {
 
     if (error) {
       throw new Error(`Failed to upsert progress: ${error.message}`);
+    }
+
+    // 8.1 Wire unlock evaluation as post-step; 8.2 wrap so failures are non-blocking
+    try {
+      const allAchievementsMap = new Map(achievements.map((a) => [a.id, a]));
+      await runUnlockEvaluation(
+        characterId,
+        upsertRows,
+        allAchievementsMap,
+        this.readClient,
+        this.writeClient,
+      );
+    } catch (unlockErr) {
+      console.error(
+        `Unlock evaluation failed for character ${characterId}:`,
+        unlockErr,
+      );
     }
   }
 
@@ -217,7 +240,7 @@ export class AchievementProgressService {
         character_id: row.character_id,
         achievement_id: row.achievement_id,
         unlocked_at: row.unlocked_at,
-        progress: row.progress as { current: number; threshold: number } | null,
+        progress: row.progress as AchievementProgressValue | null,
         notified: row.notified,
         achievement: achievement as AchievementProgressRecord["achievement"],
       };

--- a/lib/achievement-progress-service.ts
+++ b/lib/achievement-progress-service.ts
@@ -6,10 +6,8 @@ import {
   ALL_CRITERIA_TYPES,
   EVALUATOR_REGISTRY,
 } from "./achievement-progress/evaluators";
-import {
-  runUnlockEvaluation,
-  buildProgressValue,
-} from "./achievement-progress/unlock-engine";
+import { runUnlockEvaluation } from "./achievement-progress/unlock-engine";
+import { buildProgressValue } from "./achievement-progress/unlock-evaluator";
 import type {
   AchievementEvent,
   AchievementProgressRecord,

--- a/lib/achievement-progress/compound-evaluator.ts
+++ b/lib/achievement-progress/compound-evaluator.ts
@@ -1,0 +1,68 @@
+import type {
+  CompoundCondition,
+  CompoundConditionResult,
+  EvaluatorFn,
+  EvaluatorResult,
+} from "./types";
+
+/**
+ * Factory that creates the compound evaluator bound to a lazy registry getter.
+ * The getter is called at evaluation time (not import time) to avoid circular
+ * module dependencies between compound-evaluator.ts and evaluators.ts.
+ */
+export function createCompoundEvaluator(
+  getRegistry: () => Record<string, EvaluatorFn>,
+): EvaluatorFn {
+  return async (
+    client,
+    characterId,
+    userId,
+    criteriaConfig,
+  ): Promise<EvaluatorResult> => {
+    const registry = getRegistry();
+    const conditions =
+      (criteriaConfig?.conditions as CompoundCondition[] | undefined) ?? [];
+    const operator = (criteriaConfig?.operator as "AND" | "OR") ?? "AND";
+
+    const results: CompoundConditionResult[] = [];
+
+    for (const condition of conditions) {
+      const subEvaluator = registry[condition.criteria_type];
+      if (!subEvaluator) {
+        console.warn(
+          `Unknown sub-condition criteria type: ${condition.criteria_type} — treating as not met`,
+        );
+        results.push({
+          criteria_type: condition.criteria_type,
+          current: 0,
+          threshold: condition.threshold ?? 0,
+          met: false,
+        });
+        continue;
+      }
+
+      const result = await subEvaluator(client, characterId, userId, condition);
+      const met = condition.boolean
+        ? result.current > 0
+        : result.current >= (condition.threshold ?? 0);
+
+      results.push({
+        criteria_type: condition.criteria_type,
+        current: result.current,
+        threshold: condition.threshold ?? 0,
+        met,
+      });
+    }
+
+    const overallMet =
+      operator === "OR"
+        ? results.some((r) => r.met)
+        : results.every((r) => r.met);
+
+    return {
+      current: results.filter((r) => r.met).length,
+      compoundConditions: results,
+      compoundMet: overallMet,
+    };
+  };
+}

--- a/lib/achievement-progress/compound-evaluator.ts
+++ b/lib/achievement-progress/compound-evaluator.ts
@@ -54,6 +54,14 @@ export function createCompoundEvaluator(
       });
     }
 
+    if (results.length === 0) {
+      return {
+        current: 0,
+        compoundConditions: [],
+        compoundMet: false,
+      };
+    }
+
     const overallMet =
       operator === "OR"
         ? results.some((r) => r.met)

--- a/lib/achievement-progress/evaluators.ts
+++ b/lib/achievement-progress/evaluators.ts
@@ -16,16 +16,18 @@ export const EVENT_CRITERIA_MAP: Record<AchievementEventType, string[]> = {
     "xp_earned",
     "level_reached",
     "streak_reached",
+    "compound",
   ],
-  REWARD_APPROVED: ["gold_spent", "reward_redeemed"],
+  REWARD_APPROVED: ["gold_spent", "reward_redeemed", "compound"],
   BOSS_COMPLETED: [
     "boss_defeated",
     "boss_participated",
     "gold_earned",
     "xp_earned",
     "level_reached",
+    "compound",
   ],
-  CLASS_CHANGED: ["class_change"],
+  CLASS_CHANGED: ["class_change", "compound"],
 };
 
 export const ALL_CRITERIA_TYPES = [

--- a/lib/achievement-progress/evaluators.ts
+++ b/lib/achievement-progress/evaluators.ts
@@ -3,6 +3,7 @@ import type {
   CriteriaConfig,
   EvaluatorFn,
 } from "./types";
+import { createCompoundEvaluator } from "./compound-evaluator";
 
 // ─── Event → criteria-type mapping ──────────────────────────────────────────
 
@@ -41,6 +42,7 @@ export const ALL_CRITERIA_TYPES = [
   "streak_reached",
   "class_change",
   "honor_earned",
+  "compound",
 ] as const;
 
 // ─── Evaluators ──────────────────────────────────────────────────────────────
@@ -240,6 +242,7 @@ const evaluateHonorEarned: EvaluatorFn = async (client, characterId) => {
 // ─── Evaluator registry ──────────────────────────────────────────────────────
 
 export const EVALUATOR_REGISTRY: Record<string, EvaluatorFn> = {
+  compound: createCompoundEvaluator(() => EVALUATOR_REGISTRY),
   quest_complete: evaluateQuestComplete,
   quest_volunteer: evaluateQuestVolunteer,
   quest_difficulty: evaluateQuestDifficulty,

--- a/lib/achievement-progress/types.ts
+++ b/lib/achievement-progress/types.ts
@@ -11,10 +11,45 @@ export type AchievementEvent = {
   type: AchievementEventType;
 };
 
+export type CompoundCondition = {
+  criteria_type: string;
+  threshold?: number;
+  boolean?: boolean;
+};
+
+export type CompoundConditionResult = {
+  criteria_type: string;
+  current: number;
+  threshold: number;
+  met: boolean;
+};
+
+export type StandardProgress = {
+  current: number;
+  threshold: number;
+};
+
+export type CompoundProgress = {
+  conditions: CompoundConditionResult[];
+  met: boolean;
+};
+
+export type AchievementProgressValue = StandardProgress | CompoundProgress;
+
 export type CriteriaConfig = {
   threshold?: number;
   difficulty?: string;
+  evaluation_strategy?: string;
+  operator?: "AND" | "OR";
+  conditions?: CompoundCondition[];
+  boolean?: boolean;
   [key: string]: unknown;
+};
+
+export type EvaluatorResult = {
+  current: number;
+  compoundConditions?: CompoundConditionResult[];
+  compoundMet?: boolean;
 };
 
 export type EvaluatorFn = (
@@ -22,13 +57,13 @@ export type EvaluatorFn = (
   characterId: string,
   userId: string,
   criteriaConfig?: CriteriaConfig,
-) => Promise<{ current: number }>;
+) => Promise<EvaluatorResult>;
 
 export type AchievementProgressRecord = {
   character_id: string;
   achievement_id: string;
   unlocked_at: string | null;
-  progress: { current: number; threshold: number } | null;
+  progress: AchievementProgressValue | null;
   notified: boolean | null;
   achievement: {
     id: string;

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -1,0 +1,185 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database-generated";
+import { RewardCalculator } from "@/lib/reward-calculator";
+import { evaluateCriteriaMet } from "./unlock-evaluator";
+import type {
+  AchievementProgressValue,
+  CriteriaConfig,
+  CompoundProgress,
+  CompoundConditionResult,
+} from "./types";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type FetchedAchievement = {
+  id: string;
+  name: string;
+  criteria_type: string;
+  criteria_config: unknown;
+  xp_reward: number | null;
+  gold_reward: number | null;
+};
+
+export type UpsertRow = {
+  character_id: string;
+  achievement_id: string;
+  progress: AchievementProgressValue;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function buildProgressValue(
+  criteriaType: string,
+  result: {
+    current: number;
+    compoundConditions?: CompoundConditionResult[];
+    compoundMet?: boolean;
+  },
+  config: CriteriaConfig,
+): AchievementProgressValue {
+  if (criteriaType === "compound" && result.compoundConditions !== undefined) {
+    return {
+      conditions: result.compoundConditions,
+      met: result.compoundMet ?? false,
+    } satisfies CompoundProgress;
+  }
+  return { current: result.current, threshold: config?.threshold ?? 0 };
+}
+
+// ─── Core unlock evaluation engine ───────────────────────────────────────────
+
+const MAX_CASCADE_DEPTH = 10;
+
+export async function runUnlockEvaluation(
+  characterId: string,
+  progressRows: UpsertRow[],
+  achievementMap: Map<string, FetchedAchievement>,
+  readClient: SupabaseClient<Database>,
+  writeClient: SupabaseClient<Database>,
+  depth = 0,
+): Promise<void> {
+  if (depth > MAX_CASCADE_DEPTH || progressRows.length === 0) return;
+
+  // Fetch existing unlocked_at for the upserted achievement IDs
+  const achievementIds = progressRows.map((r) => r.achievement_id);
+  const { data: existingRows, error: fetchError } = await readClient
+    .from("character_achievements")
+    .select("achievement_id, unlocked_at")
+    .eq("character_id", characterId)
+    .in("achievement_id", achievementIds);
+
+  if (fetchError) {
+    throw new Error(`Failed to fetch unlock state: ${fetchError.message}`);
+  }
+
+  const unlockedAtMap = new Map(
+    (existingRows ?? []).map((r) => [r.achievement_id, r.unlocked_at]),
+  );
+
+  // Apply strategy dispatch; filter to newly eligible (criteria met + unlocked_at IS NULL)
+  const newlyEligible = progressRows.filter((row) => {
+    if (unlockedAtMap.get(row.achievement_id)) return false;
+    const achievement = achievementMap.get(row.achievement_id);
+    if (!achievement) return false;
+    const config = achievement.criteria_config as CriteriaConfig;
+    return evaluateCriteriaMet(row.progress, config);
+  });
+
+  if (newlyEligible.length === 0) return;
+
+  // Batch update unlocked_at = now() with IS NULL concurrency filter
+  const { error: unlockError } = await writeClient
+    .from("character_achievements")
+    .update({ unlocked_at: new Date().toISOString() })
+    .eq("character_id", characterId)
+    .in(
+      "achievement_id",
+      newlyEligible.map((r) => r.achievement_id),
+    )
+    .is("unlocked_at", null);
+
+  if (unlockError) {
+    throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
+  }
+
+  // Sum xp_reward and gold_reward across newly-unlocked achievements
+  const totalXp = newlyEligible.reduce(
+    (sum, row) =>
+      sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0),
+    0,
+  );
+  const totalGold = newlyEligible.reduce(
+    (sum, row) =>
+      sum + (achievementMap.get(row.achievement_id)?.gold_reward ?? 0),
+    0,
+  );
+
+  // Skip character stats update when total rewards are zero
+  if (totalXp === 0 && totalGold === 0) return;
+
+  // Fetch character's current XP, gold, and level
+  const { data: charData, error: charError } = await readClient
+    .from("characters")
+    .select("xp, gold, level")
+    .eq("id", characterId)
+    .single();
+
+  if (charError) {
+    throw new Error(`Failed to fetch character stats: ${charError.message}`);
+  }
+
+  const currentXp = charData?.xp ?? 0;
+  const currentGold = charData?.gold ?? 0;
+  const currentLevel = charData?.level ?? 1;
+
+  // Call RewardCalculator.calculateLevelUp
+  const levelUpResult = RewardCalculator.calculateLevelUp(
+    currentXp,
+    totalXp,
+    currentLevel,
+  );
+
+  // Increment characters.xp, characters.gold, and optionally level
+  const statsUpdate: Record<string, number> = {
+    xp: currentXp + totalXp,
+    gold: currentGold + totalGold,
+  };
+  if (levelUpResult) {
+    statsUpdate.level = levelUpResult.newLevel;
+  }
+
+  const { error: statsError } = await writeClient
+    .from("characters")
+    .update(statsUpdate)
+    .eq("id", characterId);
+
+  if (statsError) {
+    throw new Error(`Failed to update character stats: ${statsError.message}`);
+  }
+
+  // Level-up cascade: re-evaluate level_reached achievements
+  if (levelUpResult && depth < MAX_CASCADE_DEPTH) {
+    const newLevel = levelUpResult.newLevel;
+    const levelAchievements = [...achievementMap.values()].filter(
+      (a) => a.criteria_type === "level_reached",
+    );
+    if (levelAchievements.length > 0) {
+      const cascadeRows: UpsertRow[] = levelAchievements.map((a) => {
+        const config = a.criteria_config as CriteriaConfig;
+        return {
+          character_id: characterId,
+          achievement_id: a.id,
+          progress: { current: newLevel, threshold: config?.threshold ?? 0 },
+        };
+      });
+      await runUnlockEvaluation(
+        characterId,
+        cascadeRows,
+        achievementMap,
+        readClient,
+        writeClient,
+        depth + 1,
+      );
+    }
+  }
+}

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -130,7 +130,9 @@ export async function runUnlockEvaluation(
   // Skip character stats update when total rewards are zero
   if (totalXp === 0 && totalGold === 0) return;
 
-  // P1: Wrap reward grant and cascade in try-catch to revert on failure
+  let statsApplied = false,
+    levelApplied = false;
+  let prevLevel: number | null = null;
   try {
     // Atomically increment XP and gold to prevent concurrent read-modify-write races.
     // Returns the new values after the increment.
@@ -147,6 +149,9 @@ export async function runUnlockEvaluation(
         `Failed to increment character stats: ${rpcError.message}`,
       );
     }
+
+    statsApplied = true;
+    prevLevel = newStats?.level ?? null;
 
     // Compute level from previous XP (new xp minus the increment) to detect level-up
     const prevXp = (newStats?.xp ?? 0) - totalXp;
@@ -167,6 +172,8 @@ export async function runUnlockEvaluation(
           `Failed to update character level: ${levelError.message}`,
         );
       }
+
+      levelApplied = true;
     }
 
     // P2 + P3: Unified cascade section
@@ -250,18 +257,43 @@ export async function runUnlockEvaluation(
       }
     }
   } catch (err) {
-    // P1: Attempt to revert unlocked_at to null on any failure
-    try {
-      await writeClient
-        .from("character_achievements")
-        .update({ unlocked_at: null })
-        .eq("character_id", characterId)
-        .in("achievement_id", lockedIds);
-    } catch (revertError) {
+    const { error: revertError } = await writeClient
+      .from("character_achievements")
+      .update({ unlocked_at: null })
+      .eq("character_id", characterId)
+      .in("achievement_id", lockedIds);
+    if (revertError) {
       console.error(
         "Critical: failed to revert unlock after reward failure:",
         revertError,
       );
+    }
+    if (levelApplied && prevLevel !== null) {
+      const { error: lvlRevertErr } = await writeClient
+        .from("characters")
+        .update({ level: prevLevel })
+        .eq("id", characterId);
+      if (lvlRevertErr) {
+        console.error(
+          "Critical: failed to revert level after reward failure:",
+          lvlRevertErr,
+        );
+      }
+    }
+    if (statsApplied) {
+      const { error: statsRevertErr } = await writeClient
+        .rpc("fn_increment_character_stats", {
+          p_character_id: characterId,
+          p_xp: 0 - totalXp,
+          p_gold: 0 - totalGold,
+        })
+        .single();
+      if (statsRevertErr) {
+        console.error(
+          "Critical: failed to revert stats after reward failure:",
+          statsRevertErr,
+        );
+      }
     }
     throw err;
   }

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -218,7 +218,7 @@ export async function runUnlockEvaluation(
       if (cascadeRows.length > 0) {
         // Fix P2: snapshot existing progress before upserting so rollback can
         // restore prior values rather than blindly writing null.
-        const { data: existingCascade } = await readClient
+        const { data: existingCascade, error: snapshotErr } = await readClient
           .from("character_achievements")
           .select("achievement_id, progress")
           .eq("character_id", characterId)
@@ -226,6 +226,11 @@ export async function runUnlockEvaluation(
             "achievement_id",
             cascadeRows.map((r) => r.achievement_id),
           );
+        if (snapshotErr) {
+          throw new Error(
+            `Failed to snapshot cascade progress: ${snapshotErr.message}`,
+          );
+        }
         prevCascadeSnapshot =
           (existingCascade as typeof prevCascadeSnapshot) ?? [];
 

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -87,8 +87,11 @@ export async function runUnlockEvaluation(
 
   if (newlyEligible.length === 0) return;
 
-  // Batch update unlocked_at = now() with IS NULL concurrency filter
-  const { error: unlockError } = await writeClient
+  // Batch update unlocked_at = now() with IS NULL concurrency filter.
+  // .select() returns only the rows that matched and were updated by this call.
+  // Under concurrent unlock evaluations, only one caller wins the IS NULL race;
+  // the other receives an empty set and returns early without granting rewards.
+  const { data: actuallyUnlocked, error: unlockError } = await writeClient
     .from("character_achievements")
     .update({ unlocked_at: new Date().toISOString() })
     .eq("character_id", characterId)
@@ -96,19 +99,23 @@ export async function runUnlockEvaluation(
       "achievement_id",
       newlyEligible.map((r) => r.achievement_id),
     )
-    .is("unlocked_at", null);
+    .is("unlocked_at", null)
+    .select("achievement_id");
 
   if (unlockError) {
     throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
   }
 
-  // Sum xp_reward and gold_reward across newly-unlocked achievements
-  const totalXp = newlyEligible.reduce(
+  // Only grant rewards for achievements actually unlocked by this call
+  if (!actuallyUnlocked || actuallyUnlocked.length === 0) return;
+
+  // Sum xp_reward and gold_reward across actually-unlocked achievements
+  const totalXp = actuallyUnlocked.reduce(
     (sum, row) =>
       sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0),
     0,
   );
-  const totalGold = newlyEligible.reduce(
+  const totalGold = actuallyUnlocked.reduce(
     (sum, row) =>
       sum + (achievementMap.get(row.achievement_id)?.gold_reward ?? 0),
     0,
@@ -117,44 +124,39 @@ export async function runUnlockEvaluation(
   // Skip character stats update when total rewards are zero
   if (totalXp === 0 && totalGold === 0) return;
 
-  // Fetch character's current XP, gold, and level
-  const { data: charData, error: charError } = await readClient
-    .from("characters")
-    .select("xp, gold, level")
-    .eq("id", characterId)
+  // Atomically increment XP and gold to prevent concurrent read-modify-write races.
+  // Returns the new values after the increment.
+  const { data: newStats, error: rpcError } = await writeClient
+    .rpc("fn_increment_character_stats", {
+      p_character_id: characterId,
+      p_xp: totalXp,
+      p_gold: totalGold,
+    })
     .single();
 
-  if (charError) {
-    throw new Error(`Failed to fetch character stats: ${charError.message}`);
+  if (rpcError) {
+    throw new Error(`Failed to increment character stats: ${rpcError.message}`);
   }
 
-  const currentXp = charData?.xp ?? 0;
-  const currentGold = charData?.gold ?? 0;
-  const currentLevel = charData?.level ?? 1;
-
-  // Call RewardCalculator.calculateLevelUp
+  // Compute level from previous XP (new xp minus the increment) to detect level-up
+  const prevXp = (newStats?.xp ?? 0) - totalXp;
   const levelUpResult = RewardCalculator.calculateLevelUp(
-    currentXp,
+    prevXp,
     totalXp,
-    currentLevel,
+    newStats?.level ?? 1,
   );
 
-  // Increment characters.xp, characters.gold, and optionally level
-  const statsUpdate: Record<string, number> = {
-    xp: currentXp + totalXp,
-    gold: currentGold + totalGold,
-  };
   if (levelUpResult) {
-    statsUpdate.level = levelUpResult.newLevel;
-  }
+    const { error: levelError } = await writeClient
+      .from("characters")
+      .update({ level: levelUpResult.newLevel })
+      .eq("id", characterId);
 
-  const { error: statsError } = await writeClient
-    .from("characters")
-    .update(statsUpdate)
-    .eq("id", characterId);
-
-  if (statsError) {
-    throw new Error(`Failed to update character stats: ${statsError.message}`);
+    if (levelError) {
+      throw new Error(
+        `Failed to update character level: ${levelError.message}`,
+      );
+    }
   }
 
   // Level-up cascade: re-evaluate level_reached achievements

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -1,13 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/types/database-generated";
 import { RewardCalculator } from "@/lib/reward-calculator";
-import { evaluateCriteriaMet } from "./unlock-evaluator";
+import { evaluateCriteriaMet, buildProgressValue } from "./unlock-evaluator";
 import { EVALUATOR_REGISTRY } from "./evaluators";
 import type {
   AchievementProgressValue,
   CriteriaConfig,
-  CompoundProgress,
-  CompoundConditionResult,
   CompoundCondition,
 } from "./types";
 
@@ -25,24 +23,6 @@ export type UpsertRow = {
   achievement_id: string;
   progress: AchievementProgressValue;
 };
-
-export function buildProgressValue(
-  criteriaType: string,
-  result: {
-    current: number;
-    compoundConditions?: CompoundConditionResult[];
-    compoundMet?: boolean;
-  },
-  config: CriteriaConfig,
-): AchievementProgressValue {
-  if (criteriaType === "compound" && result.compoundConditions !== undefined) {
-    return {
-      conditions: result.compoundConditions,
-      met: result.compoundMet ?? false,
-    } satisfies CompoundProgress;
-  }
-  return { current: result.current, threshold: config?.threshold ?? 0 };
-}
 
 const MAX_CASCADE_DEPTH = 10;
 
@@ -82,7 +62,6 @@ export async function runUnlockEvaluation(
 
   if (newlyEligible.length === 0) return;
 
-  // IS NULL concurrency filter: only one concurrent caller wins the race.
   const { data: actuallyUnlocked, error: unlockError } = await writeClient
     .from("character_achievements")
     .update({ unlocked_at: new Date().toISOString() })
@@ -118,6 +97,7 @@ export async function runUnlockEvaluation(
   let statsApplied = false,
     levelApplied = false;
   let prevLevel: number | null = null;
+  const cascadeRows: UpsertRow[] = [];
   try {
     const { data: newStats, error: rpcError } = await writeClient
       .rpc("fn_increment_character_stats", {
@@ -161,12 +141,9 @@ export async function runUnlockEvaluation(
       levelApplied = (levelData?.length ?? 0) > 0;
     }
 
-    // P2 + P3: Unified cascade section
     if (depth < MAX_CASCADE_DEPTH) {
-      const cascadeRows: UpsertRow[] = [];
       const cascadeAchievementIds = new Set<string>();
 
-      // P3: Re-evaluate xp_earned with post-reward XP total
       if (totalXp > 0) {
         for (const a of achievementMap.values()) {
           if (a.criteria_type !== "xp_earned") continue;
@@ -289,6 +266,22 @@ export async function runUnlockEvaluation(
         console.error(
           "Critical: failed to revert stats after reward failure:",
           statsRevertErr,
+        );
+      }
+    }
+    if (cascadeRows.length > 0) {
+      const { error: cascadeRevertErr } = await writeClient
+        .from("character_achievements")
+        .update({ progress: null })
+        .eq("character_id", characterId)
+        .in(
+          "achievement_id",
+          cascadeRows.map((r) => r.achievement_id),
+        );
+      if (cascadeRevertErr) {
+        console.error(
+          "Critical: failed to revert cascade progress after failure:",
+          cascadeRevertErr,
         );
       }
     }

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -2,11 +2,13 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/types/database-generated";
 import { RewardCalculator } from "@/lib/reward-calculator";
 import { evaluateCriteriaMet } from "./unlock-evaluator";
+import { EVALUATOR_REGISTRY } from "./evaluators";
 import type {
   AchievementProgressValue,
   CriteriaConfig,
   CompoundProgress,
   CompoundConditionResult,
+  CompoundCondition,
 } from "./types";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -52,6 +54,7 @@ const MAX_CASCADE_DEPTH = 10;
 
 export async function runUnlockEvaluation(
   characterId: string,
+  userId: string,
   progressRows: UpsertRow[],
   achievementMap: Map<string, FetchedAchievement>,
   readClient: SupabaseClient<Database>,
@@ -159,23 +162,47 @@ export async function runUnlockEvaluation(
     }
   }
 
-  // Level-up cascade: re-evaluate level_reached achievements
+  // Level-up cascade: re-evaluate level_reached and compound achievements
   if (levelUpResult && depth < MAX_CASCADE_DEPTH) {
     const newLevel = levelUpResult.newLevel;
-    const levelAchievements = [...achievementMap.values()].filter(
-      (a) => a.criteria_type === "level_reached",
-    );
-    if (levelAchievements.length > 0) {
-      const cascadeRows: UpsertRow[] = levelAchievements.map((a) => {
-        const config = a.criteria_config as CriteriaConfig;
-        return {
-          character_id: characterId,
-          achievement_id: a.id,
-          progress: { current: newLevel, threshold: config?.threshold ?? 0 },
-        };
+    const cascadeRows: UpsertRow[] = [];
+
+    // Collect level_reached achievements
+    for (const a of achievementMap.values()) {
+      if (a.criteria_type !== "level_reached") continue;
+      const config = a.criteria_config as CriteriaConfig;
+      cascadeRows.push({
+        character_id: characterId,
+        achievement_id: a.id,
+        progress: { current: newLevel, threshold: config?.threshold ?? 0 },
       });
+    }
+
+    // Collect compound achievements with level_reached sub-conditions
+    for (const a of achievementMap.values()) {
+      if (a.criteria_type !== "compound") continue;
+      const config = a.criteria_config as CriteriaConfig;
+      const hasLevelCondition = (config?.conditions ?? []).some(
+        (c: CompoundCondition) => c.criteria_type === "level_reached",
+      );
+      if (!hasLevelCondition) continue;
+      const result = await EVALUATOR_REGISTRY.compound(
+        readClient,
+        characterId,
+        userId,
+        config,
+      );
+      cascadeRows.push({
+        character_id: characterId,
+        achievement_id: a.id,
+        progress: buildProgressValue("compound", result, config),
+      });
+    }
+
+    if (cascadeRows.length > 0) {
       await runUnlockEvaluation(
         characterId,
+        userId,
         cascadeRows,
         achievementMap,
         readClient,

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -3,6 +3,7 @@ import type { Database } from "@/lib/types/database-generated";
 import { RewardCalculator } from "@/lib/reward-calculator";
 import { evaluateCriteriaMet, buildProgressValue } from "./unlock-evaluator";
 import { EVALUATOR_REGISTRY } from "./evaluators";
+import { performRollback } from "./unlock-rollback";
 import type {
   AchievementProgressValue,
   CriteriaConfig,
@@ -97,6 +98,12 @@ export async function runUnlockEvaluation(
   let statsApplied = false,
     levelApplied = false;
   let prevLevel: number | null = null;
+  let appliedLevel: number | null = null;
+  let capturedNewStats: { xp: number; gold: number } | null = null;
+  let prevCascadeSnapshot: Array<{
+    achievement_id: string;
+    progress: unknown;
+  }> = [];
   const cascadeRows: UpsertRow[] = [];
   try {
     const { data: newStats, error: rpcError } = await writeClient
@@ -115,6 +122,9 @@ export async function runUnlockEvaluation(
 
     statsApplied = true;
     prevLevel = newStats?.level ?? null;
+    capturedNewStats = newStats
+      ? { xp: newStats.xp ?? 0, gold: newStats.gold ?? 0 }
+      : null;
 
     // Compute level from previous XP (new xp minus the increment) to detect level-up
     const prevXp = (newStats?.xp ?? 0) - totalXp;
@@ -139,6 +149,7 @@ export async function runUnlockEvaluation(
       }
 
       levelApplied = (levelData?.length ?? 0) > 0;
+      if (levelApplied) appliedLevel = levelUpResult.newLevel;
     }
 
     if (depth < MAX_CASCADE_DEPTH) {
@@ -205,7 +216,20 @@ export async function runUnlockEvaluation(
       }
 
       if (cascadeRows.length > 0) {
-        // P2: Persist cascade progress before recursing
+        // Fix P2: snapshot existing progress before upserting so rollback can
+        // restore prior values rather than blindly writing null.
+        const { data: existingCascade } = await readClient
+          .from("character_achievements")
+          .select("achievement_id, progress")
+          .eq("character_id", characterId)
+          .in(
+            "achievement_id",
+            cascadeRows.map((r) => r.achievement_id),
+          );
+        prevCascadeSnapshot =
+          (existingCascade as typeof prevCascadeSnapshot) ?? [];
+
+        // Persist cascade progress before recursing
         const { error: cascadeUpsertError } = await writeClient
           .from("character_achievements")
           .upsert(cascadeRows, {
@@ -231,60 +255,18 @@ export async function runUnlockEvaluation(
       }
     }
   } catch (err) {
-    const { error: revertError } = await writeClient
-      .from("character_achievements")
-      .update({ unlocked_at: null })
-      .eq("character_id", characterId)
-      .in("achievement_id", lockedIds);
-    if (revertError) {
-      console.error(
-        "Critical: failed to revert unlock after reward failure:",
-        revertError,
-      );
-    }
-    if (levelApplied && prevLevel !== null) {
-      const { error: lvlRevertErr } = await writeClient
-        .from("characters")
-        .update({ level: prevLevel })
-        .eq("id", characterId);
-      if (lvlRevertErr) {
-        console.error(
-          "Critical: failed to revert level after reward failure:",
-          lvlRevertErr,
-        );
-      }
-    }
-    if (statsApplied) {
-      const { error: statsRevertErr } = await writeClient
-        .rpc("fn_increment_character_stats", {
-          p_character_id: characterId,
-          p_xp: 0 - totalXp,
-          p_gold: 0 - totalGold,
-        })
-        .single();
-      if (statsRevertErr) {
-        console.error(
-          "Critical: failed to revert stats after reward failure:",
-          statsRevertErr,
-        );
-      }
-    }
-    if (cascadeRows.length > 0) {
-      const { error: cascadeRevertErr } = await writeClient
-        .from("character_achievements")
-        .update({ progress: null })
-        .eq("character_id", characterId)
-        .in(
-          "achievement_id",
-          cascadeRows.map((r) => r.achievement_id),
-        );
-      if (cascadeRevertErr) {
-        console.error(
-          "Critical: failed to revert cascade progress after failure:",
-          cascadeRevertErr,
-        );
-      }
-    }
+    await performRollback(writeClient, characterId, {
+      levelApplied,
+      prevLevel,
+      appliedLevel,
+      statsApplied,
+      capturedNewStats,
+      totalXp,
+      totalGold,
+      lockedIds,
+      cascadeRows,
+      prevCascadeSnapshot,
+    });
     throw err;
   }
 }

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -112,6 +112,9 @@ export async function runUnlockEvaluation(
   // Only grant rewards for achievements actually unlocked by this call
   if (!actuallyUnlocked || actuallyUnlocked.length === 0) return;
 
+  // P1: Extract locked IDs for potential revert on failure
+  const lockedIds = actuallyUnlocked.map((r) => r.achievement_id);
+
   // Sum xp_reward and gold_reward across actually-unlocked achievements
   const totalXp = actuallyUnlocked.reduce(
     (sum, row) =>
@@ -127,88 +130,139 @@ export async function runUnlockEvaluation(
   // Skip character stats update when total rewards are zero
   if (totalXp === 0 && totalGold === 0) return;
 
-  // Atomically increment XP and gold to prevent concurrent read-modify-write races.
-  // Returns the new values after the increment.
-  const { data: newStats, error: rpcError } = await writeClient
-    .rpc("fn_increment_character_stats", {
-      p_character_id: characterId,
-      p_xp: totalXp,
-      p_gold: totalGold,
-    })
-    .single();
+  // P1: Wrap reward grant and cascade in try-catch to revert on failure
+  try {
+    // Atomically increment XP and gold to prevent concurrent read-modify-write races.
+    // Returns the new values after the increment.
+    const { data: newStats, error: rpcError } = await writeClient
+      .rpc("fn_increment_character_stats", {
+        p_character_id: characterId,
+        p_xp: totalXp,
+        p_gold: totalGold,
+      })
+      .single();
 
-  if (rpcError) {
-    throw new Error(`Failed to increment character stats: ${rpcError.message}`);
-  }
-
-  // Compute level from previous XP (new xp minus the increment) to detect level-up
-  const prevXp = (newStats?.xp ?? 0) - totalXp;
-  const levelUpResult = RewardCalculator.calculateLevelUp(
-    prevXp,
-    totalXp,
-    newStats?.level ?? 1,
-  );
-
-  if (levelUpResult) {
-    const { error: levelError } = await writeClient
-      .from("characters")
-      .update({ level: levelUpResult.newLevel })
-      .eq("id", characterId);
-
-    if (levelError) {
+    if (rpcError) {
       throw new Error(
-        `Failed to update character level: ${levelError.message}`,
+        `Failed to increment character stats: ${rpcError.message}`,
       );
     }
-  }
 
-  // Level-up cascade: re-evaluate level_reached and compound achievements
-  if (levelUpResult && depth < MAX_CASCADE_DEPTH) {
-    const newLevel = levelUpResult.newLevel;
-    const cascadeRows: UpsertRow[] = [];
+    // Compute level from previous XP (new xp minus the increment) to detect level-up
+    const prevXp = (newStats?.xp ?? 0) - totalXp;
+    const levelUpResult = RewardCalculator.calculateLevelUp(
+      prevXp,
+      totalXp,
+      newStats?.level ?? 1,
+    );
 
-    // Collect level_reached achievements
-    for (const a of achievementMap.values()) {
-      if (a.criteria_type !== "level_reached") continue;
-      const config = a.criteria_config as CriteriaConfig;
-      cascadeRows.push({
-        character_id: characterId,
-        achievement_id: a.id,
-        progress: { current: newLevel, threshold: config?.threshold ?? 0 },
-      });
+    if (levelUpResult) {
+      const { error: levelError } = await writeClient
+        .from("characters")
+        .update({ level: levelUpResult.newLevel })
+        .eq("id", characterId);
+
+      if (levelError) {
+        throw new Error(
+          `Failed to update character level: ${levelError.message}`,
+        );
+      }
     }
 
-    // Collect compound achievements with level_reached sub-conditions
-    for (const a of achievementMap.values()) {
-      if (a.criteria_type !== "compound") continue;
-      const config = a.criteria_config as CriteriaConfig;
-      const hasLevelCondition = (config?.conditions ?? []).some(
-        (c: CompoundCondition) => c.criteria_type === "level_reached",
-      );
-      if (!hasLevelCondition) continue;
-      const result = await EVALUATOR_REGISTRY.compound(
-        readClient,
-        characterId,
-        userId,
-        config,
-      );
-      cascadeRows.push({
-        character_id: characterId,
-        achievement_id: a.id,
-        progress: buildProgressValue("compound", result, config),
-      });
-    }
+    // P2 + P3: Unified cascade section
+    if (depth < MAX_CASCADE_DEPTH) {
+      const cascadeRows: UpsertRow[] = [];
 
-    if (cascadeRows.length > 0) {
-      await runUnlockEvaluation(
-        characterId,
-        userId,
-        cascadeRows,
-        achievementMap,
-        readClient,
-        writeClient,
-        depth + 1,
+      // P3: Re-evaluate xp_earned with post-reward XP total
+      if (totalXp > 0) {
+        for (const a of achievementMap.values()) {
+          if (a.criteria_type !== "xp_earned") continue;
+          const config = a.criteria_config as CriteriaConfig;
+          cascadeRows.push({
+            character_id: characterId,
+            achievement_id: a.id,
+            progress: {
+              current: newStats?.xp ?? 0,
+              threshold: config?.threshold ?? 0,
+            },
+          });
+        }
+      }
+
+      // Level-up cascade: level_reached + compound achievements
+      if (levelUpResult) {
+        const newLevel = levelUpResult.newLevel;
+        for (const a of achievementMap.values()) {
+          if (a.criteria_type !== "level_reached") continue;
+          const config = a.criteria_config as CriteriaConfig;
+          cascadeRows.push({
+            character_id: characterId,
+            achievement_id: a.id,
+            progress: { current: newLevel, threshold: config?.threshold ?? 0 },
+          });
+        }
+
+        for (const a of achievementMap.values()) {
+          if (a.criteria_type !== "compound") continue;
+          const config = a.criteria_config as CriteriaConfig;
+          const hasLevelCondition = (config?.conditions ?? []).some(
+            (c: CompoundCondition) => c.criteria_type === "level_reached",
+          );
+          if (!hasLevelCondition) continue;
+          const result = await EVALUATOR_REGISTRY.compound(
+            readClient,
+            characterId,
+            userId,
+            config,
+          );
+          cascadeRows.push({
+            character_id: characterId,
+            achievement_id: a.id,
+            progress: buildProgressValue("compound", result, config),
+          });
+        }
+      }
+
+      if (cascadeRows.length > 0) {
+        // P2: Persist cascade progress before recursing
+        const { error: cascadeUpsertError } = await writeClient
+          .from("character_achievements")
+          .upsert(cascadeRows, {
+            onConflict: "character_id,achievement_id",
+            ignoreDuplicates: false,
+          });
+
+        if (cascadeUpsertError) {
+          throw new Error(
+            `Failed to persist cascade progress: ${cascadeUpsertError.message}`,
+          );
+        }
+
+        await runUnlockEvaluation(
+          characterId,
+          userId,
+          cascadeRows,
+          achievementMap,
+          readClient,
+          writeClient,
+          depth + 1,
+        );
+      }
+    }
+  } catch (err) {
+    // P1: Attempt to revert unlocked_at to null on any failure
+    try {
+      await writeClient
+        .from("character_achievements")
+        .update({ unlocked_at: null })
+        .eq("character_id", characterId)
+        .in("achievement_id", lockedIds);
+    } catch (revertError) {
+      console.error(
+        "Critical: failed to revert unlock after reward failure:",
+        revertError,
       );
     }
+    throw err;
   }
 }

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -155,32 +155,35 @@ export async function runUnlockEvaluation(
     if (depth < MAX_CASCADE_DEPTH) {
       const cascadeAchievementIds = new Set<string>();
 
-      if (totalXp > 0) {
+      const cascadeTriggers: Array<{
+        shouldRun: boolean;
+        criteriaType: "xp_earned" | "level_reached";
+        newValue: number;
+      }> = [
+        {
+          shouldRun: totalXp > 0,
+          criteriaType: "xp_earned",
+          newValue: newStats?.xp ?? 0,
+        },
+        {
+          shouldRun: !!(levelUpResult && levelApplied),
+          criteriaType: "level_reached",
+          newValue: levelUpResult?.newLevel ?? 0,
+        },
+      ];
+
+      for (const trigger of cascadeTriggers) {
+        if (!trigger.shouldRun) continue;
         for (const a of achievementMap.values()) {
-          if (a.criteria_type !== "xp_earned") continue;
+          if (a.criteria_type !== trigger.criteriaType) continue;
           const config = a.criteria_config as CriteriaConfig;
           cascadeRows.push({
             character_id: characterId,
             achievement_id: a.id,
             progress: {
-              current: newStats?.xp ?? 0,
+              current: trigger.newValue,
               threshold: config?.threshold ?? 0,
             },
-          });
-          cascadeAchievementIds.add(a.id);
-        }
-      }
-
-      // Level-up cascade: level_reached achievements
-      if (levelUpResult && levelApplied) {
-        const newLevel = levelUpResult.newLevel;
-        for (const a of achievementMap.values()) {
-          if (a.criteria_type !== "level_reached") continue;
-          const config = a.criteria_config as CriteriaConfig;
-          cascadeRows.push({
-            character_id: characterId,
-            achievement_id: a.id,
-            progress: { current: newLevel, threshold: config?.threshold ?? 0 },
           });
           cascadeAchievementIds.add(a.id);
         }

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -11,8 +11,6 @@ import type {
   CompoundCondition,
 } from "./types";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 export type FetchedAchievement = {
   id: string;
   name: string;
@@ -27,8 +25,6 @@ export type UpsertRow = {
   achievement_id: string;
   progress: AchievementProgressValue;
 };
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 export function buildProgressValue(
   criteriaType: string,
@@ -48,8 +44,6 @@ export function buildProgressValue(
   return { current: result.current, threshold: config?.threshold ?? 0 };
 }
 
-// ─── Core unlock evaluation engine ───────────────────────────────────────────
-
 const MAX_CASCADE_DEPTH = 10;
 
 export async function runUnlockEvaluation(
@@ -63,7 +57,6 @@ export async function runUnlockEvaluation(
 ): Promise<void> {
   if (depth > MAX_CASCADE_DEPTH || progressRows.length === 0) return;
 
-  // Fetch existing unlocked_at for the upserted achievement IDs
   const achievementIds = progressRows.map((r) => r.achievement_id);
   const { data: existingRows, error: fetchError } = await readClient
     .from("character_achievements")
@@ -79,7 +72,6 @@ export async function runUnlockEvaluation(
     (existingRows ?? []).map((r) => [r.achievement_id, r.unlocked_at]),
   );
 
-  // Apply strategy dispatch; filter to newly eligible (criteria met + unlocked_at IS NULL)
   const newlyEligible = progressRows.filter((row) => {
     if (unlockedAtMap.get(row.achievement_id)) return false;
     const achievement = achievementMap.get(row.achievement_id);
@@ -90,10 +82,7 @@ export async function runUnlockEvaluation(
 
   if (newlyEligible.length === 0) return;
 
-  // Batch update unlocked_at = now() with IS NULL concurrency filter.
-  // .select() returns only the rows that matched and were updated by this call.
-  // Under concurrent unlock evaluations, only one caller wins the IS NULL race;
-  // the other receives an empty set and returns early without granting rewards.
+  // IS NULL concurrency filter: only one concurrent caller wins the race.
   const { data: actuallyUnlocked, error: unlockError } = await writeClient
     .from("character_achievements")
     .update({ unlocked_at: new Date().toISOString() })
@@ -109,13 +98,10 @@ export async function runUnlockEvaluation(
     throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
   }
 
-  // Only grant rewards for achievements actually unlocked by this call
   if (!actuallyUnlocked || actuallyUnlocked.length === 0) return;
 
-  // P1: Extract locked IDs for potential revert on failure
   const lockedIds = actuallyUnlocked.map((r) => r.achievement_id);
 
-  // Sum xp_reward and gold_reward across actually-unlocked achievements
   const totalXp = actuallyUnlocked.reduce(
     (sum, row) =>
       sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0),
@@ -127,15 +113,12 @@ export async function runUnlockEvaluation(
     0,
   );
 
-  // Skip character stats update when total rewards are zero
   if (totalXp === 0 && totalGold === 0) return;
 
   let statsApplied = false,
     levelApplied = false;
   let prevLevel: number | null = null;
   try {
-    // Atomically increment XP and gold to prevent concurrent read-modify-write races.
-    // Returns the new values after the increment.
     const { data: newStats, error: rpcError } = await writeClient
       .rpc("fn_increment_character_stats", {
         p_character_id: characterId,
@@ -162,10 +145,12 @@ export async function runUnlockEvaluation(
     );
 
     if (levelUpResult) {
-      const { error: levelError } = await writeClient
+      const { data: levelData, error: levelError } = await writeClient
         .from("characters")
         .update({ level: levelUpResult.newLevel })
-        .eq("id", characterId);
+        .eq("id", characterId)
+        .lt("level", levelUpResult.newLevel) // only advance, never downgrade
+        .select("level");
 
       if (levelError) {
         throw new Error(
@@ -173,12 +158,13 @@ export async function runUnlockEvaluation(
         );
       }
 
-      levelApplied = true;
+      levelApplied = (levelData?.length ?? 0) > 0;
     }
 
     // P2 + P3: Unified cascade section
     if (depth < MAX_CASCADE_DEPTH) {
       const cascadeRows: UpsertRow[] = [];
+      const cascadeAchievementIds = new Set<string>();
 
       // P3: Re-evaluate xp_earned with post-reward XP total
       if (totalXp > 0) {
@@ -193,11 +179,12 @@ export async function runUnlockEvaluation(
               threshold: config?.threshold ?? 0,
             },
           });
+          cascadeAchievementIds.add(a.id);
         }
       }
 
-      // Level-up cascade: level_reached + compound achievements
-      if (levelUpResult) {
+      // Level-up cascade: level_reached achievements
+      if (levelUpResult && levelApplied) {
         const newLevel = levelUpResult.newLevel;
         for (const a of achievementMap.values()) {
           if (a.criteria_type !== "level_reached") continue;
@@ -207,15 +194,24 @@ export async function runUnlockEvaluation(
             achievement_id: a.id,
             progress: { current: newLevel, threshold: config?.threshold ?? 0 },
           });
+          cascadeAchievementIds.add(a.id);
         }
+      }
 
+      // Compound cascade: re-evaluate compound achievements with an xp_earned
+      // or level_reached sub-condition, deduplicating across both triggers.
+      const shouldEvalCompound = totalXp > 0 || (levelUpResult && levelApplied);
+      if (shouldEvalCompound) {
         for (const a of achievementMap.values()) {
           if (a.criteria_type !== "compound") continue;
+          if (cascadeAchievementIds.has(a.id)) continue; // already queued
           const config = a.criteria_config as CriteriaConfig;
-          const hasLevelCondition = (config?.conditions ?? []).some(
-            (c: CompoundCondition) => c.criteria_type === "level_reached",
+          const hasRelevantCondition = (config?.conditions ?? []).some(
+            (c: CompoundCondition) =>
+              c.criteria_type === "xp_earned" ||
+              c.criteria_type === "level_reached",
           );
-          if (!hasLevelCondition) continue;
+          if (!hasRelevantCondition) continue;
           const result = await EVALUATOR_REGISTRY.compound(
             readClient,
             characterId,
@@ -227,6 +223,7 @@ export async function runUnlockEvaluation(
             achievement_id: a.id,
             progress: buildProgressValue("compound", result, config),
           });
+          cascadeAchievementIds.add(a.id);
         }
       }
 

--- a/lib/achievement-progress/unlock-evaluator.ts
+++ b/lib/achievement-progress/unlock-evaluator.ts
@@ -3,6 +3,7 @@ import type {
   AchievementProgressValue,
   StandardProgress,
   CompoundProgress,
+  CompoundConditionResult,
 } from "./types";
 
 export type EvaluationStrategy = "threshold" | "boolean" | "compound";
@@ -23,6 +24,26 @@ export function evaluateBoolean(progress: StandardProgress): boolean {
 
 export function evaluateCompound(progress: CompoundProgress): boolean {
   return progress.met === true;
+}
+
+// ─── Progress value builder ───────────────────────────────────────────────────
+
+export function buildProgressValue(
+  criteriaType: string,
+  result: {
+    current: number;
+    compoundConditions?: CompoundConditionResult[];
+    compoundMet?: boolean;
+  },
+  config: CriteriaConfig,
+): AchievementProgressValue {
+  if (criteriaType === "compound" && result.compoundConditions !== undefined) {
+    return {
+      conditions: result.compoundConditions,
+      met: result.compoundMet ?? false,
+    } satisfies CompoundProgress;
+  }
+  return { current: result.current, threshold: config?.threshold ?? 0 };
 }
 
 // ─── Strategy dispatch ────────────────────────────────────────────────────────

--- a/lib/achievement-progress/unlock-evaluator.ts
+++ b/lib/achievement-progress/unlock-evaluator.ts
@@ -1,0 +1,51 @@
+import type {
+  CriteriaConfig,
+  AchievementProgressValue,
+  StandardProgress,
+  CompoundProgress,
+} from "./types";
+
+export type EvaluationStrategy = "threshold" | "boolean" | "compound";
+
+// ─── Strategy functions (pure logic) ──────────────────────────────────────────
+
+export function evaluateThreshold(
+  progress: StandardProgress,
+  criteriaConfig: CriteriaConfig,
+): boolean {
+  const threshold = criteriaConfig?.threshold ?? 0;
+  return progress.current >= threshold;
+}
+
+export function evaluateBoolean(progress: StandardProgress): boolean {
+  return progress.current > 0;
+}
+
+export function evaluateCompound(progress: CompoundProgress): boolean {
+  return progress.met === true;
+}
+
+// ─── Strategy dispatch ────────────────────────────────────────────────────────
+
+export function evaluateCriteriaMet(
+  progress: AchievementProgressValue,
+  criteriaConfig: CriteriaConfig,
+): boolean {
+  const strategy =
+    (criteriaConfig?.evaluation_strategy as EvaluationStrategy | undefined) ??
+    "threshold";
+
+  switch (strategy) {
+    case "threshold":
+      return evaluateThreshold(progress as StandardProgress, criteriaConfig);
+    case "boolean":
+      return evaluateBoolean(progress as StandardProgress);
+    case "compound":
+      return evaluateCompound(progress as CompoundProgress);
+    default:
+      console.warn(
+        `Unknown evaluation strategy: "${strategy}" — falling back to threshold`,
+      );
+      return evaluateThreshold(progress as StandardProgress, criteriaConfig);
+  }
+}

--- a/lib/achievement-progress/unlock-rollback.ts
+++ b/lib/achievement-progress/unlock-rollback.ts
@@ -42,25 +42,11 @@ export async function performRollback(
     prevCascadeSnapshot,
   } = state;
 
-  // Fix P1: guard with appliedLevel so a concurrent advance is not reversed.
-  if (levelApplied && prevLevel !== null && appliedLevel !== null) {
-    const { error: lvlRevertErr } = await writeClient
-      .from("characters")
-      .update({ level: prevLevel })
-      .eq("id", characterId)
-      .eq("level", appliedLevel); // no-op if level changed again
-    if (lvlRevertErr) {
-      console.error(
-        "Critical: failed to revert level after reward failure:",
-        lvlRevertErr,
-      );
-    }
-  }
-
-  // Fix P1: revert rewards before clearing unlocked_at.
-  // If stats revert fails, leave unlocked_at set so the achievement is not
-  // treated as unlockable again — the character keeps the rewards they already
-  // have rather than being allowed to receive them a second time.
+  // Revert stats first. If stats revert fails (concurrent write changed xp/gold),
+  // we intentionally keep the rewards AND the level — reverting only the level
+  // would leave the character with high XP/gold at a low level, which is
+  // inconsistent. We also leave unlocked_at set so the achievement cannot be
+  // re-triggered for a duplicate reward payout.
   let statsReverted = true;
   if (statsApplied && capturedNewStats) {
     const { error: statsRevertErr } = await writeClient
@@ -81,6 +67,28 @@ export async function performRollback(
     }
   }
 
+  // Only revert level after stats are successfully reverted. If stats rollback
+  // was skipped (concurrent write), the character keeps rewards + level to stay
+  // consistent. The appliedLevel guard prevents clobbering a concurrent advance.
+  if (
+    statsReverted &&
+    levelApplied &&
+    prevLevel !== null &&
+    appliedLevel !== null
+  ) {
+    const { error: lvlRevertErr } = await writeClient
+      .from("characters")
+      .update({ level: prevLevel })
+      .eq("id", characterId)
+      .eq("level", appliedLevel); // no-op if level changed again
+    if (lvlRevertErr) {
+      console.error(
+        "Critical: failed to revert level after reward failure:",
+        lvlRevertErr,
+      );
+    }
+  }
+
   // Only clear unlocked_at after rewards are successfully reverted.
   if (statsReverted && lockedIds.length > 0) {
     const { error: revertError } = await writeClient
@@ -96,10 +104,12 @@ export async function performRollback(
     }
   }
 
-  // Fix P2: rows that existed before get upserted with their prior progress;
-  // rows that are brand-new (not in prevCascadeSnapshot) get deleted so no
-  // phantom achievement rows remain after a failed cascade rollback.
-  if (cascadeRows.length > 0) {
+  // Cascade progress rollback: only revert when stats were successfully rolled
+  // back. When stats rollback failed, the character keeps their rewards and
+  // unlocked achievements, so cascade progress (xp_earned, level_reached,
+  // compound) must also be preserved to stay consistent with the actual
+  // character state.
+  if (statsReverted && cascadeRows.length > 0) {
     const snapshotIds = new Set(
       prevCascadeSnapshot.map((p) => p.achievement_id),
     );

--- a/lib/achievement-progress/unlock-rollback.ts
+++ b/lib/achievement-progress/unlock-rollback.ts
@@ -1,0 +1,113 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database-generated";
+import type { AchievementProgressValue } from "./types";
+
+type CascadeRow = {
+  character_id: string;
+  achievement_id: string;
+  progress: AchievementProgressValue;
+};
+
+export type RollbackState = {
+  levelApplied: boolean;
+  prevLevel: number | null;
+  /** Fix P1: the level value we wrote; guards against clobbering concurrent advances. */
+  appliedLevel: number | null;
+  statsApplied: boolean;
+  /** Fix P1: post-increment stats snapshot for the conditional SET rollback. */
+  capturedNewStats: { xp: number; gold: number } | null;
+  totalXp: number;
+  totalGold: number;
+  lockedIds: string[];
+  cascadeRows: CascadeRow[];
+  /** Fix P2: pre-upsert snapshot so rollback restores prior values, not null. */
+  prevCascadeSnapshot: Array<{ achievement_id: string; progress: unknown }>;
+};
+
+export async function performRollback(
+  writeClient: SupabaseClient<Database>,
+  characterId: string,
+  state: RollbackState,
+): Promise<void> {
+  const {
+    levelApplied,
+    prevLevel,
+    appliedLevel,
+    statsApplied,
+    capturedNewStats,
+    totalXp,
+    totalGold,
+    lockedIds,
+    cascadeRows,
+    prevCascadeSnapshot,
+  } = state;
+
+  const { error: revertError } = await writeClient
+    .from("character_achievements")
+    .update({ unlocked_at: null })
+    .eq("character_id", characterId)
+    .in("achievement_id", lockedIds);
+  if (revertError) {
+    console.error(
+      "Critical: failed to revert unlock after reward failure:",
+      revertError,
+    );
+  }
+
+  // Fix P1: guard with appliedLevel so a concurrent advance is not reversed.
+  if (levelApplied && prevLevel !== null && appliedLevel !== null) {
+    const { error: lvlRevertErr } = await writeClient
+      .from("characters")
+      .update({ level: prevLevel })
+      .eq("id", characterId)
+      .eq("level", appliedLevel); // no-op if level changed again
+    if (lvlRevertErr) {
+      console.error(
+        "Critical: failed to revert level after reward failure:",
+        lvlRevertErr,
+      );
+    }
+  }
+
+  // Fix P1: conditional SET (not negative RPC increment) — no-op if values changed.
+  if (statsApplied && capturedNewStats) {
+    const { error: statsRevertErr } = await writeClient
+      .from("characters")
+      .update({
+        xp: capturedNewStats.xp - totalXp,
+        gold: capturedNewStats.gold - totalGold,
+      })
+      .eq("id", characterId)
+      .eq("xp", capturedNewStats.xp)
+      .eq("gold", capturedNewStats.gold);
+    if (statsRevertErr) {
+      console.error(
+        "Critical: failed to revert stats after reward failure:",
+        statsRevertErr,
+      );
+    }
+  }
+
+  // Fix P2: restore prior progress (null only for rows that didn't exist before).
+  if (cascadeRows.length > 0) {
+    const restoreRows = cascadeRows.map((r) => {
+      const prior = prevCascadeSnapshot.find(
+        (p) => p.achievement_id === r.achievement_id,
+      );
+      return {
+        character_id: characterId,
+        achievement_id: r.achievement_id,
+        progress: (prior?.progress ?? null) as AchievementProgressValue,
+      };
+    });
+    const { error: cascadeRevertErr } = await writeClient
+      .from("character_achievements")
+      .upsert(restoreRows, { onConflict: "character_id,achievement_id" });
+    if (cascadeRevertErr) {
+      console.error(
+        "Critical: failed to revert cascade progress after failure:",
+        cascadeRevertErr,
+      );
+    }
+  }
+}

--- a/lib/achievement-progress/unlock-rollback.ts
+++ b/lib/achievement-progress/unlock-rollback.ts
@@ -42,18 +42,6 @@ export async function performRollback(
     prevCascadeSnapshot,
   } = state;
 
-  const { error: revertError } = await writeClient
-    .from("character_achievements")
-    .update({ unlocked_at: null })
-    .eq("character_id", characterId)
-    .in("achievement_id", lockedIds);
-  if (revertError) {
-    console.error(
-      "Critical: failed to revert unlock after reward failure:",
-      revertError,
-    );
-  }
-
   // Fix P1: guard with appliedLevel so a concurrent advance is not reversed.
   if (levelApplied && prevLevel !== null && appliedLevel !== null) {
     const { error: lvlRevertErr } = await writeClient
@@ -69,7 +57,11 @@ export async function performRollback(
     }
   }
 
-  // Fix P1: conditional SET (not negative RPC increment) — no-op if values changed.
+  // Fix P1: revert rewards before clearing unlocked_at.
+  // If stats revert fails, leave unlocked_at set so the achievement is not
+  // treated as unlockable again — the character keeps the rewards they already
+  // have rather than being allowed to receive them a second time.
+  let statsReverted = true;
   if (statsApplied && capturedNewStats) {
     const { error: statsRevertErr } = await writeClient
       .from("characters")
@@ -81,6 +73,7 @@ export async function performRollback(
       .eq("xp", capturedNewStats.xp)
       .eq("gold", capturedNewStats.gold);
     if (statsRevertErr) {
+      statsReverted = false;
       console.error(
         "Critical: failed to revert stats after reward failure:",
         statsRevertErr,
@@ -88,26 +81,68 @@ export async function performRollback(
     }
   }
 
-  // Fix P2: restore prior progress (null only for rows that didn't exist before).
-  if (cascadeRows.length > 0) {
-    const restoreRows = cascadeRows.map((r) => {
-      const prior = prevCascadeSnapshot.find(
-        (p) => p.achievement_id === r.achievement_id,
-      );
-      return {
-        character_id: characterId,
-        achievement_id: r.achievement_id,
-        progress: (prior?.progress ?? null) as AchievementProgressValue,
-      };
-    });
-    const { error: cascadeRevertErr } = await writeClient
+  // Only clear unlocked_at after rewards are successfully reverted.
+  if (statsReverted && lockedIds.length > 0) {
+    const { error: revertError } = await writeClient
       .from("character_achievements")
-      .upsert(restoreRows, { onConflict: "character_id,achievement_id" });
-    if (cascadeRevertErr) {
+      .update({ unlocked_at: null })
+      .eq("character_id", characterId)
+      .in("achievement_id", lockedIds);
+    if (revertError) {
       console.error(
-        "Critical: failed to revert cascade progress after failure:",
-        cascadeRevertErr,
+        "Critical: failed to revert unlock after reward failure:",
+        revertError,
       );
+    }
+  }
+
+  // Fix P2: rows that existed before get upserted with their prior progress;
+  // rows that are brand-new (not in prevCascadeSnapshot) get deleted so no
+  // phantom achievement rows remain after a failed cascade rollback.
+  if (cascadeRows.length > 0) {
+    const snapshotIds = new Set(
+      prevCascadeSnapshot.map((p) => p.achievement_id),
+    );
+    const newIds = cascadeRows
+      .filter((r) => !snapshotIds.has(r.achievement_id))
+      .map((r) => r.achievement_id);
+    const restoreRows = cascadeRows
+      .filter((r) => snapshotIds.has(r.achievement_id))
+      .map((r) => {
+        const prior = prevCascadeSnapshot.find(
+          (p) => p.achievement_id === r.achievement_id,
+        )!;
+        return {
+          character_id: characterId,
+          achievement_id: r.achievement_id,
+          progress: prior.progress as AchievementProgressValue,
+        };
+      });
+
+    if (restoreRows.length > 0) {
+      const { error: cascadeRevertErr } = await writeClient
+        .from("character_achievements")
+        .upsert(restoreRows, { onConflict: "character_id,achievement_id" });
+      if (cascadeRevertErr) {
+        console.error(
+          "Critical: failed to revert cascade progress after failure:",
+          cascadeRevertErr,
+        );
+      }
+    }
+
+    if (newIds.length > 0) {
+      const { error: cascadeDeleteErr } = await writeClient
+        .from("character_achievements")
+        .delete()
+        .eq("character_id", characterId)
+        .in("achievement_id", newIds);
+      if (cascadeDeleteErr) {
+        console.error(
+          "Critical: failed to delete phantom cascade rows after failure:",
+          cascadeDeleteErr,
+        );
+      }
     }
   }
 }

--- a/lib/achievement-progress/unlock-rollback.ts
+++ b/lib/achievement-progress/unlock-rollback.ts
@@ -49,7 +49,7 @@ export async function performRollback(
   // re-triggered for a duplicate reward payout.
   let statsReverted = true;
   if (statsApplied && capturedNewStats) {
-    const { error: statsRevertErr } = await writeClient
+    const { data: revertedRows, error: statsRevertErr } = await writeClient
       .from("characters")
       .update({
         xp: capturedNewStats.xp - totalXp,
@@ -57,12 +57,23 @@ export async function performRollback(
       })
       .eq("id", characterId)
       .eq("xp", capturedNewStats.xp)
-      .eq("gold", capturedNewStats.gold);
+      .eq("gold", capturedNewStats.gold)
+      .select("id");
     if (statsRevertErr) {
       statsReverted = false;
       console.error(
         "Critical: failed to revert stats after reward failure:",
         statsRevertErr,
+      );
+    } else if (!revertedRows || revertedRows.length === 0) {
+      // PostgREST returns error: null even when zero rows matched the
+      // conditional UPDATE. A zero-row result means a concurrent write changed
+      // xp or gold, so the compensation was a no-op. Treat this as a failed
+      // rollback to avoid clearing unlocked_at (which would let the same
+      // achievement pay out again).
+      statsReverted = false;
+      console.error(
+        "Critical: stats revert matched zero rows (concurrent update); treating as failed rollback",
       );
     }
   }

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -1006,6 +1006,10 @@ export type Database = {
         };
         Returns: Json;
       };
+      fn_increment_character_stats: {
+        Args: { p_character_id: string; p_xp: number; p_gold: number };
+        Returns: { xp: number; gold: number; level: number }[];
+      };
       fn_change_character_class: {
         Args: { p_character_id: string; p_new_class: string };
         Returns: {

--- a/openspec/changes/achievement-unlock-evaluation-engine/.openspec.yaml
+++ b/openspec/changes/achievement-unlock-evaluation-engine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/achievement-unlock-evaluation-engine/design.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/design.md
@@ -1,0 +1,268 @@
+# Achievement Unlock Evaluation Engine — Design
+
+## Context
+
+The achievement system has two layers already built:
+
+1. **Schema** (#134, closed): `achievements`,
+   `achievement_categories`, and `character_achievements`
+   tables with `unlocked_at`, `progress` JSONB, and
+   `xp_reward`/`gold_reward` columns on `achievements`.
+2. **Progress tracking** (#135): `AchievementProgressService`
+   computes `{ current, threshold }` progress and upserts
+   into `character_achievements`. It already has evaluators
+   for all 13 criteria types, backfill detection, and
+   integration hooks in quest approval, boss completion,
+   and reward approval flows.
+
+What's missing: after progress is written, nothing checks
+whether `current >= threshold` and sets `unlocked_at` or
+grants rewards. The evaluation engine fills this gap.
+
+The existing `updateProgress` flow writes progress via a
+batch upsert that deliberately omits `unlocked_at` to avoid
+overwriting it. The engine must operate _after_ that upsert
+completes, inspecting the freshly-written progress to decide
+which achievements should unlock.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect when an achievement's criteria are met and set
+  `unlocked_at` on the `character_achievements` row
+- Support threshold (`current >= N`), boolean
+  (`current > 0`, truthy), and compound (AND/OR over multiple
+  sub-conditions) evaluation strategies
+- Grant `xp_reward` and `gold_reward` to the character's
+  stats atomically with the unlock
+- Be idempotent: re-evaluating an already-unlocked
+  achievement must be a no-op (no duplicate rewards)
+- Support retroactive evaluation during backfill
+- Integrate into the existing `updateProgress` call so
+  no callers need to change
+
+**Non-Goals:**
+
+- Notification delivery (#137 handles this via Realtime
+  subscriptions on `unlocked_at` changes)
+- Family-wide achievements (#140 — separate aggregation)
+- Admin UI for creating/editing achievements (#139)
+- New API routes or endpoints
+
+## Decisions
+
+### 1. Inline evaluation in `updateProgress`
+
+**Decision:** Add unlock evaluation as a post-step inside
+`AchievementProgressService.updateProgress()`, not as a
+separate service class.
+
+**Why:** The progress service already has the character
+context, achievement list, and freshly-computed progress.
+Splitting into a separate `AchievementEvaluator` class
+would require passing all this context through or
+re-fetching it. The engine is pure logic (compare values,
+decide unlock) — it doesn't warrant its own service
+lifecycle.
+
+**Alternative considered:** Separate `AchievementEvaluator`
+class instantiated by the progress service. Rejected
+because it adds indirection without meaningful separation
+of concerns — the evaluator needs the same DB client and
+the same achievement data the progress service already
+holds.
+
+**Implementation:** After the progress upsert succeeds,
+iterate the upserted rows. For each row, apply the
+appropriate strategy (threshold: `current >= threshold`,
+boolean: `current > 0`, compound: combined check). If
+criteria are met and the row was not already unlocked,
+mark it for unlock.
+
+### 2. Evaluation strategy dispatch
+
+**Decision:** Use a strategy map keyed by a new
+`evaluation_strategy` field derived from
+`criteria_config`, defaulting to `"threshold"`.
+
+**Why:** All 42 seeded achievements today use simple
+threshold comparison (`current >= threshold`). Some
+achievements are inherently boolean ("Change your class",
+"Earn any honor") where the question is "did it happen?"
+rather than "did it reach N?". Compound is needed for
+future achievements like "Complete 5 quests AND reach
+level 3". Keeping a strategy map makes intent explicit
+and the system extensible.
+
+**Strategies:**
+
+- **threshold**: `current >= threshold`. Default for
+  achievements with a numeric target. Used by the
+  majority of seeded achievements.
+- **boolean**: `current > 0` (truthy). For achievements
+  where the criteria is simply "did this happen at
+  least once?" — e.g., class changes, first quest
+  completion. No threshold value needed in
+  `criteria_config`; the evaluator result is treated
+  as truthy/falsy.
+- **compound**: `criteria_config` contains a `conditions`
+  array and an `operator` field (`"AND"` or `"OR"`).
+  Each condition references a `criteria_type` +
+  `threshold` (or `boolean: true`). The engine evaluates
+  each sub-condition independently and combines results.
+
+**Alternative considered:** Treating compound as a
+separate achievement type with its own table. Rejected —
+JSONB `criteria_config` already supports arbitrary
+structure, and compound achievements are a presentation
+over existing evaluator functions.
+
+### 3. Reward granting via separate update
+
+**Decision:** Grant XP and gold via a direct
+`characters` table update after setting `unlocked_at`,
+using the service-role write client.
+
+**Why:** Supabase JS client doesn't support multi-table
+transactions. We can't atomically set `unlocked_at` AND
+update `characters.xp`/`characters.gold` in one call.
+Instead, we rely on idempotency: if `unlocked_at` is
+already set, rewards are never re-granted.
+
+**Sequence:**
+
+1. Filter upserted progress to find newly-met criteria
+   (where criteria are satisfied per strategy and
+   `unlocked_at` IS NULL on the existing row)
+2. Set `unlocked_at = now()` on those rows
+3. Sum `xp_reward` and `gold_reward` across all
+   newly-unlocked achievements
+4. Fetch character's current XP/level, call
+   `RewardCalculator.calculateLevelUp()` with the
+   summed XP reward to determine if a level-up occurs
+5. Increment `characters.xp` and `characters.gold`
+   (and `characters.level` if level-up) via a single
+   update
+6. If level changed, re-evaluate `level_reached`
+   criteria to cascade-unlock level-based achievements
+
+**Idempotency guarantee:** Step 1 checks `unlocked_at IS
+NULL`. If a retry hits after step 2 but before step 4
+(partial failure), the next call sees `unlocked_at`
+already set and skips those achievements. The character
+may miss the reward in this edge case. To handle it, the
+retroactive evaluation path can detect "unlocked but
+stats not updated" by comparing expected vs actual
+rewards. For v0.8.0, this edge case is acceptable —
+it requires a crash between two sequential DB calls.
+
+**Alternative considered:** Using a Postgres function
+(RPC) to atomically unlock + grant rewards. Better
+atomicity, but adds migration complexity and moves logic
+into SQL. Can be adopted later if the edge case proves
+problematic.
+
+### 4. Compound evaluation via sub-evaluator reuse
+
+**Decision:** Compound achievements reuse the existing
+`EVALUATOR_REGISTRY` functions for each sub-condition.
+
+**Why:** The evaluator functions are already pure and
+tested. A compound condition like
+`{ operator: "AND", conditions: [
+  { criteria_type: "quest_complete", threshold: 5 },
+  { criteria_type: "level_reached", threshold: 3 }
+] }`
+just runs each sub-evaluator and combines results.
+
+**Progress shape for compound:** The progress JSONB
+stores individual sub-condition progress plus an overall
+met/not-met flag:
+
+```json
+{
+  "conditions": [
+    { "criteria_type": "quest_complete",
+      "current": 7, "threshold": 5, "met": true }
+  ],
+  "met": true
+}
+```
+
+The `met` field at the top level determines unlock.
+
+### 5. Fetch achievement rewards in progress flow
+
+**Decision:** Expand the `fetchAchievements` query to
+also select `xp_reward`, `gold_reward`, and `name` so
+the evaluation step has everything it needs without an
+additional query.
+
+**Why:** One extra SELECT column in an already-required
+query is far cheaper than a separate fetch. The reward
+values are small integers that add negligible payload.
+
+### 6. Retroactive unlock during backfill
+
+**Decision:** When backfill runs (first `updateProgress`
+call for a character), the evaluation engine runs against
+all backfilled progress in the same call. No separate
+"retroactive scan" endpoint.
+
+**Why:** The backfill already computes progress for all
+13 criteria types. Running unlock evaluation on those
+results is trivial — just the same threshold check. A
+separate admin endpoint adds API surface with no benefit
+since backfill already handles it.
+
+## Risks / Trade-offs
+
+**[Non-atomic reward granting]** →
+Character stats update is a separate DB call from
+`unlocked_at` write. Mitigation: idempotency via
+`unlocked_at IS NULL` check. Edge case of missed rewards
+on crash is acceptable for v0.8.0; can upgrade to RPC
+later.
+
+**[Compound evaluation DB cost]** →
+A compound achievement with N sub-conditions runs N
+evaluator queries. Mitigation: compound achievements are
+expected to be rare (< 5 in the initial set). If they
+grow, we can cache sub-evaluator results within a single
+`updateProgress` call since the same criteria types are
+often evaluated for multiple achievements already.
+
+**[Reward inflation from retroactive unlocks]** →
+A character who has been playing for weeks gets a burst
+of XP/gold when backfill runs. Mitigation: this is
+intentional — they earned it. The XP/gold amounts on
+achievements are modest (tuned as "bonus" not "primary
+income"). If needed, rewards can be capped or flagged
+as retroactive.
+
+**[Notification timing for bulk unlocks]** →
+Retroactive backfill may unlock many achievements at
+once, each writing `unlocked_at`. The notification
+system (#137) will see a burst of Realtime events.
+Mitigation: #137's design should include queuing
+(sequential display of toasts). This is out of scope
+for the evaluation engine.
+
+## Resolved Questions
+
+- **Level-up from XP rewards:** The engine SHALL apply
+  level-ups when granted XP pushes a character past a
+  level threshold. `RewardCalculator.calculateLevelUp()`
+  already exists as pure logic in `lib/reward-calculator.ts`
+  and is used by quest approval. After granting XP, the
+  engine calls `calculateLevelUp` with the character's
+  current XP, the granted XP, and current level. If a
+  level-up occurs, the engine updates `characters.level`
+  in the same stats update that writes XP/gold, then
+  re-evaluates `level_reached` criteria so level-based
+  achievements can cascade-unlock in the same call.
+- **Compound achievement seeding:** This change will
+  include 2 example compound achievements to prove the
+  strategy works. Admin UI for creating more is deferred
+  to #139.

--- a/openspec/changes/achievement-unlock-evaluation-engine/proposal.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/proposal.md
@@ -1,0 +1,80 @@
+# Achievement Unlock Evaluation Engine
+
+## Why
+
+The achievement progress tracking service (#135) computes
+and persists how far a character is toward each achievement,
+but nothing in the system actually _unlocks_ achievements
+when criteria are met. Without an evaluation engine, progress
+values accumulate silently — characters never receive their
+badges, XP rewards, or gold rewards. This engine is the
+missing link that turns tracked progress into tangible
+unlocks, and it's a prerequisite for the notification system
+(#137) and family achievements (#140) downstream in v0.8.0.
+
+## What Changes
+
+- Add an `AchievementEvaluator` that inspects progress
+  against `criteria_config` thresholds after each progress
+  update and determines unlock eligibility
+- Support three evaluation strategies: **threshold**
+  (current >= N), **boolean** (current is truthy), and
+  **compound** (multiple conditions combined with AND/OR
+  logic)
+- On unlock: insert `unlocked_at` timestamp into
+  `character_achievements` and award `xp_reward` /
+  `gold_reward` defined on the achievement to the
+  character's stats
+- Guarantee idempotent evaluation — re-evaluating an
+  already-unlocked achievement is a no-op (no duplicate
+  rewards, no duplicate unlocks)
+- Support retroactive evaluation — scan a character's
+  existing progress to grant any achievements they already
+  qualify for but haven't been awarded
+- Integrate evaluation into the existing
+  `AchievementProgressService.updateProgress()` flow so
+  unlocks happen automatically after progress is written
+
+## Capabilities
+
+### New Capabilities
+
+- `achievement-unlock-evaluation`: Core evaluation engine
+  that compares progress against criteria thresholds,
+  supports threshold/boolean/compound strategies, triggers
+  unlocks, and grants XP/gold rewards. Covers idempotent
+  unlock guarantees and retroactive evaluation.
+
+### Modified Capabilities
+
+- `achievement-progress`: The progress service's
+  `updateProgress` method must invoke the evaluation engine
+  after writing progress, so that unlocks are detected in
+  the same call. This is a requirement-level change to the
+  service's contract — callers currently expect
+  progress-only behavior, and after this change, unlocks
+  and reward grants will also occur.
+
+## Impact
+
+- **Code**: `lib/achievement-progress-service.ts` gains
+  evaluation + unlock + reward-granting logic (or delegates
+  to a new evaluator module). Character `xp` and `gold`
+  columns are updated on unlock.
+- **Database**: Writes to `character_achievements.unlocked_at`
+  on unlock. Writes to `characters.xp` and `characters.gold`
+  for rewards. No new tables or migrations required — the
+  schema from #134 already supports this.
+- **APIs**: No new API routes. Evaluation is triggered
+  internally by the progress service, which is already
+  integrated into quest approval, boss completion, and
+  reward approval flows.
+- **Dependencies**: Depends on #134 (schema, closed) and
+  #135 (progress tracking, in progress). Downstream
+  consumers: #137 (notifications subscribe to `unlocked_at`
+  changes via Realtime), #140 (family achievements build on
+  per-character unlock state).
+- **Risks**: Reward granting must be atomic with the unlock
+  write to prevent double-rewarding on retry. Compound
+  evaluation strategy adds complexity — needs thorough test
+  coverage for AND/OR combinations and edge cases.

--- a/openspec/changes/achievement-unlock-evaluation-engine/specs/achievement-progress/spec.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/specs/achievement-progress/spec.md
@@ -1,0 +1,175 @@
+# achievement-progress Delta Specification
+
+## Purpose
+
+Modify the `updateProgress` method to invoke the
+unlock evaluation engine after writing progress, and
+expand the achievements query to include reward fields.
+
+## MODIFIED Requirements
+
+### Requirement: updateProgress method
+
+The `updateProgress` method SHALL accept a
+`characterId` (string) and an event object containing
+`type` (the triggering event type) and optional
+metadata. It SHALL resolve the character's `user_id`
+and the owning user's `family_id` from the
+`characters` and `user_profiles` tables, fetch all
+visible achievements (global plus matching
+family-scoped rows) from the `achievements` table,
+run the appropriate evaluators, upsert results into
+`character_achievements`, and then invoke the unlock
+evaluation engine to detect and process any newly-met
+achievement criteria.
+
+#### Scenario: Progress updated after quest approval
+
+- **WHEN** `updateProgress` is called with a
+  `characterId` and event type `QUEST_APPROVED`
+- **THEN** it SHALL evaluate all quest-related criteria
+  (`quest_complete`, `quest_volunteer`,
+  `quest_difficulty`) plus `gold_earned`, `xp_earned`,
+  `level_reached`, and `streak_reached` for that
+  character
+- **AND** it SHALL run unlock evaluation against the
+  upserted progress
+
+#### Scenario: Progress updated after reward approval
+
+- **WHEN** `updateProgress` is called with a
+  `characterId` and event type `REWARD_APPROVED`
+- **THEN** it SHALL evaluate `gold_spent` and
+  `reward_redeemed` criteria for that character
+- **AND** it SHALL run unlock evaluation against the
+  upserted progress
+
+#### Scenario: Progress updated after boss completion
+
+- **WHEN** `updateProgress` is called with a
+  `characterId` and event type `BOSS_COMPLETED`
+- **THEN** it SHALL evaluate `boss_defeated`,
+  `boss_participated`, `gold_earned`, `xp_earned`,
+  and `level_reached` criteria for that character
+- **AND** it SHALL run unlock evaluation against the
+  upserted progress
+
+#### Scenario: Progress updated after class change
+
+- **WHEN** `updateProgress` is called with a
+  `characterId` and event type `CLASS_CHANGED`
+- **THEN** it SHALL evaluate `class_change` criteria
+  for that character
+- **AND** it SHALL run unlock evaluation against the
+  upserted progress
+
+#### Scenario: Invalid character ID
+
+- **WHEN** `updateProgress` is called with a
+  `characterId` that does not exist in `characters`
+- **THEN** it SHALL throw an error and not modify any
+  `character_achievements` rows
+
+#### Scenario: Unlock evaluation failure is non-blocking
+
+- **WHEN** the unlock evaluation engine throws an
+  error after progress has been successfully upserted
+- **THEN** the progress upsert SHALL persist and the
+  error SHALL be logged but SHALL NOT cause
+  `updateProgress` to throw
+
+### Requirement: Retroactive backfill on first evaluation
+
+On the first `updateProgress` call for a character
+(detected by absence of any `character_achievements`
+rows for that character), the service SHALL run all
+13 evaluators to backfill progress from existing
+database state. The full set of backfill upserts
+SHALL be written in a single batch upsert call so
+that the operation is atomic — either all rows are
+written or none are. After the backfill upsert, the
+unlock evaluation engine SHALL run against all
+backfilled progress to retroactively unlock and
+reward any achievements whose criteria are already
+met. Subsequent calls SHALL run only the evaluators
+mapped to the triggering event type.
+
+#### Scenario: First evaluation triggers full backfill
+
+- **WHEN** `updateProgress` is called for a character
+  with zero `character_achievements` rows
+- **THEN** the service SHALL evaluate all 13 criteria
+  types and upsert progress for every achievement in
+  a single batch upsert
+- **AND** the unlock evaluation engine SHALL run
+  against all backfilled progress
+
+#### Scenario: Partial backfill failure leaves no rows
+
+- **WHEN** the batch upsert during backfill fails
+- **THEN** no `character_achievements` rows SHALL be
+  written for that character, and the next
+  `updateProgress` call SHALL retry the full backfill
+
+#### Scenario: Subsequent evaluation is scoped
+
+- **WHEN** `updateProgress` is called for a character
+  that already has `character_achievements` rows
+- **THEN** the service SHALL evaluate only the
+  criteria types mapped to the event type
+- **AND** unlock evaluation SHALL run only against
+  the scoped progress results
+
+## ADDED Requirements
+
+### Requirement: Expanded achievements query
+
+The `fetchAchievements` method within `updateProgress`
+SHALL select `xp_reward`, `gold_reward`, and `name`
+in addition to the existing `id`, `criteria_type`, and
+`criteria_config` columns. These fields are required
+by the unlock evaluation engine for reward granting
+and logging.
+
+#### Scenario: Query includes reward columns
+
+- **WHEN** `fetchAchievements` is called
+- **THEN** the returned rows SHALL include `id`,
+  `name`, `criteria_type`, `criteria_config`,
+  `xp_reward`, and `gold_reward` fields
+
+#### Scenario: Reward values are accessible
+
+- **WHEN** the unlock evaluation engine processes an
+  achievement from the fetched list
+- **THEN** it SHALL have access to `xp_reward` and
+  `gold_reward` without an additional query
+
+### Requirement: Compound criteria type in evaluator registry
+
+The evaluator registry SHALL include an entry for the
+`compound` criteria type. The compound evaluator SHALL
+NOT perform a database query itself; instead it SHALL
+delegate to the sub-condition evaluators referenced in
+`criteria_config.conditions` and return a composite
+result. The compound evaluator SHALL be included in
+`ALL_CRITERIA_TYPES`.
+
+#### Scenario: Compound criteria type is registered
+
+- **WHEN** the evaluator registry is inspected
+- **THEN** it SHALL contain an entry for `"compound"`
+
+#### Scenario: Compound evaluator delegates to sub-evaluators
+
+- **WHEN** the compound evaluator is called with a
+  `criteria_config` containing two conditions
+- **THEN** it SHALL call the registered evaluator for
+  each sub-condition's `criteria_type`
+
+#### Scenario: Unknown sub-condition criteria type
+
+- **WHEN** a compound condition references a
+  `criteria_type` not in the registry
+- **THEN** the compound evaluator SHALL log a warning
+  and treat that sub-condition as not met

--- a/openspec/changes/achievement-unlock-evaluation-engine/specs/achievement-progress/spec.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/specs/achievement-progress/spec.md
@@ -78,26 +78,43 @@ achievement criteria.
   error SHALL be logged but SHALL NOT cause
   `updateProgress` to throw
 
-### Requirement: Retroactive backfill on first evaluation
+### Requirement: Retroactive backfill on missing rows
 
-On the first `updateProgress` call for a character
-(detected by absence of any `character_achievements`
-rows for that character), the service SHALL run all
-13 evaluators to backfill progress from existing
-database state. The full set of backfill upserts
+Whenever `updateProgress` is called for a character
+and any achievement lacks a corresponding
+`character_achievements` row for that character, the
+service SHALL run all 13 evaluators to backfill
+progress from existing database state. This covers
+two cases: (1) the first evaluation for a character
+who has no rows yet, and (2) post-deployment cases
+where new achievements are added after a character's
+initial backfill. The full set of backfill upserts
 SHALL be written in a single batch upsert call so
 that the operation is atomic — either all rows are
 written or none are. After the backfill upsert, the
 unlock evaluation engine SHALL run against all
 backfilled progress to retroactively unlock and
 reward any achievements whose criteria are already
-met. Subsequent calls SHALL run only the evaluators
-mapped to the triggering event type.
+met. Subsequent calls WHERE all achievements have
+rows SHALL run only the evaluators mapped to the
+triggering event type.
 
 #### Scenario: First evaluation triggers full backfill
 
 - **WHEN** `updateProgress` is called for a character
   with zero `character_achievements` rows
+- **THEN** the service SHALL evaluate all 13 criteria
+  types and upsert progress for every achievement in
+  a single batch upsert
+- **AND** the unlock evaluation engine SHALL run
+  against all backfilled progress
+
+#### Scenario: New achievements trigger partial backfill
+
+- **WHEN** `updateProgress` is called for a character
+  that has some `character_achievements` rows but
+  is missing rows for one or more achievements
+  (e.g., new achievements added post-deployment)
 - **THEN** the service SHALL evaluate all 13 criteria
   types and upsert progress for every achievement in
   a single batch upsert
@@ -114,7 +131,8 @@ mapped to the triggering event type.
 #### Scenario: Subsequent evaluation is scoped
 
 - **WHEN** `updateProgress` is called for a character
-  that already has `character_achievements` rows
+  that already has `character_achievements` rows for
+  every achievement
 - **THEN** the service SHALL evaluate only the
   criteria types mapped to the event type
 - **AND** unlock evaluation SHALL run only against

--- a/openspec/changes/achievement-unlock-evaluation-engine/specs/achievement-unlock-evaluation/spec.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/specs/achievement-unlock-evaluation/spec.md
@@ -1,0 +1,492 @@
+# achievement-unlock-evaluation Specification
+
+## Purpose
+
+Define the evaluation engine that determines when an
+achievement's criteria are met, triggers the unlock by
+setting `unlocked_at`, and grants XP/gold rewards to
+the character.
+
+## ADDED Requirements
+
+### Requirement: Evaluation strategy dispatch
+
+The engine SHALL support three evaluation strategies:
+`threshold`, `boolean`, and `compound`. The strategy
+SHALL be determined by the `evaluation_strategy` field
+in `criteria_config`, defaulting to `"threshold"` when
+absent.
+
+#### Scenario: Default strategy is threshold
+
+- **WHEN** an achievement has no `evaluation_strategy`
+  field in `criteria_config`
+- **THEN** the engine SHALL use the `threshold`
+  strategy
+
+#### Scenario: Explicit threshold strategy
+
+- **WHEN** an achievement has
+  `criteria_config.evaluation_strategy` set to
+  `"threshold"`
+- **THEN** the engine SHALL use the `threshold`
+  strategy
+
+#### Scenario: Boolean strategy
+
+- **WHEN** an achievement has
+  `criteria_config.evaluation_strategy` set to
+  `"boolean"`
+- **THEN** the engine SHALL use the `boolean` strategy
+
+#### Scenario: Compound strategy
+
+- **WHEN** an achievement has
+  `criteria_config.evaluation_strategy` set to
+  `"compound"`
+- **THEN** the engine SHALL use the `compound` strategy
+
+#### Scenario: Unknown strategy falls back to threshold
+
+- **WHEN** an achievement has an unrecognized
+  `evaluation_strategy` value
+- **THEN** the engine SHALL fall back to the
+  `threshold` strategy and log a warning
+
+### Requirement: Threshold evaluation
+
+The threshold strategy SHALL compare the evaluator's
+`current` value against the `threshold` value from
+`criteria_config`. The achievement is met when
+`current >= threshold`.
+
+#### Scenario: Criteria met exactly at threshold
+
+- **WHEN** an evaluator returns `{ current: 10 }` and
+  the achievement has
+  `criteria_config: { "threshold": 10 }`
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: Criteria met above threshold
+
+- **WHEN** an evaluator returns `{ current: 15 }` and
+  the achievement has
+  `criteria_config: { "threshold": 10 }`
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: Criteria not met below threshold
+
+- **WHEN** an evaluator returns `{ current: 7 }` and
+  the achievement has
+  `criteria_config: { "threshold": 10 }`
+- **THEN** the engine SHALL determine the criteria are
+  NOT met
+
+#### Scenario: Zero threshold is always met
+
+- **WHEN** an achievement has
+  `criteria_config: { "threshold": 0 }` and the
+  evaluator returns `{ current: 0 }`
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+### Requirement: Boolean evaluation
+
+The boolean strategy SHALL check whether the
+evaluator's `current` value is truthy (`current > 0`).
+No `threshold` field is required in `criteria_config`.
+
+#### Scenario: Boolean criteria met with positive value
+
+- **WHEN** an evaluator returns `{ current: 1 }` for
+  a boolean-strategy achievement
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: Boolean criteria met with large value
+
+- **WHEN** an evaluator returns `{ current: 5 }` for
+  a boolean-strategy achievement
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: Boolean criteria not met with zero
+
+- **WHEN** an evaluator returns `{ current: 0 }` for
+  a boolean-strategy achievement
+- **THEN** the engine SHALL determine the criteria are
+  NOT met
+
+### Requirement: Compound evaluation
+
+The compound strategy SHALL evaluate multiple
+sub-conditions and combine them using the `operator`
+field in `criteria_config` (`"AND"` or `"OR"`). Each
+sub-condition in the `conditions` array SHALL reference
+a `criteria_type` and either a `threshold` (numeric
+comparison) or `boolean: true` (truthy check). The
+engine SHALL reuse the existing `EVALUATOR_REGISTRY`
+functions to evaluate each sub-condition.
+
+#### Scenario: AND compound with all conditions met
+
+- **WHEN** a compound achievement has
+  `operator: "AND"` with conditions
+  `[{ criteria_type: "quest_complete", threshold: 5 },
+  { criteria_type: "level_reached", threshold: 3 }]`
+  and the evaluators return `{ current: 7 }` and
+  `{ current: 4 }` respectively
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: AND compound with one condition unmet
+
+- **WHEN** a compound achievement has
+  `operator: "AND"` with conditions
+  `[{ criteria_type: "quest_complete", threshold: 5 },
+  { criteria_type: "level_reached", threshold: 3 }]`
+  and the evaluators return `{ current: 7 }` and
+  `{ current: 2 }` respectively
+- **THEN** the engine SHALL determine the criteria are
+  NOT met
+
+#### Scenario: OR compound with one condition met
+
+- **WHEN** a compound achievement has
+  `operator: "OR"` with conditions
+  `[{ criteria_type: "quest_complete", threshold: 10 },
+  { criteria_type: "boss_defeated", threshold: 3 }]`
+  and the evaluators return `{ current: 2 }` and
+  `{ current: 5 }` respectively
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: OR compound with no conditions met
+
+- **WHEN** a compound achievement has
+  `operator: "OR"` with conditions
+  `[{ criteria_type: "quest_complete", threshold: 10 },
+  { criteria_type: "boss_defeated", threshold: 3 }]`
+  and the evaluators return `{ current: 2 }` and
+  `{ current: 1 }` respectively
+- **THEN** the engine SHALL determine the criteria are
+  NOT met
+
+#### Scenario: Compound with boolean sub-condition
+
+- **WHEN** a compound achievement has
+  `operator: "AND"` with conditions
+  `[{ criteria_type: "quest_complete", threshold: 5 },
+  { criteria_type: "class_change", boolean: true }]`
+  and the evaluators return `{ current: 7 }` and
+  `{ current: 1 }` respectively
+- **THEN** the engine SHALL determine the criteria are
+  met
+
+#### Scenario: Default operator is AND
+
+- **WHEN** a compound achievement has no `operator`
+  field in `criteria_config`
+- **THEN** the engine SHALL default to `"AND"`
+
+### Requirement: Compound progress JSONB shape
+
+For compound achievements, the progress upsert SHALL
+write a JSONB object containing a `conditions` array
+(with each sub-condition's `criteria_type`, `current`,
+`threshold`, and `met` status) and a top-level `met`
+boolean indicating overall result.
+
+#### Scenario: Compound progress with mixed results
+
+- **WHEN** a compound AND achievement has two
+  conditions where quest_complete (current: 7,
+  threshold: 5) is met and level_reached (current: 2,
+  threshold: 3) is not met
+- **THEN** the upserted progress SHALL be
+  `{ "conditions": [{ "criteria_type":
+  "quest_complete", "current": 7, "threshold": 5,
+  "met": true }, { "criteria_type": "level_reached",
+  "current": 2, "threshold": 3, "met": false }],
+  "met": false }`
+
+#### Scenario: Compound progress when all met
+
+- **WHEN** all sub-conditions of a compound AND
+  achievement are met
+- **THEN** the progress SHALL have `"met": true` at
+  the top level and each condition SHALL have
+  `"met": true`
+
+### Requirement: Unlock detection
+
+After the progress upsert completes, the engine SHALL
+identify achievements that are newly eligible for
+unlock. An achievement is newly eligible when: (1) the
+evaluation strategy determines criteria are met, AND
+(2) the `unlocked_at` column on the existing
+`character_achievements` row is NULL.
+
+#### Scenario: Newly met threshold achievement
+
+- **WHEN** progress is upserted with
+  `{ current: 10, threshold: 10 }` and the existing
+  row has `unlocked_at` IS NULL
+- **THEN** the engine SHALL mark this achievement for
+  unlock
+
+#### Scenario: Already unlocked achievement is skipped
+
+- **WHEN** progress is upserted with
+  `{ current: 15, threshold: 10 }` and the existing
+  row has `unlocked_at` already set
+- **THEN** the engine SHALL NOT re-unlock or re-grant
+  rewards for this achievement
+
+#### Scenario: Progress below threshold is not unlocked
+
+- **WHEN** progress is upserted with
+  `{ current: 7, threshold: 10 }` and `unlocked_at`
+  IS NULL
+- **THEN** the engine SHALL NOT unlock this achievement
+
+#### Scenario: Compound achievement unlock via met flag
+
+- **WHEN** a compound achievement's progress has
+  `"met": true` at the top level and `unlocked_at`
+  IS NULL
+- **THEN** the engine SHALL mark this achievement for
+  unlock
+
+### Requirement: Set unlocked_at on unlock
+
+For each newly-eligible achievement, the engine SHALL
+update the `character_achievements` row to set
+`unlocked_at` to the current timestamp. The update
+SHALL use the service-role write client and SHALL
+filter on `unlocked_at IS NULL` to prevent race
+conditions.
+
+#### Scenario: unlocked_at is set on unlock
+
+- **WHEN** an achievement is newly eligible for unlock
+- **THEN** the engine SHALL update the
+  `character_achievements` row with
+  `unlocked_at = now()`
+
+#### Scenario: Concurrent unlock attempts are safe
+
+- **WHEN** two concurrent `updateProgress` calls both
+  detect the same achievement as eligible
+- **THEN** only one SHALL set `unlocked_at` (the
+  `IS NULL` filter prevents the second from matching)
+  and rewards SHALL be granted only once
+
+### Requirement: Grant XP and gold rewards on unlock
+
+After setting `unlocked_at`, the engine SHALL sum
+`xp_reward` and `gold_reward` across all
+newly-unlocked achievements in the current evaluation
+and increment the character's `xp` and `gold` columns
+via a single `characters` table update using the
+service-role write client.
+
+#### Scenario: Single achievement rewards granted
+
+- **WHEN** one achievement with `xp_reward: 50` and
+  `gold_reward: 25` is unlocked
+- **THEN** the engine SHALL increment the character's
+  `xp` by 50 and `gold` by 25
+
+#### Scenario: Multiple achievements rewards summed
+
+- **WHEN** three achievements are unlocked in a single
+  evaluation with total `xp_reward: 150` and
+  `gold_reward: 75`
+- **THEN** the engine SHALL increment the character's
+  `xp` by 150 and `gold` by 75 in a single update
+
+#### Scenario: Zero rewards are not written
+
+- **WHEN** newly-unlocked achievements all have
+  `xp_reward: 0` and `gold_reward: 0`
+- **THEN** the engine SHALL skip the character stats
+  update
+
+#### Scenario: Rewards are not granted on re-evaluation
+
+- **WHEN** `updateProgress` is called again for a
+  character who already has `unlocked_at` set on all
+  eligible achievements
+- **THEN** no rewards SHALL be granted and no
+  character stats update SHALL occur
+
+### Requirement: Level-up from XP rewards
+
+After granting XP rewards, the engine SHALL call
+`RewardCalculator.calculateLevelUp()` with the
+character's current XP, the granted XP total, and
+current level. If a level-up occurs, the engine SHALL
+include the new level in the same `characters` table
+update that writes XP and gold.
+
+#### Scenario: XP reward triggers level-up
+
+- **WHEN** a character at level 3 with 140 XP unlocks
+  an achievement granting 60 XP, and level 4 requires
+  200 XP total (per `RewardCalculator`)
+- **THEN** the engine SHALL update `characters.level`
+  to 4 in the same update that increments XP and gold
+
+#### Scenario: XP reward does not trigger level-up
+
+- **WHEN** a character at level 3 with 100 XP unlocks
+  an achievement granting 10 XP, and level 4 requires
+  200 XP total
+- **THEN** the engine SHALL NOT modify
+  `characters.level`
+
+#### Scenario: Level-up cascades to level achievements
+
+- **WHEN** granting XP causes a level-up from level 4
+  to level 5
+- **THEN** the engine SHALL re-evaluate
+  `level_reached` criteria after the stats update so
+  that level-based achievements can cascade-unlock in
+  the same call
+
+### Requirement: Idempotent unlock evaluation
+
+Calling the evaluation engine multiple times for the
+same character and event SHALL NOT produce duplicate
+unlocks or duplicate reward grants. The engine relies
+on `unlocked_at IS NULL` as the guard: once set,
+subsequent evaluations skip that achievement entirely.
+
+#### Scenario: Duplicate evaluation produces no change
+
+- **WHEN** `updateProgress` is called twice with the
+  same character and event, and the first call
+  unlocked an achievement
+- **THEN** the second call SHALL not re-set
+  `unlocked_at` and SHALL NOT grant additional rewards
+
+#### Scenario: Idempotent after partial failure
+
+- **WHEN** the first call set `unlocked_at` but
+  failed before granting rewards (crash between DB
+  calls)
+- **THEN** the next call SHALL see `unlocked_at`
+  already set and SHALL NOT grant rewards (acceptable
+  edge case for v0.8.0)
+
+### Requirement: Retroactive unlock during backfill
+
+When the progress service performs a full backfill
+(first `updateProgress` call for a character), the
+evaluation engine SHALL run against all backfilled
+progress results. Any achievements whose criteria are
+already met SHALL be unlocked and rewarded in the same
+call.
+
+#### Scenario: Backfill unlocks qualifying achievements
+
+- **WHEN** a character's first `updateProgress` call
+  triggers full backfill and 5 of 42 achievements
+  have criteria already met
+- **THEN** those 5 achievements SHALL have
+  `unlocked_at` set and their combined XP/gold
+  rewards SHALL be granted
+
+#### Scenario: Backfill with no qualifying achievements
+
+- **WHEN** a character's first `updateProgress` call
+  triggers full backfill and no achievements have
+  criteria met
+- **THEN** no achievements SHALL be unlocked and no
+  rewards SHALL be granted
+
+### Requirement: Fetch achievement rewards in query
+
+The `fetchAchievements` query within `updateProgress`
+SHALL select `xp_reward`, `gold_reward`, and `name`
+in addition to the existing `id`, `criteria_type`, and
+`criteria_config` columns. This provides the evaluation
+engine with reward values without an additional query.
+
+#### Scenario: Achievement data includes reward fields
+
+- **WHEN** `fetchAchievements` returns achievement rows
+- **THEN** each row SHALL include `xp_reward`,
+  `gold_reward`, and `name` fields
+
+### Requirement: Compound achievement seed data
+
+The achievement seed data SHALL include at least 2
+compound achievements to validate the compound
+evaluation strategy. These SHALL be added via a new
+migration file.
+
+#### Scenario: AND compound achievement is seeded
+
+- **WHEN** the migration runs
+- **THEN** at least one achievement SHALL exist with
+  `criteria_type: "compound"` and
+  `criteria_config.operator: "AND"` containing
+  multiple sub-conditions
+
+#### Scenario: OR compound achievement is seeded
+
+- **WHEN** the migration runs
+- **THEN** at least one achievement SHALL exist with
+  `criteria_type: "compound"` and
+  `criteria_config.operator: "OR"` containing
+  multiple sub-conditions
+
+#### Scenario: Compound achievements have rewards
+
+- **WHEN** compound achievements are seeded
+- **THEN** each SHALL have non-zero `xp_reward` and
+  `gold_reward` values
+
+### Requirement: Evaluation engine unit tests
+
+The evaluation engine SHALL have unit tests covering
+each evaluation strategy, unlock detection, reward
+granting, level-up cascading, idempotency, and
+retroactive unlock behavior.
+
+#### Scenario: Threshold strategy tests
+
+- **WHEN** unit tests run
+- **THEN** tests SHALL cover met-at-threshold,
+  met-above-threshold, not-met-below-threshold, and
+  zero-threshold cases
+
+#### Scenario: Boolean strategy tests
+
+- **WHEN** unit tests run
+- **THEN** tests SHALL cover truthy (current > 0) and
+  falsy (current === 0) cases
+
+#### Scenario: Compound strategy tests
+
+- **WHEN** unit tests run
+- **THEN** tests SHALL cover AND-all-met,
+  AND-partial-met, OR-one-met, OR-none-met, boolean
+  sub-conditions, and default-operator cases
+
+#### Scenario: Unlock and reward tests
+
+- **WHEN** unit tests run
+- **THEN** tests SHALL cover single unlock, multiple
+  unlock, zero-reward skip, already-unlocked skip,
+  and level-up cascade cases
+
+#### Scenario: Idempotency tests
+
+- **WHEN** unit tests run
+- **THEN** tests SHALL verify that duplicate
+  evaluations produce no additional unlocks or rewards

--- a/openspec/changes/achievement-unlock-evaluation-engine/tasks.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/tasks.md
@@ -2,139 +2,139 @@
 
 ## 1. Evaluation Strategy Functions (Pure Logic)
 
-- [ ] 1.1 Create `lib/achievement-progress/unlock-evaluator.ts`
+- [x] 1.1 Create `lib/achievement-progress/unlock-evaluator.ts`
   with types for evaluation strategies and the strategy
   dispatch function
-- [ ] 1.2 Implement `evaluateThreshold` strategy function
+- [x] 1.2 Implement `evaluateThreshold` strategy function
   (`current >= threshold`)
-- [ ] 1.3 Implement `evaluateBoolean` strategy function
+- [x] 1.3 Implement `evaluateBoolean` strategy function
   (`current > 0`, truthy)
-- [ ] 1.4 Implement `evaluateCompound` strategy function
+- [x] 1.4 Implement `evaluateCompound` strategy function
   (AND/OR over sub-conditions using EVALUATOR_REGISTRY)
-- [ ] 1.5 Implement strategy dispatch that reads
+- [x] 1.5 Implement strategy dispatch that reads
   `criteria_config.evaluation_strategy` and defaults to
   `"threshold"`, with warning on unknown strategy
-- [ ] 1.6 Write unit tests for threshold strategy
+- [x] 1.6 Write unit tests for threshold strategy
   (met-at, met-above, not-met-below, zero-threshold)
-- [ ] 1.7 Write unit tests for boolean strategy
+- [x] 1.7 Write unit tests for boolean strategy
   (truthy with positive, truthy with large, falsy with zero)
-- [ ] 1.8 Write unit tests for compound strategy
+- [x] 1.8 Write unit tests for compound strategy
   (AND-all-met, AND-partial, OR-one-met, OR-none-met,
   boolean sub-condition, default AND operator)
-- [ ] 1.9 Write unit tests for strategy dispatch
+- [x] 1.9 Write unit tests for strategy dispatch
   (default threshold, explicit strategies, unknown fallback)
 
 ## 2. Compound Evaluator in Registry
 
-- [ ] 2.1 Add `compound` to `ALL_CRITERIA_TYPES` in
+- [x] 2.1 Add `compound` to `ALL_CRITERIA_TYPES` in
   `lib/achievement-progress/evaluators.ts`
-- [ ] 2.2 Implement compound evaluator function that
+- [x] 2.2 Implement compound evaluator function that
   delegates to sub-evaluators from EVALUATOR_REGISTRY
   and returns composite `{ current }` result
-- [ ] 2.3 Register compound evaluator in EVALUATOR_REGISTRY
-- [ ] 2.4 Handle unknown sub-condition criteria types
+- [x] 2.3 Register compound evaluator in EVALUATOR_REGISTRY
+- [x] 2.4 Handle unknown sub-condition criteria types
   (log warning, treat as not met)
-- [ ] 2.5 Write unit tests for compound evaluator
+- [x] 2.5 Write unit tests for compound evaluator
   (delegation, unknown sub-type handling)
 
 ## 3. Compound Progress JSONB Shape
 
-- [ ] 3.1 Update progress upsert logic to produce compound
+- [x] 3.1 Update progress upsert logic to produce compound
   JSONB shape (`{ conditions: [...], met: boolean }`)
   for compound-type achievements
-- [ ] 3.2 Write unit tests for compound progress shape
+- [x] 3.2 Write unit tests for compound progress shape
   (mixed results, all met)
 
 ## 4. Expand fetchAchievements Query
 
-- [ ] 4.1 Add `xp_reward`, `gold_reward`, and `name` to
+- [x] 4.1 Add `xp_reward`, `gold_reward`, and `name` to
   the `fetchAchievements` SELECT in
   `lib/achievement-progress-service.ts`
-- [ ] 4.2 Update TypeScript types for the fetched
+- [x] 4.2 Update TypeScript types for the fetched
   achievement shape to include reward fields
-- [ ] 4.3 Write unit test verifying reward fields are
+- [x] 4.3 Write unit test verifying reward fields are
   present in fetched achievement data
 
 ## 5. Unlock Detection and unlocked_at Write
 
-- [ ] 5.1 After progress upsert, fetch existing
+- [x] 5.1 After progress upsert, fetch existing
   `unlocked_at` values for the upserted achievement IDs
-- [ ] 5.2 Apply strategy dispatch to each upserted row to
+- [x] 5.2 Apply strategy dispatch to each upserted row to
   determine if criteria are met
-- [ ] 5.3 Filter to achievements where criteria are met
+- [x] 5.3 Filter to achievements where criteria are met
   AND `unlocked_at IS NULL` (newly eligible)
-- [ ] 5.4 Batch update `unlocked_at = now()` on
+- [x] 5.4 Batch update `unlocked_at = now()` on
   newly-eligible rows using service-role write client
   with `unlocked_at IS NULL` filter for concurrency
   safety
-- [ ] 5.5 Write unit tests for unlock detection
+- [x] 5.5 Write unit tests for unlock detection
   (newly met, already unlocked skip, below threshold
   skip, compound met-flag unlock)
-- [ ] 5.6 Write unit tests for concurrent unlock safety
+- [x] 5.6 Write unit tests for concurrent unlock safety
   (IS NULL filter prevents double-unlock)
 
 ## 6. Reward Granting
 
-- [ ] 6.1 Sum `xp_reward` and `gold_reward` across all
+- [x] 6.1 Sum `xp_reward` and `gold_reward` across all
   newly-unlocked achievements
-- [ ] 6.2 Skip character stats update when total rewards
+- [x] 6.2 Skip character stats update when total rewards
   are zero
-- [ ] 6.3 Fetch character's current XP, gold, and level
+- [x] 6.3 Fetch character's current XP, gold, and level
   before updating
-- [ ] 6.4 Call `RewardCalculator.calculateLevelUp()` with
+- [x] 6.4 Call `RewardCalculator.calculateLevelUp()` with
   current XP, summed XP reward, and current level
-- [ ] 6.5 Increment `characters.xp`, `characters.gold`,
+- [x] 6.5 Increment `characters.xp`, `characters.gold`,
   and optionally `characters.level` in a single update
-- [ ] 6.6 Write unit tests for reward granting (single
+- [x] 6.6 Write unit tests for reward granting (single
   unlock, multiple unlock summing, zero-reward skip)
-- [ ] 6.7 Write unit tests for level-up from XP rewards
+- [x] 6.7 Write unit tests for level-up from XP rewards
   (triggers level-up, no level-up when insufficient XP)
 
 ## 7. Level-Up Cascade
 
-- [ ] 7.1 After stats update with level change, re-evaluate
+- [x] 7.1 After stats update with level change, re-evaluate
   `level_reached` criteria for the character
-- [ ] 7.2 If cascade produces new unlocks, repeat the
+- [x] 7.2 If cascade produces new unlocks, repeat the
   unlock + reward flow (bounded to prevent infinite loops)
-- [ ] 7.3 Write unit tests for level-up cascade
+- [x] 7.3 Write unit tests for level-up cascade
   (cascade unlocks level achievement, no cascade when
   no level change)
 
 ## 8. Integration into updateProgress
 
-- [ ] 8.1 Wire unlock evaluation as a post-step in
+- [x] 8.1 Wire unlock evaluation as a post-step in
   `updateProgress` after the progress upsert succeeds
-- [ ] 8.2 Wrap unlock evaluation in try/catch so failures
+- [x] 8.2 Wrap unlock evaluation in try/catch so failures
   are logged but do not cause `updateProgress` to throw
-- [ ] 8.3 Ensure retroactive backfill path also runs
+- [x] 8.3 Ensure retroactive backfill path also runs
   unlock evaluation against all backfilled progress
-- [ ] 8.4 Write integration tests for updateProgress
+- [x] 8.4 Write integration tests for updateProgress
   end-to-end (progress + unlock + rewards in one call)
-- [ ] 8.5 Write tests for unlock evaluation failure being
+- [x] 8.5 Write tests for unlock evaluation failure being
   non-blocking (progress persists, error logged)
 
 ## 9. Idempotency Tests
 
-- [ ] 9.1 Write test: duplicate `updateProgress` call
+- [x] 9.1 Write test: duplicate `updateProgress` call
   produces no additional unlocks or rewards
-- [ ] 9.2 Write test: re-evaluation of already-unlocked
+- [x] 9.2 Write test: re-evaluation of already-unlocked
   achievement is a no-op
 
 ## 10. Compound Achievement Seed Migration
 
-- [ ] 10.1 Create new Supabase migration file for compound
+- [x] 10.1 Create new Supabase migration file for compound
   seed achievements
-- [ ] 10.2 Seed one AND compound achievement (e.g.,
+- [x] 10.2 Seed one AND compound achievement (e.g.,
   "Complete 5 quests AND reach level 3")
-- [ ] 10.3 Seed one OR compound achievement (e.g.,
+- [x] 10.3 Seed one OR compound achievement (e.g.,
   "Defeat 3 bosses OR earn 500 gold")
-- [ ] 10.4 Assign compound achievements to appropriate
+- [x] 10.4 Assign compound achievements to appropriate
   categories with non-zero XP/gold rewards
-- [ ] 10.5 Write migration test validating compound
+- [x] 10.5 Write migration test validating compound
   seed data structure
 
 ## 11. Quality Gate
 
-- [ ] 11.1 Run `npm run build` — zero TypeScript errors
-- [ ] 11.2 Run `npm run lint` — zero lint errors
-- [ ] 11.3 Run `npm run test` — all tests pass
+- [x] 11.1 Run `npm run build` — zero TypeScript errors
+- [x] 11.2 Run `npm run lint` — zero lint errors
+- [x] 11.3 Run `npm run test` — all tests pass

--- a/openspec/changes/achievement-unlock-evaluation-engine/tasks.md
+++ b/openspec/changes/achievement-unlock-evaluation-engine/tasks.md
@@ -1,0 +1,140 @@
+# Achievement Unlock Evaluation Engine — Tasks
+
+## 1. Evaluation Strategy Functions (Pure Logic)
+
+- [ ] 1.1 Create `lib/achievement-progress/unlock-evaluator.ts`
+  with types for evaluation strategies and the strategy
+  dispatch function
+- [ ] 1.2 Implement `evaluateThreshold` strategy function
+  (`current >= threshold`)
+- [ ] 1.3 Implement `evaluateBoolean` strategy function
+  (`current > 0`, truthy)
+- [ ] 1.4 Implement `evaluateCompound` strategy function
+  (AND/OR over sub-conditions using EVALUATOR_REGISTRY)
+- [ ] 1.5 Implement strategy dispatch that reads
+  `criteria_config.evaluation_strategy` and defaults to
+  `"threshold"`, with warning on unknown strategy
+- [ ] 1.6 Write unit tests for threshold strategy
+  (met-at, met-above, not-met-below, zero-threshold)
+- [ ] 1.7 Write unit tests for boolean strategy
+  (truthy with positive, truthy with large, falsy with zero)
+- [ ] 1.8 Write unit tests for compound strategy
+  (AND-all-met, AND-partial, OR-one-met, OR-none-met,
+  boolean sub-condition, default AND operator)
+- [ ] 1.9 Write unit tests for strategy dispatch
+  (default threshold, explicit strategies, unknown fallback)
+
+## 2. Compound Evaluator in Registry
+
+- [ ] 2.1 Add `compound` to `ALL_CRITERIA_TYPES` in
+  `lib/achievement-progress/evaluators.ts`
+- [ ] 2.2 Implement compound evaluator function that
+  delegates to sub-evaluators from EVALUATOR_REGISTRY
+  and returns composite `{ current }` result
+- [ ] 2.3 Register compound evaluator in EVALUATOR_REGISTRY
+- [ ] 2.4 Handle unknown sub-condition criteria types
+  (log warning, treat as not met)
+- [ ] 2.5 Write unit tests for compound evaluator
+  (delegation, unknown sub-type handling)
+
+## 3. Compound Progress JSONB Shape
+
+- [ ] 3.1 Update progress upsert logic to produce compound
+  JSONB shape (`{ conditions: [...], met: boolean }`)
+  for compound-type achievements
+- [ ] 3.2 Write unit tests for compound progress shape
+  (mixed results, all met)
+
+## 4. Expand fetchAchievements Query
+
+- [ ] 4.1 Add `xp_reward`, `gold_reward`, and `name` to
+  the `fetchAchievements` SELECT in
+  `lib/achievement-progress-service.ts`
+- [ ] 4.2 Update TypeScript types for the fetched
+  achievement shape to include reward fields
+- [ ] 4.3 Write unit test verifying reward fields are
+  present in fetched achievement data
+
+## 5. Unlock Detection and unlocked_at Write
+
+- [ ] 5.1 After progress upsert, fetch existing
+  `unlocked_at` values for the upserted achievement IDs
+- [ ] 5.2 Apply strategy dispatch to each upserted row to
+  determine if criteria are met
+- [ ] 5.3 Filter to achievements where criteria are met
+  AND `unlocked_at IS NULL` (newly eligible)
+- [ ] 5.4 Batch update `unlocked_at = now()` on
+  newly-eligible rows using service-role write client
+  with `unlocked_at IS NULL` filter for concurrency
+  safety
+- [ ] 5.5 Write unit tests for unlock detection
+  (newly met, already unlocked skip, below threshold
+  skip, compound met-flag unlock)
+- [ ] 5.6 Write unit tests for concurrent unlock safety
+  (IS NULL filter prevents double-unlock)
+
+## 6. Reward Granting
+
+- [ ] 6.1 Sum `xp_reward` and `gold_reward` across all
+  newly-unlocked achievements
+- [ ] 6.2 Skip character stats update when total rewards
+  are zero
+- [ ] 6.3 Fetch character's current XP, gold, and level
+  before updating
+- [ ] 6.4 Call `RewardCalculator.calculateLevelUp()` with
+  current XP, summed XP reward, and current level
+- [ ] 6.5 Increment `characters.xp`, `characters.gold`,
+  and optionally `characters.level` in a single update
+- [ ] 6.6 Write unit tests for reward granting (single
+  unlock, multiple unlock summing, zero-reward skip)
+- [ ] 6.7 Write unit tests for level-up from XP rewards
+  (triggers level-up, no level-up when insufficient XP)
+
+## 7. Level-Up Cascade
+
+- [ ] 7.1 After stats update with level change, re-evaluate
+  `level_reached` criteria for the character
+- [ ] 7.2 If cascade produces new unlocks, repeat the
+  unlock + reward flow (bounded to prevent infinite loops)
+- [ ] 7.3 Write unit tests for level-up cascade
+  (cascade unlocks level achievement, no cascade when
+  no level change)
+
+## 8. Integration into updateProgress
+
+- [ ] 8.1 Wire unlock evaluation as a post-step in
+  `updateProgress` after the progress upsert succeeds
+- [ ] 8.2 Wrap unlock evaluation in try/catch so failures
+  are logged but do not cause `updateProgress` to throw
+- [ ] 8.3 Ensure retroactive backfill path also runs
+  unlock evaluation against all backfilled progress
+- [ ] 8.4 Write integration tests for updateProgress
+  end-to-end (progress + unlock + rewards in one call)
+- [ ] 8.5 Write tests for unlock evaluation failure being
+  non-blocking (progress persists, error logged)
+
+## 9. Idempotency Tests
+
+- [ ] 9.1 Write test: duplicate `updateProgress` call
+  produces no additional unlocks or rewards
+- [ ] 9.2 Write test: re-evaluation of already-unlocked
+  achievement is a no-op
+
+## 10. Compound Achievement Seed Migration
+
+- [ ] 10.1 Create new Supabase migration file for compound
+  seed achievements
+- [ ] 10.2 Seed one AND compound achievement (e.g.,
+  "Complete 5 quests AND reach level 3")
+- [ ] 10.3 Seed one OR compound achievement (e.g.,
+  "Defeat 3 bosses OR earn 500 gold")
+- [ ] 10.4 Assign compound achievements to appropriate
+  categories with non-zero XP/gold rewards
+- [ ] 10.5 Write migration test validating compound
+  seed data structure
+
+## 11. Quality Gate
+
+- [ ] 11.1 Run `npm run build` — zero TypeScript errors
+- [ ] 11.2 Run `npm run lint` — zero lint errors
+- [ ] 11.3 Run `npm run test` — all tests pass

--- a/openspec/specs/achievement-progress/spec.md
+++ b/openspec/specs/achievement-progress/spec.md
@@ -476,19 +476,25 @@ accumulating from event payloads.
   canonical state, not just the delta from the
   latest event
 
-### Requirement: Retroactive backfill on first evaluation
+### Requirement: Retroactive backfill on missing achievements
 
-On the first `updateProgress` call for a character
-(detected by absence of any `character_achievements`
-rows for that character), the service SHALL run all
-13 evaluators to backfill progress from existing
-database state. The full set of backfill upserts
-SHALL be written in a single batch upsert call so
-that the operation is atomic — either all rows are
-written or none are. This prevents partial backfill
-from being misinterpreted as complete on subsequent
-calls. Subsequent calls SHALL run only the evaluators
-mapped to the triggering event type.
+The service SHALL detect when any achievements are
+missing from a character's `character_achievements`
+rows (i.e., some achievements exist in the
+`achievements` table that have no corresponding row
+for this character). When such gaps are detected,
+the service SHALL run all 13 evaluators to backfill
+progress from existing database state. The full set
+of backfill upserts SHALL be written in a single
+batch upsert call so that the operation is atomic —
+either all rows are written or none are. This
+prevents partial backfill from being misinterpreted
+as complete on subsequent calls. It also ensures
+newly seeded achievements are backfilled for
+returning characters on their next `updateProgress`
+call. Subsequent calls with no missing achievements
+SHALL run only the evaluators mapped to the
+triggering event type.
 
 #### Scenario: First evaluation triggers full backfill
 
@@ -498,17 +504,27 @@ mapped to the triggering event type.
   types and upsert progress for every achievement in
   a single batch upsert
 
+#### Scenario: New achievement seeds trigger backfill for returning characters
+
+- **WHEN** `updateProgress` is called for a character
+  that has some `character_achievements` rows, but a
+  newly seeded achievement has no row for that
+  character
+- **THEN** the service SHALL detect the gap and run a
+  full backfill for all 13 criteria types
+
 #### Scenario: Partial backfill failure leaves no rows
 
 - **WHEN** the batch upsert during backfill fails
-- **THEN** no `character_achievements` rows SHALL be
-  written for that character, and the next
+- **THEN** no new `character_achievements` rows SHALL
+  be written for that character, and the next
   `updateProgress` call SHALL retry the full backfill
 
 #### Scenario: Subsequent evaluation is scoped
 
 - **WHEN** `updateProgress` is called for a character
-  that already has `character_achievements` rows
+  that has `character_achievements` rows for every
+  known achievement
 - **THEN** the service SHALL evaluate only the
   criteria types mapped to the event type
 

--- a/supabase/migrations/20260320000001_compound_achievement_seeds.sql
+++ b/supabase/migrations/20260320000001_compound_achievement_seeds.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- Compound Achievement Seeds
+-- Adds two compound achievements to validate the compound evaluation strategy:
+--   1. AND compound: "Complete 5 quests AND reach level 3"
+--   2. OR compound:  "Defeat 3 bosses OR earn 500 gold"
+-- ============================================================================
+
+-- 10.2 AND compound achievement
+INSERT INTO achievements (
+  name,
+  description,
+  category_id,
+  xp_reward,
+  gold_reward,
+  criteria_type,
+  criteria_config
+)
+SELECT
+  'Seasoned Adventurer',
+  'Complete 5 quests and reach level 3.',
+  (SELECT id FROM achievement_categories WHERE name = 'Growth'),
+  200,
+  75,
+  'compound',
+  '{
+    "evaluation_strategy": "compound",
+    "operator": "AND",
+    "conditions": [
+      { "criteria_type": "quest_complete", "threshold": 5 },
+      { "criteria_type": "level_reached",  "threshold": 3 }
+    ]
+  }'::jsonb;
+
+-- 10.3 OR compound achievement
+INSERT INTO achievements (
+  name,
+  description,
+  category_id,
+  xp_reward,
+  gold_reward,
+  criteria_type,
+  criteria_config
+)
+SELECT
+  'Path of Glory',
+  'Defeat 3 bosses or earn 500 gold.',
+  (SELECT id FROM achievement_categories WHERE name = 'Combat'),
+  150,
+  50,
+  'compound',
+  '{
+    "evaluation_strategy": "compound",
+    "operator": "OR",
+    "conditions": [
+      { "criteria_type": "boss_defeated", "threshold": 3 },
+      { "criteria_type": "gold_earned",   "threshold": 500 }
+    ]
+  }'::jsonb;

--- a/supabase/migrations/20260320000001_compound_achievement_seeds.sql
+++ b/supabase/migrations/20260320000001_compound_achievement_seeds.sql
@@ -44,7 +44,7 @@ INSERT INTO achievements (
 SELECT
   'Path of Glory',
   'Defeat 3 bosses or earn 500 gold.',
-  (SELECT id FROM achievement_categories WHERE name = 'Combat'),
+  (SELECT id FROM achievement_categories WHERE name = 'Adventurer'),
   150,
   50,
   'compound',

--- a/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
+++ b/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
@@ -16,5 +16,4 @@ RETURNS TABLE (xp INTEGER, gold INTEGER, level INTEGER) AS $$
   RETURNING xp, gold, level;
 $$ LANGUAGE sql SECURITY DEFINER;
 
-GRANT EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER) TO authenticated;
 GRANT EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER) TO service_role;

--- a/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
+++ b/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
@@ -10,8 +10,8 @@ CREATE OR REPLACE FUNCTION fn_increment_character_stats(
 RETURNS TABLE (xp INTEGER, gold INTEGER, level INTEGER) AS $$
   UPDATE characters
   SET
-    xp = xp + p_xp,
-    gold = gold + p_gold
+    xp = COALESCE(xp, 0) + p_xp,
+    gold = COALESCE(gold, 0) + p_gold
   WHERE id = p_character_id
   RETURNING xp, gold, level;
 $$ LANGUAGE sql SECURITY DEFINER;

--- a/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
+++ b/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
@@ -16,4 +16,5 @@ RETURNS TABLE (xp INTEGER, gold INTEGER, level INTEGER) AS $$
   RETURNING xp, gold, level;
 $$ LANGUAGE sql SECURITY DEFINER;
 
+REVOKE ALL ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER) TO service_role;

--- a/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
+++ b/supabase/migrations/20260320000002_increment_character_stats_rpc.sql
@@ -1,0 +1,20 @@
+-- Atomically increment a character's XP and gold in a single operation.
+-- Returns the new xp, gold, and current level after the update.
+-- Using this function prevents concurrent read-modify-write races when multiple
+-- achievements unlock simultaneously for the same character.
+CREATE OR REPLACE FUNCTION fn_increment_character_stats(
+  p_character_id UUID,
+  p_xp INTEGER,
+  p_gold INTEGER
+)
+RETURNS TABLE (xp INTEGER, gold INTEGER, level INTEGER) AS $$
+  UPDATE characters
+  SET
+    xp = xp + p_xp,
+    gold = gold + p_gold
+  WHERE id = p_character_id
+  RETURNING xp, gold, level;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER) TO service_role;

--- a/supabase/migrations/20260321000001_restrict_increment_stats_rpc.sql
+++ b/supabase/migrations/20260321000001_restrict_increment_stats_rpc.sql
@@ -1,4 +1,0 @@
--- SECURITY: fn_increment_character_stats is SECURITY DEFINER with no ownership check.
--- It must only be callable by the service role.
-REVOKE EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER)
-  FROM authenticated;

--- a/supabase/migrations/20260321000001_restrict_increment_stats_rpc.sql
+++ b/supabase/migrations/20260321000001_restrict_increment_stats_rpc.sql
@@ -1,0 +1,4 @@
+-- SECURITY: fn_increment_character_stats is SECURITY DEFINER with no ownership check.
+-- It must only be callable by the service role.
+REVOKE EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER)
+  FROM authenticated;

--- a/supabase/migrations/20260321000002_revoke_public_execute_increment_stats.sql
+++ b/supabase/migrations/20260321000002_revoke_public_execute_increment_stats.sql
@@ -1,0 +1,6 @@
+-- SECURITY: fn_increment_character_stats is SECURITY DEFINER with no
+-- ownership check. The previous migration revoked from authenticated;
+-- this revokes from PUBLIC as well, fully restricting execution to
+-- service_role only.
+REVOKE EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER)
+  FROM PUBLIC;

--- a/supabase/migrations/20260321000002_revoke_public_execute_increment_stats.sql
+++ b/supabase/migrations/20260321000002_revoke_public_execute_increment_stats.sql
@@ -1,6 +1,0 @@
--- SECURITY: fn_increment_character_stats is SECURITY DEFINER with no
--- ownership check. The previous migration revoked from authenticated;
--- this revokes from PUBLIC as well, fully restricting execution to
--- service_role only.
-REVOKE EXECUTE ON FUNCTION fn_increment_character_stats(UUID, INTEGER, INTEGER)
-  FROM PUBLIC;

--- a/tests/integration/quest-instance-service.approve.test.ts
+++ b/tests/integration/quest-instance-service.approve.test.ts
@@ -1,11 +1,12 @@
 /**
- * Integration tests for QuestInstanceService
- * Tests claimQuest, releaseQuest, and assignQuest methods
- * Run with: npm run test -- quest-instance-service.integration
+ * Integration tests for QuestInstanceService.approveQuest
+ * Tests the approval workflow for ad-hoc family quests
+ * Run with: npm run test -- quest-instance-service.approve
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
 import { createClient } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
 import { questInstanceService } from "@/lib/quest-instance-service";
 
 // Create admin client with service role key to bypass RLS for setup
@@ -15,12 +16,13 @@ const adminSupabase = createClient(
     "sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz",
 );
 
-describe("QuestInstanceService Integration Tests", () => {
+describe("QuestInstanceService approveQuest", () => {
   let testFamilyId: string;
   let testGMUserId: string;
+  let testGMEmail: string;
   let testHeroUserId: string;
   let testHeroCharacterId: string;
-  let testFamilyQuestId: string;
+  let questToApproveId: string;
 
   // Service instance using admin client to bypass RLS
   let questService: InstanceType<typeof questInstanceService.constructor>;
@@ -39,11 +41,12 @@ describe("QuestInstanceService Integration Tests", () => {
       throw new Error(`Failed to create GM user: ${gmAuthError?.message}`);
     }
     testGMUserId = gmAuthUser.user.id;
+    testGMEmail = gmAuthUser.user.email!;
 
     // Create test family using admin client (bypasses RLS)
     const { data: family, error: familyError } = await adminSupabase
       .from("families")
-      .insert({ name: "Quest Claim Test Family", code: `QCT${Date.now()}` })
+      .insert({ name: "Quest Approve Test Family", code: `QAT${Date.now()}` })
       .select()
       .single();
 
@@ -103,27 +106,46 @@ describe("QuestInstanceService Integration Tests", () => {
       throw new Error(`Failed to create character: ${characterError.message}`);
     testHeroCharacterId = character.id;
 
-    // Create a FAMILY quest in AVAILABLE status using admin client
+    // Create quest for approval using admin client (bypasses RLS)
     const { data: quest, error: questError } = await adminSupabase
       .from("quest_instances")
       .insert({
-        title: "Test Family Quest",
-        description: "A test family quest for claiming",
+        title: "Quest Ready For Approval",
+        description: "Approve this quest to complete the flow",
         xp_reward: 100,
-        gold_reward: 50,
-        difficulty: "MEDIUM",
+        gold_reward: 60,
+        difficulty: "EASY",
         category: "DAILY",
         family_id: testFamilyId,
         created_by_id: testGMUserId,
         quest_type: "FAMILY",
-        status: "AVAILABLE",
+        status: "CLAIMED",
+        assigned_to_id: testHeroUserId,
+        volunteered_by: testHeroCharacterId,
+        volunteer_bonus: 0.2,
       })
       .select()
       .single();
 
-    if (questError)
-      throw new Error(`Failed to create test quest: ${questError.message}`);
-    testFamilyQuestId = quest.id;
+    if (questError || !quest) {
+      throw new Error(
+        `Failed to create quest for approval test: ${questError?.message}`,
+      );
+    }
+
+    questToApproveId = quest.id;
+
+    // Simulate active family quest assignment using admin client
+    const { error: activeQuestError } = await adminSupabase
+      .from("characters")
+      .update({ active_family_quest_id: questToApproveId })
+      .eq("id", testHeroCharacterId);
+
+    if (activeQuestError) {
+      throw new Error(
+        `Failed to set active family quest: ${activeQuestError.message}`,
+      );
+    }
 
     // Initialize quest service with admin client to bypass RLS
     const { QuestInstanceService } =
@@ -133,12 +155,6 @@ describe("QuestInstanceService Integration Tests", () => {
 
   afterAll(async () => {
     // Clean up test data using admin client
-    if (testFamilyQuestId) {
-      await adminSupabase
-        .from("quest_instances")
-        .delete()
-        .eq("id", testFamilyQuestId);
-    }
     if (testHeroCharacterId) {
       await adminSupabase
         .from("characters")
@@ -158,81 +174,34 @@ describe("QuestInstanceService Integration Tests", () => {
     }
   }, 30000);
 
-  describe("claimQuest", () => {
-    it("should successfully claim a family quest", async () => {
-      const claimedQuest = await questService.claimQuest(
-        testFamilyQuestId,
-        testHeroCharacterId,
+  it("should allow GM to approve an ad-hoc family quest", async () => {
+    await supabase.auth.signInWithPassword({
+      email: testGMEmail,
+      password: "testpassword123",
+    });
+
+    const approvedQuest = await questService.approveQuest(questToApproveId);
+
+    expect(approvedQuest).toBeDefined();
+    expect(approvedQuest.status).toBe("APPROVED");
+    expect(approvedQuest.approved_at).toBeTruthy();
+    expect(approvedQuest.completed_at).toBeTruthy();
+
+    const { data: updatedCharacter, error: characterError } = await supabase
+      .from("characters")
+      .select("xp, gold, level, active_family_quest_id")
+      .eq("id", testHeroCharacterId)
+      .single();
+
+    if (characterError || !updatedCharacter) {
+      throw new Error(
+        `Failed to fetch character after approval: ${characterError?.message}`,
       );
+    }
 
-      expect(claimedQuest).toBeDefined();
-      expect(claimedQuest.status).toBe("CLAIMED");
-      expect(claimedQuest.assigned_to_id).toBe(testHeroUserId);
-      expect(claimedQuest.volunteered_by).toBe(testHeroCharacterId);
-      expect(claimedQuest.volunteer_bonus).toBe(0.2); // 20% bonus
-    });
-
-    it("should fail if hero already has active family quest", async () => {
-      // Try to claim another quest while already having one
-      const { data: anotherQuest } = await adminSupabase
-        .from("quest_instances")
-        .insert({
-          title: "Another Family Quest",
-          description: "Another test quest",
-          xp_reward: 100,
-          gold_reward: 50,
-          difficulty: "MEDIUM",
-          category: "DAILY",
-          family_id: testFamilyId,
-          created_by_id: testGMUserId,
-          quest_type: "FAMILY",
-          status: "AVAILABLE",
-        })
-        .select()
-        .single();
-
-      await expect(
-        questService.claimQuest(anotherQuest!.id, testHeroCharacterId),
-      ).rejects.toThrow("Hero already has an active family quest");
-
-      // Clean up
-      if (anotherQuest) {
-        await adminSupabase
-          .from("quest_instances")
-          .delete()
-          .eq("id", anotherQuest.id);
-      }
-    });
-  });
-
-  describe("releaseQuest", () => {
-    it("should successfully release a claimed quest", async () => {
-      const releasedQuest = await questService.releaseQuest(
-        testFamilyQuestId,
-        testHeroCharacterId,
-      );
-
-      expect(releasedQuest).toBeDefined();
-      expect(releasedQuest.status).toBe("AVAILABLE");
-      expect(releasedQuest.assigned_to_id).toBeNull();
-      expect(releasedQuest.volunteered_by).toBeNull();
-      expect(releasedQuest.volunteer_bonus).toBeNull();
-    });
-  });
-
-  describe("assignQuest", () => {
-    it("should allow GM to manually assign a quest (no volunteer bonus)", async () => {
-      const assignedQuest = await questService.assignQuest(
-        testFamilyQuestId,
-        testHeroCharacterId,
-        testGMUserId,
-      );
-
-      expect(assignedQuest).toBeDefined();
-      expect(assignedQuest.status).toBe("PENDING");
-      expect(assignedQuest.assigned_to_id).toBe(testHeroUserId);
-      expect(assignedQuest.volunteered_by).toBe(testHeroCharacterId); // Track specific character for approval path
-      expect(assignedQuest.volunteer_bonus).toBeNull(); // No bonus for GM assignment
-    });
+    expect(updatedCharacter.xp).toBeGreaterThanOrEqual(120); // 100 base + 20 volunteer bonus, plus any achievement unlock XP
+    expect(updatedCharacter.gold).toBeGreaterThanOrEqual(72); // 60 base + 12 volunteer bonus, plus any achievement unlock gold
+    expect(updatedCharacter.active_family_quest_id).toBeNull();
+    expect(updatedCharacter.level).toBeGreaterThan(1);
   });
 });

--- a/tests/unit/migrations/compound-achievement-seeds.test.ts
+++ b/tests/unit/migrations/compound-achievement-seeds.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the compound achievement seed migration.
+ * Validates the SQL file contains the required compound achievement
+ * seed data with correct structure. Actual SQL correctness is validated
+ * by `supabase db reset`.
+ */
+import { describe, it, expect, beforeAll } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Compound Achievement Seeds Migration (20260320000001)", () => {
+  const migrationPath = path.join(
+    __dirname,
+    "../../../supabase/migrations/20260320000001_compound_achievement_seeds.sql",
+  );
+  let sql: string;
+
+  beforeAll(() => {
+    sql = fs.readFileSync(migrationPath, "utf-8");
+  });
+
+  it("10.5 migration file exists and is readable", () => {
+    expect(sql).toBeTruthy();
+    expect(sql.length).toBeGreaterThan(0);
+  });
+
+  // 10.2 AND compound achievement
+  it("10.2 seeds at least one AND compound achievement", () => {
+    // criteria_type value 'compound' appears in the INSERT
+    expect(sql).toMatch(/'compound'/i);
+    expect(sql).toMatch(/"operator"\s*:\s*"AND"/i);
+  });
+
+  it("10.2 AND compound achievement has multiple sub-conditions", () => {
+    expect(sql).toMatch(/"conditions"/i);
+    // At least two criteria_type entries within conditions
+    const conditionsMatches = sql.match(/"criteria_type"/g);
+    expect(conditionsMatches!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("10.2 AND compound achievement references quest_complete and level_reached", () => {
+    expect(sql).toMatch(/"criteria_type"\s*:\s*"quest_complete"/i);
+    expect(sql).toMatch(/"criteria_type"\s*:\s*"level_reached"/i);
+  });
+
+  // 10.3 OR compound achievement
+  it("10.3 seeds at least one OR compound achievement", () => {
+    expect(sql).toMatch(/"operator"\s*:\s*"OR"/i);
+  });
+
+  it("10.3 OR compound achievement references boss_defeated or gold_earned", () => {
+    const hasBossDefeated = /"criteria_type"\s*:\s*"boss_defeated"/i.test(sql);
+    const hasGoldEarned = /"criteria_type"\s*:\s*"gold_earned"/i.test(sql);
+    expect(hasBossDefeated || hasGoldEarned).toBe(true);
+  });
+
+  // 10.4 Compound achievements have non-zero rewards
+  it("10.4 compound achievements have non-zero xp_reward values", () => {
+    // Verify xp_reward values in the INSERT statements are > 0
+    // Extract xp_reward lines around the compound inserts
+    const xpMatches = sql.match(/\d+,\s*\n\s*'compound'/g);
+    expect(xpMatches).toBeTruthy();
+    xpMatches!.forEach((match) => {
+      const num = parseInt(match, 10);
+      expect(num).toBeGreaterThan(0);
+    });
+  });
+
+  it("10.4 evaluation_strategy is set to compound in criteria_config", () => {
+    expect(sql).toMatch(/"evaluation_strategy"\s*:\s*"compound"/i);
+    // Should appear twice (once per achievement)
+    const matches = sql.match(/"evaluation_strategy"\s*:\s*"compound"/gi);
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("10.5 compound achievements are cast to jsonb", () => {
+    // The criteria_config should be cast with ::jsonb
+    const jsonbMatches = sql.match(/::jsonb/g);
+    expect(jsonbMatches).toBeTruthy();
+    expect(jsonbMatches!.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the achievement unlock evaluation engine with retroactive backfill support
- Backfill triggers whenever any achievement is missing a `character_achievements` row (covers both first-call and post-deployment new-achievement cases)
- Includes stats rollback compensation with cascade abort on zero-row rollback detection
- Revokes PUBLIC execute on `fn_increment_character_stats` to close privilege-escalation path

## Spec divergence resolved

Updated `achievement-progress/spec.md` to reflect the broader backfill trigger: the implementation fires a full backfill when *any* achievement row is missing, not only on the very first call. This handles post-deployment cases where new achievements are added after a character's initial backfill.

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm run lint` — zero lint warnings
- [ ] `npm run test` — all unit tests pass

Closes #136