### PR TITLE
feat: achievement notification system

### DIFF
--- a/app/api/character-achievements/[id]/notified/route.ts
+++ b/app/api/character-achievements/[id]/notified/route.ts
@@ -36,7 +36,7 @@ export async function PATCH(
 
     const { data: existing, error: lookupError } = await serviceSupabase
       .from("character_achievements")
-      .select("id, characters(family_id)")
+      .select("id, characters(user_profiles(family_id))")
       .eq("id", id)
       .maybeSingle();
 
@@ -48,12 +48,16 @@ export async function PATCH(
     }
 
     // Ownership check — 403 if the character belongs to a different family
-    const characterFamily = (
-      existing as { id: string; characters: { family_id: string } | null }
-    ).characters;
+    const characters = existing.characters;
+    const userProfile =
+      characters && !Array.isArray(characters)
+        ? characters.user_profiles
+        : null;
+    const characterFamilyId =
+      userProfile && !Array.isArray(userProfile) ? userProfile.family_id : null;
     if (
-      !characterFamily ||
-      characterFamily.family_id !== requesterProfile.family_id
+      !characterFamilyId ||
+      characterFamilyId !== requesterProfile.family_id
     ) {
       throw new ForbiddenError(
         "Character achievement does not belong to your family",

--- a/app/api/character-achievements/[id]/notified/route.ts
+++ b/app/api/character-achievements/[id]/notified/route.ts
@@ -8,6 +8,7 @@ import {
   createServerSupabaseClient,
   createServiceSupabaseClient,
 } from "@/lib/supabase-server";
+import { ForbiddenError } from "@/lib/errors";
 
 /**
  * PATCH /api/character-achievements/[id]/notified
@@ -25,14 +26,17 @@ export async function PATCH(
 
     // Auth check — 401 if unauthenticated
     const userSupabase = createServerSupabaseClient(token);
-    await authenticateAndFetchUserProfile(userSupabase, token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
 
     // Record lookup via service-role client — 404 if not found
     const serviceSupabase = createServiceSupabaseClient();
 
     const { data: existing, error: lookupError } = await serviceSupabase
       .from("character_achievements")
-      .select("id")
+      .select("id, characters(family_id)")
       .eq("id", id)
       .maybeSingle();
 
@@ -40,6 +44,20 @@ export async function PATCH(
       return NextResponse.json(
         { error: "Character achievement not found" },
         { status: 404 },
+      );
+    }
+
+    // Ownership check — 403 if the character belongs to a different family
+    const characterFamily = (
+      existing as { id: string; characters: { family_id: string } | null }
+    ).characters;
+    if (
+      !characterFamily ||
+      characterFamily.family_id !== requesterProfile.family_id
+    ) {
+      throw new ForbiddenError(
+        "Character achievement does not belong to your family",
+        "NOTIFIED_FORBIDDEN",
       );
     }
 

--- a/app/api/character-achievements/[id]/notified/route.ts
+++ b/app/api/character-achievements/[id]/notified/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+
+/**
+ * PATCH /api/character-achievements/[id]/notified
+ * Mark a character achievement as notified.
+ * Uses service-role client because character_achievements INSERT/UPDATE
+ * is restricted to service role by RLS policy.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const token = extractBearerToken(request);
+
+    // Auth check — 401 if unauthenticated
+    const userSupabase = createServerSupabaseClient(token);
+    await authenticateAndFetchUserProfile(userSupabase, token);
+
+    // Record lookup via service-role client — 404 if not found
+    const serviceSupabase = createServiceSupabaseClient();
+
+    const { data: existing, error: lookupError } = await serviceSupabase
+      .from("character_achievements")
+      .select("id")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (lookupError || !existing) {
+      return NextResponse.json(
+        { error: "Character achievement not found" },
+        { status: 404 },
+      );
+    }
+
+    // Update notified flag
+    const { error: updateError } = await serviceSupabase
+      .from("character_achievements")
+      .update({ notified: true })
+      .eq("id", id);
+
+    if (updateError) {
+      throw new Error(`Failed to update notified flag: ${updateError.message}`);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { NetworkReadyProvider } from "@/lib/network-ready-context";
 import { AuthProvider } from "@/lib/auth-context";
 import { CharacterProvider } from "@/lib/character-context";
 import { RealtimeProvider } from "@/lib/realtime-context";
+import { AchievementNotificationManagerHost } from "@/components/achievements/AchievementNotificationManagerHost";
 import SiteFooter from "@/components/layout/site-footer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { getGitReferenceMetadata } from "@/lib/git-metadata";
@@ -26,14 +27,15 @@ const cinzel = Cinzel({
 });
 
 const orbitron = Orbitron({
-  variable: "--font-game", 
+  variable: "--font-game",
   subsets: ["latin"],
   weight: ["400", "500", "600", "700", "900"],
 });
 
 export const metadata: Metadata = {
   title: "ChoreQuest - Transform Chores into Epic Adventures",
-  description: "A fantasy RPG-themed family chore management system that transforms household tasks into heroic quests, where family members become mighty heroes.",
+  description:
+    "A fantasy RPG-themed family chore management system that transforms household tasks into heroic quests, where family members become mighty heroes.",
 };
 
 export default function RootLayout({
@@ -53,6 +55,7 @@ export default function RootLayout({
             <AuthProvider>
               <RealtimeProvider>
                 <CharacterProvider>
+                  <AchievementNotificationManagerHost />
                   <div className="flex min-h-screen flex-col">
                     <main className="flex-1">{children}</main>
                     <SiteFooter gitReference={gitReference} />

--- a/components/achievements/AchievementNotificationManager.test.tsx
+++ b/components/achievements/AchievementNotificationManager.test.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import type { RealtimeEvent } from "@/lib/realtime-context";
+import { AchievementNotificationManager } from "./AchievementNotificationManager";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  motion: {
+    div: ({
+      children,
+      initial,
+      animate,
+      exit,
+      transition,
+      ...props
+    }: React.PropsWithChildren<{
+      initial?: unknown;
+      animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+      [key: string]: unknown;
+    }>) => {
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      return (
+        <div {...(props as React.HTMLAttributes<HTMLDivElement>)}>
+          {children}
+        </div>
+      );
+    },
+  },
+}));
+
+const mockFrom = jest.fn();
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: "tok" } } }),
+    },
+  },
+}));
+
+const mockOnAchievementUnlockUpdate = jest.fn();
+jest.mock("@/lib/realtime-context", () => ({
+  useRealtime: () => ({
+    onAchievementUnlockUpdate: mockOnAchievementUnlockUpdate,
+  }),
+}));
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const CHAR_ID = "char-1";
+const ACH_ID = "ach-1";
+const CA_ID = "ca-1";
+
+function makeUnlockEvent(
+  overrides: Partial<RealtimeEvent> = {},
+): RealtimeEvent {
+  return {
+    type: "achievement_unlock_updated",
+    table: "character_achievements",
+    action: "UPDATE",
+    record: {
+      id: CA_ID,
+      character_id: CHAR_ID,
+      achievement_id: ACH_ID,
+      unlocked_at: "2026-03-22",
+      notified: false,
+    },
+    old_record: {
+      id: CA_ID,
+      character_id: CHAR_ID,
+      achievement_id: ACH_ID,
+      unlocked_at: null,
+      notified: false,
+    },
+    ...overrides,
+  };
+}
+
+const ACHIEVEMENT_DATA = {
+  name: "First Steps",
+  description: "Complete your first quest",
+  icon: "🏆",
+  xp_reward: 100,
+  gold_reward: 50,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+let capturedListener: ((event: RealtimeEvent) => void) | null = null;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  capturedListener = null;
+  (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+
+  mockOnAchievementUnlockUpdate.mockImplementation((listener) => {
+    capturedListener = listener;
+    return () => {};
+  });
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "character_achievements") {
+      const resolvedChain = {
+        eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+      };
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        not: jest.fn().mockReturnValue(resolvedChain),
+      };
+    }
+    if (table === "achievements") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest
+          .fn()
+          .mockResolvedValue({ data: ACHIEVEMENT_DATA, error: null }),
+      };
+    }
+    return {};
+  });
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("AchievementNotificationManager — integration", () => {
+  it("renders a toast when a realtime unlock event arrives", async () => {
+    render(<AchievementNotificationManager characterId={CHAR_ID} />);
+
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("First Steps")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Complete your first quest")).toBeInTheDocument();
+    expect(screen.getByText("+100 XP")).toBeInTheDocument();
+    expect(screen.getByText("+50 Gold")).toBeInTheDocument();
+  });
+
+  it("calls notified API when toast is displayed", async () => {
+    render(<AchievementNotificationManager characterId={CHAR_ID} />);
+
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/character-achievements/${CA_ID}/notified`,
+        expect.objectContaining({ method: "PATCH" }),
+      ),
+    );
+  });
+
+  it("auto-dismisses toast after 5 seconds", async () => {
+    render(<AchievementNotificationManager characterId={CHAR_ID} />);
+
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("First Steps")).toBeInTheDocument(),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("First Steps")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("renders nothing when characterId is null", () => {
+    render(<AchievementNotificationManager characterId={null} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/components/achievements/AchievementNotificationManager.tsx
+++ b/components/achievements/AchievementNotificationManager.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useAchievementNotifications } from "@/hooks/useAchievementNotifications";
+import { AchievementUnlockToast } from "./AchievementUnlockToast";
+
+type AchievementNotificationManagerProps = {
+  characterId: string | null | undefined;
+};
+
+export function AchievementNotificationManager({
+  characterId,
+}: AchievementNotificationManagerProps) {
+  const { current, onDismiss } = useAchievementNotifications(characterId);
+
+  return (
+    <AchievementUnlockToast notification={current} onDismiss={onDismiss} />
+  );
+}

--- a/components/achievements/AchievementNotificationManagerHost.tsx
+++ b/components/achievements/AchievementNotificationManagerHost.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useCharacter } from "@/lib/character-context";
+import { AchievementNotificationManager } from "./AchievementNotificationManager";
+
+/**
+ * Thin host component that reads the current character from context
+ * and passes the characterId to the notification manager.
+ * Placed inside CharacterProvider in the root layout.
+ */
+export function AchievementNotificationManagerHost() {
+  const { character } = useCharacter();
+  return <AchievementNotificationManager characterId={character?.id} />;
+}

--- a/components/achievements/AchievementUnlockToast.test.tsx
+++ b/components/achievements/AchievementUnlockToast.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AchievementUnlockToast } from "./AchievementUnlockToast";
+import type { AchievementNotification } from "@/hooks/useAchievementNotifications";
+
+jest.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  motion: {
+    div: ({
+      children,
+      initial,
+      animate,
+      exit,
+      transition,
+      ...props
+    }: React.PropsWithChildren<{
+      initial?: unknown;
+      animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+      [key: string]: unknown;
+    }>) => {
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      return (
+        <div {...(props as React.HTMLAttributes<HTMLDivElement>)}>
+          {children}
+        </div>
+      );
+    },
+  },
+}));
+
+const makeNotification = (
+  overrides: Partial<AchievementNotification> = {},
+): AchievementNotification => ({
+  id: "ca-1",
+  achievementId: "ach-1",
+  name: "First Steps",
+  description: "Complete your first quest",
+  icon: "🏆",
+  xpReward: 100,
+  goldReward: 50,
+  ...overrides,
+});
+
+describe("AchievementUnlockToast", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe("rendering", () => {
+    it("renders achievement name and description", () => {
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification()}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText("First Steps")).toBeInTheDocument();
+      expect(screen.getByText("Complete your first quest")).toBeInTheDocument();
+    });
+
+    it("renders the icon", () => {
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification({ icon: "🏆" })}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText("🏆")).toBeInTheDocument();
+    });
+
+    it("renders XP and gold rewards", () => {
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification({ xpReward: 100, goldReward: 50 })}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText("+100 XP")).toBeInTheDocument();
+      expect(screen.getByText("+50 Gold")).toBeInTheDocument();
+    });
+
+    it("hides rewards section when both are null", () => {
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification({ xpReward: null, goldReward: null })}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(screen.queryByText(/XP/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Gold/)).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when notification is null", () => {
+      const { container } = render(
+        <AchievementUnlockToast notification={null} onDismiss={jest.fn()} />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders dismiss button", () => {
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification()}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /dismiss/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("auto-dismiss", () => {
+    it("calls onDismiss after 5 seconds", () => {
+      const onDismiss = jest.fn();
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification()}
+          onDismiss={onDismiss}
+        />,
+      );
+
+      expect(onDismiss).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onDismiss before 5 seconds", () => {
+      const onDismiss = jest.fn();
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification()}
+          onDismiss={onDismiss}
+        />,
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(4999);
+      });
+
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("manual dismiss", () => {
+    it("calls onDismiss when dismiss button is clicked", async () => {
+      const onDismiss = jest.fn();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification()}
+          onDismiss={onDismiss}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /dismiss/i }));
+
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/components/achievements/AchievementUnlockToast.test.tsx
+++ b/components/achievements/AchievementUnlockToast.test.tsx
@@ -93,6 +93,18 @@ describe("AchievementUnlockToast", () => {
       expect(screen.getByText("+50 Gold")).toBeInTheDocument();
     });
 
+    it("renders rewards section when xpReward is 0 and goldReward is null", () => {
+      render(
+        <AchievementUnlockToast
+          notification={makeNotification({ xpReward: 0, goldReward: null })}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText("+0 XP")).toBeInTheDocument();
+      expect(screen.queryByText(/Gold/)).not.toBeInTheDocument();
+    });
+
     it("hides rewards section when both are null", () => {
       render(
         <AchievementUnlockToast

--- a/components/achievements/AchievementUnlockToast.tsx
+++ b/components/achievements/AchievementUnlockToast.tsx
@@ -57,7 +57,8 @@ export function AchievementUnlockToast({
               </p>
 
               {/* Rewards */}
-              {(notification.xpReward || notification.goldReward) && (
+              {(notification.xpReward != null ||
+                notification.goldReward != null) && (
                 <div className="flex gap-3 mt-2">
                   {notification.xpReward != null && (
                     <span className="text-xs font-semibold bg-white/20 rounded px-2 py-0.5">

--- a/components/achievements/AchievementUnlockToast.tsx
+++ b/components/achievements/AchievementUnlockToast.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { X, Star } from "lucide-react";
+import type { AchievementNotification } from "@/hooks/useAchievementNotifications";
+
+type AchievementUnlockToastProps = {
+  notification: AchievementNotification | null;
+  onDismiss: () => void;
+};
+
+const AUTO_DISMISS_MS = 5000;
+
+export function AchievementUnlockToast({
+  notification,
+  onDismiss,
+}: AchievementUnlockToastProps) {
+  useEffect(() => {
+    if (!notification) return;
+    const timer = setTimeout(onDismiss, AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [notification, onDismiss]);
+
+  return (
+    <AnimatePresence>
+      {notification && (
+        <motion.div
+          key={notification.id}
+          initial={{ opacity: 0, y: -60, scale: 0.85 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -40, scale: 0.9 }}
+          transition={{ type: "spring", stiffness: 300, damping: 24 }}
+          className="fixed top-6 right-6 z-50 w-80 bg-gradient-to-br from-yellow-500 via-amber-500 to-orange-500 text-white rounded-xl shadow-2xl border border-yellow-300 overflow-hidden"
+          role="alert"
+          aria-live="assertive"
+        >
+          {/* Celebratory shimmer bar */}
+          <div className="h-1 bg-gradient-to-r from-white/0 via-white/60 to-white/0 animate-pulse" />
+
+          <div className="p-4 flex items-start gap-3">
+            {/* Icon */}
+            <div className="flex-shrink-0 w-12 h-12 rounded-full bg-white/20 flex items-center justify-center text-2xl">
+              {notification.icon ?? <Star className="h-6 w-6" />}
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-widest text-yellow-100 mb-0.5">
+                Achievement Unlocked!
+              </p>
+              <p className="font-bold text-base leading-tight truncate">
+                {notification.name}
+              </p>
+              <p className="text-sm text-yellow-50 mt-0.5 line-clamp-2">
+                {notification.description}
+              </p>
+
+              {/* Rewards */}
+              {(notification.xpReward || notification.goldReward) && (
+                <div className="flex gap-3 mt-2">
+                  {notification.xpReward != null && (
+                    <span className="text-xs font-semibold bg-white/20 rounded px-2 py-0.5">
+                      +{notification.xpReward} XP
+                    </span>
+                  )}
+                  {notification.goldReward != null && (
+                    <span className="text-xs font-semibold bg-white/20 rounded px-2 py-0.5">
+                      +{notification.goldReward} Gold
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Dismiss button */}
+            <button
+              type="button"
+              onClick={onDismiss}
+              aria-label="Dismiss achievement notification"
+              className="flex-shrink-0 text-white/70 hover:text-white transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/hooks/useAchievementNotifications.catchup.test.ts
+++ b/hooks/useAchievementNotifications.catchup.test.ts
@@ -122,6 +122,30 @@ describe("useAchievementNotifications — catch-up query and deduplication", () 
     expect(result.current.current).toBeNull();
   });
 
+  it("clears queue when characterId transitions to null", async () => {
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { result, rerender } = renderHook(
+      ({ charId }: { charId: string | null }) =>
+        useAchievementNotifications(charId),
+      { initialProps: { charId: CHAR_ID } },
+    );
+
+    await waitFor(() => expect(result.current.current).not.toBeNull());
+
+    rerender({ charId: null });
+
+    await waitFor(() => expect(result.current.current).toBeNull());
+  });
+
   it("calls notified API when an item becomes current", async () => {
     const catchUpRows = [
       { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },

--- a/hooks/useAchievementNotifications.catchup.test.ts
+++ b/hooks/useAchievementNotifications.catchup.test.ts
@@ -166,4 +166,70 @@ describe("useAchievementNotifications — catch-up query and deduplication", () 
       ),
     );
   });
+
+  it("still shows toast when notified PATCH returns non-OK", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+
+    await waitFor(() => expect(result.current.current?.id).toBe(CA_ID));
+  });
+
+  it("retries notified PATCH on remount after a failed write", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false });
+
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { unmount } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    unmount();
+
+    // Remount — guard was not set (PATCH failed), so the write should be retried
+    renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it("resets notified guard on character switch so failed writes can retry", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { rerender } = renderHook(
+      ({ charId }: { charId: string | null }) =>
+        useAchievementNotifications(charId),
+      { initialProps: { charId: CHAR_ID } },
+    );
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // Switch away resets the guard
+    rerender({ charId: null });
+    // Switch back — catch-up re-fetches the still-unnotified row
+    rerender({ charId: CHAR_ID });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+  });
 });

--- a/hooks/useAchievementNotifications.catchup.test.ts
+++ b/hooks/useAchievementNotifications.catchup.test.ts
@@ -1,0 +1,145 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { RealtimeEvent } from "@/lib/realtime-context";
+import { useAchievementNotifications } from "./useAchievementNotifications";
+import {
+  CHAR_ID,
+  ACH_ID,
+  CA_ID,
+  makeAchievement,
+  makeUnlockEvent,
+  makeCatchUpChain,
+  makeAchievementChain,
+} from "./useAchievementNotifications.test-utils";
+
+const mockFrom = jest.fn();
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: "tok" } } }),
+    },
+  },
+}));
+
+const mockOnAchievementUnlockUpdate = jest.fn();
+jest.mock("@/lib/realtime-context", () => ({
+  useRealtime: () => ({
+    onAchievementUnlockUpdate: mockOnAchievementUnlockUpdate,
+  }),
+}));
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+let capturedListener: ((event: RealtimeEvent) => void) | null = null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedListener = null;
+  (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+  mockOnAchievementUnlockUpdate.mockImplementation((listener) => {
+    capturedListener = listener;
+    return () => {};
+  });
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "character_achievements") return makeCatchUpChain([]);
+    if (table === "achievements")
+      return makeAchievementChain(makeAchievement());
+    return {};
+  });
+});
+
+describe("useAchievementNotifications — catch-up query and deduplication", () => {
+  it("loads unnotified achievements on mount", async () => {
+    const catchUpRows = [
+      {
+        id: "ca-10",
+        achievement_id: "ach-10",
+        achievements: {
+          name: "Veteran",
+          description: "Complete 10 quests",
+          icon: "⚔️",
+          xp_reward: 200,
+          gold_reward: 100,
+        },
+      },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+
+    await waitFor(() =>
+      expect(result.current.current?.achievementId).toBe("ach-10"),
+    );
+    expect(result.current.current?.name).toBe("Veteran");
+  });
+
+  it("deduplicates when realtime event arrives for achievement already in catch-up queue", async () => {
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() => expect(result.current.current).not.toBeNull());
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Dismiss the first item — queue should now be empty (no duplicate)
+    act(() => result.current.onDismiss());
+    await waitFor(() => expect(result.current.current).toBeNull());
+  });
+
+  it("skips catch-up rows with no joined achievement data", async () => {
+    const catchUpRows = [
+      { id: "ca-bad", achievement_id: "ach-bad", achievements: null },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(null);
+    });
+
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.current).toBeNull();
+  });
+
+  it("calls notified API when an item becomes current", async () => {
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(catchUpRows);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    renderHook(() => useAchievementNotifications(CHAR_ID));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/character-achievements/${CA_ID}/notified`,
+        expect.objectContaining({ method: "PATCH" }),
+      ),
+    );
+  });
+});

--- a/hooks/useAchievementNotifications.character-filter.test.ts
+++ b/hooks/useAchievementNotifications.character-filter.test.ts
@@ -136,4 +136,50 @@ describe("useAchievementNotifications — character-scoped filtering", () => {
     renderHook(() => useAchievementNotifications(null));
     expect(mockOnAchievementUnlockUpdate).not.toHaveBeenCalled();
   });
+
+  it("discards in-flight fetch results when character changes before fetch resolves", async () => {
+    let resolveAchievementFetch!: (data: unknown) => void;
+    const pendingFetch = new Promise((resolve) => {
+      resolveAchievementFetch = resolve;
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements") return makeCatchUpChain([]);
+      if (table === "achievements")
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockReturnValue(pendingFetch),
+        };
+      return {};
+    });
+
+    const { result, rerender } = renderHook(
+      ({ charId }: { charId: string | null }) =>
+        useAchievementNotifications(charId),
+      { initialProps: { charId: CHAR_ID } },
+    );
+
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    // Fire unlock event for CHAR_ID — starts the async fetch but doesn't resolve yet
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    // Switch to a different character before fetch resolves
+    rerender({ charId: null });
+
+    // Now resolve the fetch for the old character
+    act(() => {
+      resolveAchievementFetch({ data: makeAchievement(), error: null });
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The stale result must not appear in the queue
+    expect(result.current.current).toBeNull();
+  });
 });

--- a/hooks/useAchievementNotifications.character-filter.test.ts
+++ b/hooks/useAchievementNotifications.character-filter.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { RealtimeEvent } from "@/lib/realtime-context";
+import { useAchievementNotifications } from "./useAchievementNotifications";
+import {
+  CHAR_ID,
+  OTHER_CHAR_ID,
+  ACH_ID,
+  CA_ID,
+  makeAchievement,
+  makeUnlockEvent,
+  makeCatchUpChain,
+  makeAchievementChain,
+} from "./useAchievementNotifications.test-utils";
+
+const mockFrom = jest.fn();
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: "tok" } } }),
+    },
+  },
+}));
+
+const mockOnAchievementUnlockUpdate = jest.fn();
+jest.mock("@/lib/realtime-context", () => ({
+  useRealtime: () => ({
+    onAchievementUnlockUpdate: mockOnAchievementUnlockUpdate,
+  }),
+}));
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+let capturedListener: ((event: RealtimeEvent) => void) | null = null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedListener = null;
+  (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+  mockOnAchievementUnlockUpdate.mockImplementation((listener) => {
+    capturedListener = listener;
+    return () => {};
+  });
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "character_achievements") return makeCatchUpChain([]);
+    if (table === "achievements")
+      return makeAchievementChain(makeAchievement());
+    return {};
+  });
+});
+
+describe("useAchievementNotifications — character-scoped filtering", () => {
+  it("ignores realtime events for a different character", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(
+        makeUnlockEvent({
+          record: {
+            id: "ca-other",
+            character_id: OTHER_CHAR_ID,
+            achievement_id: ACH_ID,
+            unlocked_at: "2026-03-22",
+            notified: false,
+          },
+        }),
+      );
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.current).toBeNull();
+  });
+
+  it("only shows events for the current character", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      // Event for current character — should enqueue
+      capturedListener?.(makeUnlockEvent());
+      // Event for other character — should be ignored
+      capturedListener?.(
+        makeUnlockEvent({
+          record: {
+            id: "ca-other",
+            character_id: OTHER_CHAR_ID,
+            achievement_id: "ach-other",
+            unlocked_at: "2026-03-22",
+            notified: false,
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => expect(result.current.current).not.toBeNull());
+    expect(result.current.current?.id).toBe(CA_ID);
+
+    // After dismiss, nothing more to show
+    act(() => result.current.onDismiss());
+    await waitFor(() => expect(result.current.current).toBeNull());
+  });
+
+  it("clears queue and re-runs catch-up when character changes", async () => {
+    let currentCharId = CHAR_ID;
+    const catchUpRows = [
+      { id: CA_ID, achievement_id: ACH_ID, achievements: makeAchievement() },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "character_achievements")
+        return makeCatchUpChain(currentCharId === CHAR_ID ? catchUpRows : []);
+      return makeAchievementChain(makeAchievement());
+    });
+
+    const { result, rerender } = renderHook(
+      ({ charId }) => useAchievementNotifications(charId),
+      { initialProps: { charId: CHAR_ID } },
+    );
+
+    await waitFor(() => expect(result.current.current).not.toBeNull());
+
+    currentCharId = "char-2";
+    rerender({ charId: "char-2" });
+
+    await waitFor(() => expect(result.current.current).toBeNull());
+  });
+
+  it("does not subscribe when characterId is null", () => {
+    renderHook(() => useAchievementNotifications(null));
+    expect(mockOnAchievementUnlockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useAchievementNotifications.queue.test.ts
+++ b/hooks/useAchievementNotifications.queue.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { RealtimeEvent } from "@/lib/realtime-context";
+import { useAchievementNotifications } from "./useAchievementNotifications";
+import {
+  CHAR_ID,
+  makeAchievement,
+  makeUnlockEvent,
+  makeCatchUpChain,
+  makeAchievementChain,
+} from "./useAchievementNotifications.test-utils";
+
+const mockFrom = jest.fn();
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: "tok" } } }),
+    },
+  },
+}));
+
+const mockOnAchievementUnlockUpdate = jest.fn();
+jest.mock("@/lib/realtime-context", () => ({
+  useRealtime: () => ({
+    onAchievementUnlockUpdate: mockOnAchievementUnlockUpdate,
+  }),
+}));
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+let capturedListener: ((event: RealtimeEvent) => void) | null = null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedListener = null;
+  (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+  mockOnAchievementUnlockUpdate.mockImplementation((listener) => {
+    capturedListener = listener;
+    return () => {};
+  });
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "character_achievements") return makeCatchUpChain([]);
+    if (table === "achievements")
+      return makeAchievementChain(makeAchievement());
+    return {};
+  });
+});
+
+describe("useAchievementNotifications — queue management", () => {
+  it("shows one notification at a time and advances on dismiss", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(
+        makeUnlockEvent({
+          record: {
+            id: "ca-1",
+            character_id: CHAR_ID,
+            achievement_id: "ach-1",
+            unlocked_at: "2026-03-22",
+            notified: false,
+          },
+        }),
+      );
+      capturedListener?.(
+        makeUnlockEvent({
+          record: {
+            id: "ca-2",
+            character_id: CHAR_ID,
+            achievement_id: "ach-2",
+            unlocked_at: "2026-03-22",
+            notified: false,
+          },
+          old_record: { id: "ca-2", unlocked_at: null, notified: false },
+        }),
+      );
+    });
+
+    await waitFor(() => expect(result.current.current?.id).toBe("ca-1"));
+
+    act(() => {
+      result.current.onDismiss();
+    });
+
+    await waitFor(() => expect(result.current.current?.id).toBe("ca-2"));
+  });
+
+  it("returns null when queue is empty", () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    expect(result.current.current).toBeNull();
+  });
+
+  it("calls unsubscribe on unmount", async () => {
+    const unsubscribe = jest.fn();
+    mockOnAchievementUnlockUpdate.mockReturnValue(unsubscribe);
+
+    const { unmount } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it("queue is empty after dismissing the last notification", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    await waitFor(() => expect(result.current.current).not.toBeNull());
+
+    act(() => {
+      result.current.onDismiss();
+    });
+
+    await waitFor(() => expect(result.current.current).toBeNull());
+  });
+});

--- a/hooks/useAchievementNotifications.test-utils.ts
+++ b/hooks/useAchievementNotifications.test-utils.ts
@@ -1,0 +1,64 @@
+import type { RealtimeEvent } from "@/lib/realtime-context";
+
+export const CHAR_ID = "char-1";
+export const OTHER_CHAR_ID = "char-other";
+export const ACH_ID = "ach-1";
+export const CA_ID = "ca-1";
+
+export function makeAchievement(overrides = {}) {
+  return {
+    name: "First Steps",
+    description: "Complete your first quest",
+    icon: "🏆",
+    xp_reward: 100,
+    gold_reward: 50,
+    ...overrides,
+  };
+}
+
+export function makeUnlockEvent(
+  overrides: Partial<RealtimeEvent> = {},
+): RealtimeEvent {
+  return {
+    type: "achievement_unlock_updated",
+    table: "character_achievements",
+    action: "UPDATE",
+    record: {
+      id: CA_ID,
+      character_id: CHAR_ID,
+      achievement_id: ACH_ID,
+      unlocked_at: "2026-03-22",
+      notified: false,
+    },
+    old_record: {
+      id: CA_ID,
+      character_id: CHAR_ID,
+      achievement_id: ACH_ID,
+      unlocked_at: null,
+      notified: false,
+    },
+    ...overrides,
+  };
+}
+
+export function makeCatchUpChain(rows: unknown[] = []) {
+  const resolvedChain = {
+    eq: jest.fn().mockResolvedValue({ data: rows, error: null }),
+  };
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    not: jest.fn().mockReturnValue(resolvedChain),
+  };
+}
+
+export function makeAchievementChain(data: unknown = null) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({
+      data,
+      error: data ? null : { message: "not found" },
+    }),
+  };
+}

--- a/hooks/useAchievementNotifications.ts
+++ b/hooks/useAchievementNotifications.ts
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { supabase } from "@/lib/supabase";
+import { useRealtime } from "@/lib/realtime-context";
+import type { RealtimeEvent } from "@/lib/realtime-context";
+
+export type AchievementNotification = {
+  /** character_achievements.id — used to mark notified */
+  id: string;
+  /** achievements.id — used for deduplication */
+  achievementId: string;
+  name: string;
+  description: string;
+  icon: string | null;
+  xpReward: number | null;
+  goldReward: number | null;
+};
+
+async function getAuthToken(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  try {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    return session?.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAchievementById(achievementId: string): Promise<{
+  name: string;
+  description: string;
+  icon: string | null;
+  xp_reward: number | null;
+  gold_reward: number | null;
+} | null> {
+  const { data, error } = await supabase
+    .from("achievements")
+    .select("name, description, icon, xp_reward, gold_reward")
+    .eq("id", achievementId)
+    .single();
+
+  if (error || !data) return null;
+  return data;
+}
+
+async function markCharacterAchievementNotified(id: string): Promise<void> {
+  const token = await getAuthToken();
+  if (!token) return;
+
+  await fetch(`/api/character-achievements/${id}/notified`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+type CatchUpRow = {
+  id: string;
+  achievement_id: string;
+  achievements: {
+    name: string;
+    description: string;
+    icon: string | null;
+    xp_reward: number | null;
+    gold_reward: number | null;
+  } | null;
+};
+
+async function fetchUnnotifiedAchievements(
+  characterId: string,
+): Promise<AchievementNotification[]> {
+  const { data, error } = await supabase
+    .from("character_achievements")
+    .select(
+      "id, achievement_id, achievements(name, description, icon, xp_reward, gold_reward)",
+    )
+    .eq("character_id", characterId)
+    .not("unlocked_at", "is", null)
+    .eq("notified", false);
+
+  if (error || !data) return [];
+
+  return (data as unknown as CatchUpRow[])
+    .filter((row) => row.achievements !== null)
+    .map((row) => ({
+      id: row.id,
+      achievementId: row.achievement_id,
+      name: row.achievements!.name,
+      description: row.achievements!.description,
+      icon: row.achievements!.icon,
+      xpReward: row.achievements!.xp_reward,
+      goldReward: row.achievements!.gold_reward,
+    }));
+}
+
+export interface UseAchievementNotificationsReturn {
+  current: AchievementNotification | null;
+  onDismiss: () => void;
+}
+
+export function useAchievementNotifications(
+  characterId: string | null | undefined,
+): UseAchievementNotificationsReturn {
+  const { onAchievementUnlockUpdate } = useRealtime();
+  const [queue, setQueue] = useState<AchievementNotification[]>([]);
+  // Track achievement IDs already in the queue to deduplicate catch-up + realtime
+  const queuedAchievementIds = useRef<Set<string>>(new Set());
+
+  const enqueue = useCallback((notification: AchievementNotification) => {
+    if (queuedAchievementIds.current.has(notification.achievementId)) return;
+    queuedAchievementIds.current.add(notification.achievementId);
+    setQueue((prev) => [...prev, notification]);
+  }, []);
+
+  // Catch-up query: runs on mount and on character switch
+  useEffect(() => {
+    if (!characterId) return;
+
+    // Clear queue when character changes
+    queuedAchievementIds.current = new Set();
+    setQueue([]);
+
+    let cancelled = false;
+
+    fetchUnnotifiedAchievements(characterId).then((notifications) => {
+      if (cancelled) return;
+      notifications.forEach(enqueue);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [characterId, enqueue]);
+
+  // Realtime subscription for new unlocks
+  useEffect(() => {
+    if (!characterId) return;
+
+    const unsubscribe = onAchievementUnlockUpdate((event: RealtimeEvent) => {
+      // Only act on UPDATE events (unlock engine UPDATEs existing rows)
+      if (event.action !== "UPDATE") return;
+
+      const record = event.record;
+      const oldRecord = event.old_record;
+
+      // Filter to current character only
+      if (record.character_id !== characterId) return;
+
+      // Only process null → non-null unlocked_at transitions
+      if (!record.unlocked_at) return;
+      if (oldRecord?.unlocked_at != null) return;
+
+      // Skip if already notified
+      if (record.notified) return;
+
+      const achievementId = record.achievement_id as string;
+      const caId = record.id as string;
+
+      // Fetch achievement data and enqueue
+      fetchAchievementById(achievementId).then((achievement) => {
+        if (!achievement) return;
+        enqueue({
+          id: caId,
+          achievementId,
+          name: achievement.name,
+          description: achievement.description,
+          icon: achievement.icon,
+          xpReward: achievement.xp_reward,
+          goldReward: achievement.gold_reward,
+        });
+      });
+    });
+
+    return unsubscribe;
+  }, [characterId, onAchievementUnlockUpdate, enqueue]);
+
+  // Mark notified when a new item becomes current
+  const prevCurrentIdRef = useRef<string | null>(null);
+  const current = queue[0] ?? null;
+
+  useEffect(() => {
+    if (!current) return;
+    if (current.id === prevCurrentIdRef.current) return;
+    prevCurrentIdRef.current = current.id;
+    markCharacterAchievementNotified(current.id);
+  }, [current]);
+
+  const onDismiss = useCallback(() => {
+    setQueue((prev) => {
+      const next = prev.slice(1);
+      return next;
+    });
+  }, []);
+
+  return { current, onDismiss };
+}

--- a/hooks/useAchievementNotifications.ts
+++ b/hooks/useAchievementNotifications.ts
@@ -107,6 +107,9 @@ export function useAchievementNotifications(
   const [queue, setQueue] = useState<AchievementNotification[]>([]);
   // Track achievement IDs already in the queue to deduplicate catch-up + realtime
   const queuedAchievementIds = useRef<Set<string>>(new Set());
+  // Track the current characterId so in-flight async fetches can detect stale results
+  const currentCharacterIdRef = useRef<string | null | undefined>(characterId);
+  currentCharacterIdRef.current = characterId;
 
   const enqueue = useCallback((notification: AchievementNotification) => {
     if (queuedAchievementIds.current.has(notification.achievementId)) return;
@@ -116,7 +119,12 @@ export function useAchievementNotifications(
 
   // Catch-up query: runs on mount and on character switch
   useEffect(() => {
-    if (!characterId) return;
+    if (!characterId) {
+      // Clear stale queue when character is deselected (logout, reload, etc.)
+      queuedAchievementIds.current = new Set();
+      setQueue([]);
+      return;
+    }
 
     // Clear queue when character changes
     queuedAchievementIds.current = new Set();
@@ -157,10 +165,14 @@ export function useAchievementNotifications(
 
       const achievementId = record.achievement_id as string;
       const caId = record.id as string;
+      // Capture the characterId at event-receive time so we can detect a switch
+      const capturedCharId = characterId;
 
       // Fetch achievement data and enqueue
       fetchAchievementById(achievementId).then((achievement) => {
         if (!achievement) return;
+        // Discard if the active character changed while the fetch was in-flight
+        if (currentCharacterIdRef.current !== capturedCharId) return;
         enqueue({
           id: caId,
           achievementId,

--- a/hooks/useAchievementNotifications.ts
+++ b/hooks/useAchievementNotifications.ts
@@ -46,14 +46,19 @@ async function fetchAchievementById(achievementId: string): Promise<{
   return data;
 }
 
-async function markCharacterAchievementNotified(id: string): Promise<void> {
+async function markCharacterAchievementNotified(id: string): Promise<boolean> {
   const token = await getAuthToken();
-  if (!token) return;
+  if (!token) return false;
 
-  await fetch(`/api/character-achievements/${id}/notified`, {
-    method: "PATCH",
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  try {
+    const response = await fetch(`/api/character-achievements/${id}/notified`, {
+      method: "PATCH",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 type CatchUpRow = {
@@ -110,6 +115,9 @@ export function useAchievementNotifications(
   // Track the current characterId so in-flight async fetches can detect stale results
   const currentCharacterIdRef = useRef<string | null | undefined>(characterId);
   currentCharacterIdRef.current = characterId;
+  // Guard to avoid re-firing the mark-notified effect for the same id;
+  // reset when the queue is cleared so failed writes can be retried
+  const prevCurrentIdRef = useRef<string | null>(null);
 
   const enqueue = useCallback((notification: AchievementNotification) => {
     if (queuedAchievementIds.current.has(notification.achievementId)) return;
@@ -122,12 +130,14 @@ export function useAchievementNotifications(
     if (!characterId) {
       // Clear stale queue when character is deselected (logout, reload, etc.)
       queuedAchievementIds.current = new Set();
+      prevCurrentIdRef.current = null;
       setQueue([]);
       return;
     }
 
     // Clear queue when character changes
     queuedAchievementIds.current = new Set();
+    prevCurrentIdRef.current = null;
     setQueue([]);
 
     let cancelled = false;
@@ -188,15 +198,16 @@ export function useAchievementNotifications(
     return unsubscribe;
   }, [characterId, onAchievementUnlockUpdate, enqueue]);
 
-  // Mark notified when a new item becomes current
-  const prevCurrentIdRef = useRef<string | null>(null);
+  // Mark notified when a new item becomes current; only set the guard on success
+  // so transient failures (auth not ready, network, 5xx) can be retried on remount
   const current = queue[0] ?? null;
 
   useEffect(() => {
     if (!current) return;
     if (current.id === prevCurrentIdRef.current) return;
-    prevCurrentIdRef.current = current.id;
-    markCharacterAchievementNotified(current.id);
+    markCharacterAchievementNotified(current.id).then((success) => {
+      if (success) prevCurrentIdRef.current = current.id;
+    });
   }, [current]);
 
   const onDismiss = useCallback(() => {

--- a/hooks/useAchievementNotifications.ts
+++ b/hooks/useAchievementNotifications.ts
@@ -127,18 +127,14 @@ export function useAchievementNotifications(
 
   // Catch-up query: runs on mount and on character switch
   useEffect(() => {
-    if (!characterId) {
-      // Clear stale queue when character is deselected (logout, reload, etc.)
-      queuedAchievementIds.current = new Set();
-      prevCurrentIdRef.current = null;
-      setQueue([]);
-      return;
-    }
-
-    // Clear queue when character changes
+    // Clear queue and refs on character change or deselection
     queuedAchievementIds.current = new Set();
     prevCurrentIdRef.current = null;
     setQueue([]);
+
+    if (!characterId) {
+      return;
+    }
 
     let cancelled = false;
 

--- a/hooks/useAchievementNotifications.unlock-detection.test.ts
+++ b/hooks/useAchievementNotifications.unlock-detection.test.ts
@@ -1,0 +1,123 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { RealtimeEvent } from "@/lib/realtime-context";
+import { useAchievementNotifications } from "./useAchievementNotifications";
+import {
+  CHAR_ID,
+  ACH_ID,
+  CA_ID,
+  makeAchievement,
+  makeUnlockEvent,
+  makeCatchUpChain,
+  makeAchievementChain,
+} from "./useAchievementNotifications.test-utils";
+
+const mockFrom = jest.fn();
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: "tok" } } }),
+    },
+  },
+}));
+
+const mockOnAchievementUnlockUpdate = jest.fn();
+jest.mock("@/lib/realtime-context", () => ({
+  useRealtime: () => ({
+    onAchievementUnlockUpdate: mockOnAchievementUnlockUpdate,
+  }),
+}));
+
+global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+let capturedListener: ((event: RealtimeEvent) => void) | null = null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedListener = null;
+  (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+  mockOnAchievementUnlockUpdate.mockImplementation((listener) => {
+    capturedListener = listener;
+    return () => {};
+  });
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "character_achievements") return makeCatchUpChain([]);
+    if (table === "achievements")
+      return makeAchievementChain(makeAchievement());
+    return {};
+  });
+});
+
+describe("useAchievementNotifications — unlock detection", () => {
+  it("enqueues a notification when UPDATE transitions unlocked_at null → non-null", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent());
+    });
+
+    await waitFor(() => expect(result.current.current).not.toBeNull());
+    expect(result.current.current?.achievementId).toBe(ACH_ID);
+  });
+
+  it("ignores events where unlocked_at was already set (non-null old_record)", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(
+        makeUnlockEvent({
+          old_record: { id: CA_ID, unlocked_at: "2026-01-01", notified: false },
+        }),
+      );
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.current).toBeNull();
+  });
+
+  it("ignores events where notified is already true", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(
+        makeUnlockEvent({
+          record: {
+            id: CA_ID,
+            character_id: CHAR_ID,
+            achievement_id: ACH_ID,
+            unlocked_at: "2026-03-22",
+            notified: true,
+          },
+        }),
+      );
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.current).toBeNull();
+  });
+
+  it("ignores INSERT events", async () => {
+    const { result } = renderHook(() => useAchievementNotifications(CHAR_ID));
+    await waitFor(() =>
+      expect(mockOnAchievementUnlockUpdate).toHaveBeenCalled(),
+    );
+
+    act(() => {
+      capturedListener?.(makeUnlockEvent({ action: "INSERT" }));
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.current).toBeNull();
+  });
+});

--- a/lib/realtime-context.tsx
+++ b/lib/realtime-context.tsx
@@ -34,6 +34,7 @@ export const useRealtime = () => {
       onFamilyMemberUpdate: () => () => {},
       onBossQuestUpdate: () => () => {},
       onBossParticipantUpdate: () => () => {},
+      onAchievementUnlockUpdate: () => () => {},
       refreshQuests: () => {},
       refreshQuestTemplates: () => {},
       refreshCharacters: () => {},
@@ -60,6 +61,7 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
   const familyMemberListeners = useRef(createListenerRegistry());
   const bossQuestListeners = useRef(createListenerRegistry());
   const bossParticipantListeners = useRef(createListenerRegistry());
+  const achievementUnlockListeners = useRef(createListenerRegistry());
 
   const clearListenersRef = useRef(() => {
     questListeners.current.clear();
@@ -70,6 +72,7 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
     familyMemberListeners.current.clear();
     bossQuestListeners.current.clear();
     bossParticipantListeners.current.clear();
+    achievementUnlockListeners.current.clear();
   });
 
   const setUpChannel = useCallback(async () => {
@@ -108,6 +111,7 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
       familyMember: familyMemberListeners.current,
       bossQuest: bossQuestListeners.current,
       bossParticipant: bossParticipantListeners.current,
+      achievementUnlock: achievementUnlockListeners.current,
     };
 
     const channels = createFamilyRealtimeChannels(familyId, registries);
@@ -234,6 +238,10 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
     (cb: Listener) => bossParticipantListeners.current.add(cb),
     [],
   );
+  const onAchievementUnlockUpdate = useCallback(
+    (cb: Listener) => achievementUnlockListeners.current.add(cb),
+    [],
+  );
 
   const value = React.useMemo(
     () => ({
@@ -247,6 +255,7 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
       onFamilyMemberUpdate,
       onBossQuestUpdate,
       onBossParticipantUpdate,
+      onAchievementUnlockUpdate,
       refreshQuests,
       refreshQuestTemplates,
       refreshCharacters,
@@ -263,6 +272,7 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
       onQuestUpdate,
       onRewardRedemptionUpdate,
       onRewardUpdate,
+      onAchievementUnlockUpdate,
       refreshQuests,
       refreshQuestTemplates,
       refreshCharacters,

--- a/lib/realtime/__tests__/achievement-unlock-listener.test.ts
+++ b/lib/realtime/__tests__/achievement-unlock-listener.test.ts
@@ -1,0 +1,90 @@
+import { createListenerRegistry } from "../listener-registry";
+import type { RealtimeEvent } from "../types";
+
+const makeUnlockEvent = (
+  overrides: Partial<RealtimeEvent> = {},
+): RealtimeEvent => ({
+  type: "achievement_unlock_updated",
+  table: "character_achievements",
+  action: "UPDATE",
+  record: {
+    id: "ca-1",
+    character_id: "char-1",
+    unlocked_at: "2026-01-01",
+    notified: false,
+  },
+  old_record: {
+    id: "ca-1",
+    character_id: "char-1",
+    unlocked_at: null,
+    notified: false,
+  },
+  ...overrides,
+});
+
+describe("achievement unlock listener registry", () => {
+  it("registers and receives an achievement unlock event", () => {
+    const registry = createListenerRegistry();
+    const listener = jest.fn();
+
+    registry.add(listener);
+    registry.emit(makeUnlockEvent());
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "achievement_unlock_updated" }),
+    );
+  });
+
+  it("delivers events to multiple registered listeners", () => {
+    const registry = createListenerRegistry();
+    const listenerA = jest.fn();
+    const listenerB = jest.fn();
+
+    registry.add(listenerA);
+    registry.add(listenerB);
+    registry.emit(makeUnlockEvent());
+
+    expect(listenerA).toHaveBeenCalledTimes(1);
+    expect(listenerB).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribing removes the listener from future events", () => {
+    const registry = createListenerRegistry();
+    const listener = jest.fn();
+
+    const unsubscribe = registry.add(listener);
+    unsubscribe();
+    registry.emit(makeUnlockEvent());
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("clear() removes all listeners", () => {
+    const registry = createListenerRegistry();
+    const listener = jest.fn();
+
+    registry.add(listener);
+    registry.clear();
+    registry.emit(makeUnlockEvent());
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emits correct old_record on UPDATE events (null to non-null transition)", () => {
+    const registry = createListenerRegistry();
+    const listener = jest.fn();
+
+    registry.add(listener);
+    registry.emit(
+      makeUnlockEvent({
+        old_record: { id: "ca-1", unlocked_at: null },
+        record: { id: "ca-1", unlocked_at: "2026-03-22", notified: false },
+      }),
+    );
+
+    const event = listener.mock.calls[0][0] as RealtimeEvent;
+    expect(event.old_record?.unlocked_at).toBeNull();
+    expect(event.record.unlocked_at).toBe("2026-03-22");
+  });
+});

--- a/lib/realtime/__tests__/channel-subscriptions.test.ts
+++ b/lib/realtime/__tests__/channel-subscriptions.test.ts
@@ -1,0 +1,106 @@
+import { createFamilyRealtimeChannels } from "../channel-subscriptions";
+import { createListenerRegistry } from "../listener-registry";
+
+const mockOn = jest.fn().mockReturnThis();
+const mockChannel = jest.fn(() => ({ on: mockOn }));
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: { channel: (...args: unknown[]) => mockChannel(...args) },
+}));
+
+const FAMILY_ID = "family-123";
+
+function makeRegistries() {
+  return {
+    quest: createListenerRegistry(),
+    questTemplate: createListenerRegistry(),
+    character: createListenerRegistry(),
+    reward: createListenerRegistry(),
+    rewardRedemption: createListenerRegistry(),
+    familyMember: createListenerRegistry(),
+    bossQuest: createListenerRegistry(),
+    bossParticipant: createListenerRegistry(),
+    achievementUnlock: createListenerRegistry(),
+  };
+}
+
+describe("createFamilyRealtimeChannels", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChannel.mockReturnValue({ on: mockOn });
+  });
+
+  it("creates a channel for character_achievements", () => {
+    const registries = makeRegistries();
+    createFamilyRealtimeChannels(FAMILY_ID, registries);
+
+    const channelNames = mockChannel.mock.calls.map((c) => c[0]);
+    expect(channelNames).toContain(
+      `family_${FAMILY_ID}_character_achievements`,
+    );
+  });
+
+  it("subscribes to character_achievements without a family_id filter", () => {
+    const registries = makeRegistries();
+    createFamilyRealtimeChannels(FAMILY_ID, registries);
+
+    const achIdx = mockChannel.mock.calls.findIndex(
+      (c) => c[0] === `family_${FAMILY_ID}_character_achievements`,
+    );
+    expect(achIdx).toBeGreaterThanOrEqual(0);
+
+    // The postgres_changes subscription options for that channel's .on() call
+    const onCall = mockOn.mock.calls[achIdx];
+    const opts = onCall[1] as Record<string, unknown>;
+    expect(opts.table).toBe("character_achievements");
+    expect(opts.filter).toBeUndefined();
+  });
+
+  it("maps achievement channel events to achievement_unlock_updated type", () => {
+    const registries = makeRegistries();
+    const emitSpy = jest.spyOn(registries.achievementUnlock, "emit");
+
+    // Capture the postgres_changes callback for the achievement channel
+    let achievementCallback: ((payload: unknown) => void) | null = null;
+    mockChannel.mockImplementation((name: string) => {
+      return {
+        on: (_event: string, _opts: unknown, cb: (p: unknown) => void) => {
+          if (name === `family_${FAMILY_ID}_character_achievements`) {
+            achievementCallback = cb;
+          }
+          return { on: mockOn };
+        },
+      };
+    });
+
+    createFamilyRealtimeChannels(FAMILY_ID, registries);
+
+    expect(achievementCallback).not.toBeNull();
+
+    achievementCallback!({
+      eventType: "UPDATE",
+      new: { id: "ca-1", character_id: "char-1", unlocked_at: "2026-01-01" },
+      old: { id: "ca-1", character_id: "char-1", unlocked_at: null },
+    });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "achievement_unlock_updated",
+        table: "character_achievements",
+        action: "UPDATE",
+      }),
+    );
+  });
+
+  it("creates channels for all expected tables including character_achievements", () => {
+    const registries = makeRegistries();
+    createFamilyRealtimeChannels(FAMILY_ID, registries);
+
+    const channelNames = mockChannel.mock.calls.map((c) => c[0] as string);
+    expect(channelNames).toContain(`family_${FAMILY_ID}_quest_instances`);
+    expect(channelNames).toContain(`family_${FAMILY_ID}_characters`);
+    expect(channelNames).toContain(
+      `family_${FAMILY_ID}_character_achievements`,
+    );
+  });
+});

--- a/lib/realtime/channel-subscriptions.ts
+++ b/lib/realtime/channel-subscriptions.ts
@@ -11,6 +11,7 @@ type ChannelRegistries = {
   familyMember: ListenerRegistry;
   bossQuest: ListenerRegistry;
   bossParticipant: ListenerRegistry;
+  achievementUnlock: ListenerRegistry;
 };
 
 const mapEvent =
@@ -96,6 +97,14 @@ export const createFamilyRealtimeChannels = (
       table: "boss_battle_participants",
       eventType: "boss_participant_updated",
       registry: registries.bossParticipant,
+    },
+    {
+      channelName: `family_${familyId}_character_achievements`,
+      table: "character_achievements",
+      // character_achievements has no family_id column; omit filter so events
+      // are delivered. The notification hook filters client-side by character_id.
+      eventType: "achievement_unlock_updated",
+      registry: registries.achievementUnlock,
     },
   ];
 

--- a/lib/realtime/types.ts
+++ b/lib/realtime/types.ts
@@ -8,7 +8,8 @@ export type RealtimeEventType =
   | "reward_redemption_updated"
   | "family_member_updated"
   | "boss_quest_updated"
-  | "boss_participant_updated";
+  | "boss_participant_updated"
+  | "achievement_unlock_updated";
 
 export interface RealtimeEvent {
   type: RealtimeEventType;
@@ -37,6 +38,7 @@ export interface RealtimeContextType {
   onFamilyMemberUpdate: (callback: Listener) => () => void;
   onBossQuestUpdate: (callback: Listener) => () => void;
   onBossParticipantUpdate: (callback: Listener) => () => void;
+  onAchievementUnlockUpdate: (callback: Listener) => () => void;
   refreshQuests: () => void;
   refreshQuestTemplates: () => void;
   refreshCharacters: () => void;

--- a/openspec/changes/achievement-notification-system/.openspec.yaml
+++ b/openspec/changes/achievement-notification-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/achievement-notification-system/design.md
+++ b/openspec/changes/achievement-notification-system/design.md
@@ -1,0 +1,197 @@
+# Achievement Notification System — Design
+
+## Context
+
+The achievement unlock evaluation engine (#136) writes to
+`character_achievements` when progress changes or an
+achievement is fully unlocked (sets `unlocked_at`). The
+schema already includes a `notified` boolean column
+(default `false`) and `REPLICA IDENTITY FULL` on the
+table — both anticipating this notification system.
+
+The app has two relevant patterns:
+
+1. **Realtime subscriptions** — one channel per table,
+   listener registries that persist across reconnects,
+   family-scoped where possible.
+2. **Toast notifications** — `useNotification` hook for
+   generic toasts, plus the specialized
+   `RedeemSuccessToast` pattern for richer, dedicated
+   toast components.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Deliver real-time in-app toast when a character unlocks
+  an achievement
+- Display achievement name, description, icon, and
+  XP/gold rewards in the toast
+- Auto-dismiss after ~5 seconds with manual dismiss
+- Queue multiple simultaneous unlocks and show
+  sequentially
+- Mark `notified: true` to prevent re-showing on refresh
+- Follow existing realtime and toast architecture
+
+**Non-Goals:**
+
+- Push notifications (browser/mobile) — future work
+- Sound effects — deferred; CSS animation only for now
+- Achievement progress toasts (only full unlocks)
+- Admin/parent notification of child achievements
+- Email or external notification channels
+
+## Decisions
+
+### 1. Dedicated hook + component vs. extending useNotification
+
+**Decision:** Create a dedicated
+`useAchievementNotifications` hook and
+`AchievementUnlockToast` component, separate from the
+generic `useNotification` system.
+
+**Why:** Achievement toasts need richer data (icon,
+description, rewards), sequential queuing, and
+database writes (`notified` flag). The generic
+`useNotification` hook handles simple text messages
+with no queue ordering. Extending it would bloat the
+generic system. The `RedeemSuccessToast` sets precedent
+for dedicated toast components.
+
+**Alternative considered:** Extend `useNotification`
+with a new `'achievement'` type. Rejected because it
+would require the generic hook to understand
+achievement-specific data structures and sequencing.
+
+### 2. Realtime subscription approach
+
+**Decision:** Add a new `achievementUnlock` listener
+registry and `character_achievements` channel to the
+existing `RealtimeProvider`, following the same pattern
+as all other table subscriptions.
+
+**Why:** Consistent with the established one-channel-
+per-table architecture. The listener registry pattern
+ensures callbacks survive channel reconnects.
+
+**Filter strategy:** `character_achievements` has no
+`family_id` column (same situation as
+`reward_redemptions`). Subscribe without a filter. The
+notification hook will filter client-side by matching
+`character_id` against the current character context.
+
+**Alternative considered:** A separate React context
+for achievement notifications. Rejected — it would
+duplicate the realtime plumbing that `RealtimeProvider`
+already manages.
+
+### 3. Detecting new unlocks vs. all changes
+
+**Decision:** Listen for UPDATE events where
+`unlocked_at` transitions from null to non-null, and
+`notified` is false.
+
+**Why:** The unlock engine first INSERTs a
+`character_achievements` row with `unlocked_at = null`
+(in-progress), then UPDATEs it when criteria are met.
+The meaningful signal is the UPDATE that sets
+`unlocked_at`. Checking `notified = false` provides
+idempotency.
+
+**Alternative considered:** Listen for INSERT with
+`unlocked_at` already set. This could miss achievements
+that were inserted as in-progress and later unlocked.
+Listening for UPDATE covers both flows.
+
+### 4. Notification queue architecture
+
+**Decision:** A simple array-based queue in the hook.
+When realtime delivers unlock events, push to queue.
+Display one toast at a time. On dismiss or auto-dismiss,
+shift the queue and show the next item.
+
+**Why:** Simultaneous unlocks are uncommon (typically
+1-2 at most). A simple queue avoids over-engineering.
+No need for a priority system or persistence — if the
+user navigates away mid-queue, remaining items will
+show via the `notified = false` catch-up fetch.
+
+### 5. Catch-up on mount for missed notifications
+
+**Decision:** On mount, the hook queries
+`character_achievements` for rows where
+`unlocked_at IS NOT NULL AND notified = false` for the
+current character. These are added to the queue ahead
+of any realtime events.
+
+**Why:** Covers the case where achievements unlock
+while the user is offline or on a different page, or
+if the realtime event was missed. The `notified` column
+ensures each achievement is shown exactly once.
+
+### 6. Marking notified
+
+**Decision:** Call a Supabase update to set
+`notified = true` immediately when a toast is displayed
+(not on dismiss).
+
+**Why:** If the user refreshes mid-display, the
+achievement won't re-queue. Setting on display rather
+than dismiss prevents the edge case where a user
+dismisses quickly and refreshes before the write
+completes.
+
+**Auth note:** `character_achievements` INSERT/UPDATE
+is service-role only per RLS policy. The `notified`
+update will need to go through an API route
+(`PATCH /api/character-achievements/[id]/notified`)
+that uses the service-role client.
+
+### 7. Component placement
+
+**Decision:** Mount `AchievementNotificationManager`
+(the component that owns the hook and renders toasts)
+inside the `CharacterProvider` in the layout, so it
+has access to both realtime context and the selected
+character.
+
+**Why:** It needs `useRealtime()` for the subscription
+and the current `characterId` to filter events and
+query unnotified achievements.
+
+## Risks / Trade-offs
+
+- **No family_id filter on realtime channel** — All
+  `character_achievements` events for all families hit
+  the client. Client-side filtering by `character_id`
+  is cheap, but generates unnecessary network traffic.
+  → Mitigation: Same pattern as `reward_redemptions`;
+  acceptable at current scale. Can add a DB function or
+  view with `family_id` later if needed.
+
+- **Service-role requirement for notified update** —
+  Adds an API route for a single-column update.
+  → Mitigation: Lightweight route, consistent with
+  existing patterns (quest approval, reward redemption).
+
+- **Race between realtime event and catch-up query** —
+  On mount, both the catch-up query and a realtime
+  event could deliver the same achievement.
+  → Mitigation: Deduplicate in the queue by
+  `achievement_id`. The `notified` flag provides a
+  second layer of protection.
+
+- **Toast stacking if many achievements unlock** —
+  Sequential display could feel slow with 5+ unlocks.
+  → Mitigation: Unlikely in practice (achievement
+  criteria are varied). Could add a "X more unlocked"
+  summary toast later if needed.
+
+## Open Questions
+
+- Should the toast include a "View Achievements" link
+  that navigates to a future achievements page?
+  (Deferred — no achievements page exists yet.)
+- Should the CSS animation be configurable per
+  achievement rarity/tier? (Deferred — keep simple for
+  initial implementation.)

--- a/openspec/changes/achievement-notification-system/proposal.md
+++ b/openspec/changes/achievement-notification-system/proposal.md
@@ -1,0 +1,59 @@
+# Achievement Notification System
+
+## Why
+
+The achievement system can now track progress and evaluate
+unlocks (#134, #136), but players receive no feedback when
+they earn an achievement. Without real-time notifications,
+unlocks go unnoticed — undermining the motivational loop
+that achievements are designed to create. The
+`character_achievements.notified` column already exists
+in the schema, waiting for a consumer.
+
+## What Changes
+
+- Subscribe to `character_achievements` table via
+  Supabase Realtime to detect new unlocks
+- Add a new `AchievementUnlockToast` component that
+  displays achievement name, description, icon, and
+  XP/gold rewards with a celebratory CSS animation
+- Toast auto-dismisses after ~5 seconds with a manual
+  dismiss option
+- Queue multiple simultaneous unlocks and display them
+  sequentially
+- Mark `notified: true` on `character_achievements`
+  after displaying to prevent re-showing on refresh
+- Extend `RealtimeProvider` with an achievement unlock
+  listener registry following the existing channel
+  subscription pattern
+
+## Capabilities
+
+### New Capabilities
+
+- `achievement-notification`: Real-time achievement
+  unlock detection, notification queuing, toast display,
+  and notified-state management
+
+### Modified Capabilities
+
+- `realtime-subscriptions`: Add
+  `character_achievements` table subscription and
+  `achievement_unlocked` event type to the existing
+  realtime channel system
+
+## Impact
+
+- **Components**: New `AchievementUnlockToast`
+  component; new notification queue hook
+- **Contexts**: `RealtimeProvider` gains achievement
+  unlock listener registry and channel subscription
+- **Types**: `RealtimeEventType` enum extended with
+  achievement unlock event
+- **Database**: Requires `REPLICA IDENTITY FULL` on
+  `character_achievements` (already set in schema
+  migration); writes to `notified` column on display
+- **Dependencies**: Builds on achievement schema (#134)
+  and unlock evaluation engine (#136); follows patterns
+  from existing realtime subscriptions and
+  `RedeemSuccessToast`

--- a/openspec/changes/achievement-notification-system/specs/achievement-notification/spec.md
+++ b/openspec/changes/achievement-notification-system/specs/achievement-notification/spec.md
@@ -156,8 +156,7 @@ RLS restricts direct client writes to service-role only.
 #### Scenario: PATCH updates notified flag
 
 - **WHEN** a `PATCH` request is sent to
-  `/api/character-achievements/[id]/notified` with
-  `{ "notified": true }`
+  `/api/character-achievements/[id]/notified`
 - **THEN** the API SHALL update the
   `character_achievements` row and return 200
 

--- a/openspec/changes/achievement-notification-system/specs/achievement-notification/spec.md
+++ b/openspec/changes/achievement-notification-system/specs/achievement-notification/spec.md
@@ -1,0 +1,174 @@
+# Achievement Notification Specification
+
+## ADDED Requirements
+
+### Requirement: Achievement unlock toast display
+
+The system SHALL display a toast notification when a
+character unlocks an achievement. The toast MUST show the
+achievement name, description, icon, and any XP/gold
+rewards earned. The toast MUST auto-dismiss after 5
+seconds and provide a manual dismiss button.
+
+#### Scenario: Toast appears on achievement unlock
+
+- **WHEN** a `character_achievements` row is updated
+  with `unlocked_at` transitioning from null to non-null
+  for the current character
+- **THEN** an `AchievementUnlockToast` SHALL appear as a
+  fixed overlay displaying the achievement name,
+  description, icon, and XP/gold reward amounts
+
+#### Scenario: Toast auto-dismisses after timeout
+
+- **WHEN** an achievement unlock toast has been visible
+  for 5 seconds without user interaction
+- **THEN** the toast SHALL automatically dismiss with an
+  exit animation
+
+#### Scenario: Toast manually dismissed
+
+- **WHEN** the user clicks the dismiss button on an
+  achievement unlock toast
+- **THEN** the toast SHALL immediately dismiss with an
+  exit animation
+
+#### Scenario: Toast renders with celebratory animation
+
+- **WHEN** an achievement unlock toast appears
+- **THEN** the toast SHALL render with a CSS entrance
+  animation (slide-in and/or scale effect) to create a
+  celebratory visual flourish
+
+### Requirement: Achievement notification queue
+
+The system SHALL queue multiple simultaneous achievement
+unlocks and display them sequentially, one at a time.
+
+#### Scenario: Multiple simultaneous unlocks queued
+
+- **WHEN** two or more achievements unlock at the same
+  time for the current character
+- **THEN** the system SHALL display them one at a time
+  in sequence, showing the next toast only after the
+  previous one is dismissed or auto-dismissed
+
+#### Scenario: Queue processes in order
+
+- **WHEN** three achievements (A, B, C) are queued for
+  notification
+- **THEN** the system SHALL display A first, then B after
+  A is dismissed, then C after B is dismissed
+
+#### Scenario: New unlock during active toast
+
+- **WHEN** a new achievement unlocks while a toast is
+  currently being displayed
+- **THEN** the new achievement SHALL be added to the end
+  of the queue and displayed after all preceding toasts
+  are dismissed
+
+### Requirement: Achievement notified state management
+
+The system SHALL mark achievements as `notified: true`
+in the database after displaying their toast to prevent
+re-showing on page refresh or reconnection.
+
+#### Scenario: Notified flag set on display
+
+- **WHEN** an achievement unlock toast is displayed to
+  the user
+- **THEN** the system SHALL immediately update
+  `character_achievements.notified` to `true` via API
+  route
+
+#### Scenario: Already-notified achievements not re-shown
+
+- **WHEN** a realtime event arrives for an achievement
+  where `notified` is already `true`
+- **THEN** the system SHALL NOT add it to the
+  notification queue
+
+#### Scenario: Notified update persists across refresh
+
+- **WHEN** a user refreshes the page after an
+  achievement toast was displayed
+- **THEN** the achievement SHALL NOT appear in the
+  notification queue because `notified` is `true` in
+  the database
+
+### Requirement: Catch-up notification on mount
+
+The system SHALL query for unnotified unlocked
+achievements on mount and queue them for display, so
+achievements unlocked while the user was offline or on
+another page are not missed.
+
+#### Scenario: Unnotified achievements shown on mount
+
+- **WHEN** the notification manager component mounts and
+  the current character has achievements where
+  `unlocked_at IS NOT NULL AND notified = false`
+- **THEN** those achievements SHALL be added to the
+  notification queue and displayed sequentially
+
+#### Scenario: No duplicate between catch-up and realtime
+
+- **WHEN** a catch-up query returns an achievement and
+  a realtime event arrives for the same achievement
+- **THEN** the system SHALL deduplicate by
+  `achievement_id` and display the achievement only once
+
+#### Scenario: No catch-up toasts for notified achievements
+
+- **WHEN** the notification manager mounts and all
+  unlocked achievements for the current character have
+  `notified = true`
+- **THEN** no toasts SHALL be displayed
+
+### Requirement: Character-scoped notifications
+
+The notification system SHALL only display achievement
+toasts for the currently selected character, filtering
+out events for other characters.
+
+#### Scenario: Only current character events shown
+
+- **WHEN** a `character_achievements` realtime event
+  arrives for a character that is NOT the currently
+  selected character
+- **THEN** the system SHALL NOT add it to the
+  notification queue
+
+#### Scenario: Queue clears on character switch
+
+- **WHEN** the user switches to a different character
+  while achievement toasts are queued
+- **THEN** the pending queue SHALL be cleared and
+  catch-up query SHALL re-run for the new character
+
+### Requirement: Notified update API route
+
+The system SHALL provide an API route for updating the
+`notified` flag on `character_achievements` rows, since
+RLS restricts direct client writes to service-role only.
+
+#### Scenario: PATCH updates notified flag
+
+- **WHEN** a `PATCH` request is sent to
+  `/api/character-achievements/[id]/notified` with
+  `{ "notified": true }`
+- **THEN** the API SHALL update the
+  `character_achievements` row and return 200
+
+#### Scenario: Unauthorized request rejected
+
+- **WHEN** an unauthenticated request is sent to the
+  notified API route
+- **THEN** the API SHALL return 401
+
+#### Scenario: Non-existent record returns 404
+
+- **WHEN** a `PATCH` request targets a
+  `character_achievements` ID that does not exist
+- **THEN** the API SHALL return 404

--- a/openspec/changes/achievement-notification-system/specs/realtime-subscriptions/spec.md
+++ b/openspec/changes/achievement-notification-system/specs/realtime-subscriptions/spec.md
@@ -1,0 +1,113 @@
+# Realtime Subscriptions — Achievement Delta
+
+## MODIFIED Requirements
+
+### Requirement: Realtime Context Subscription API
+
+The `useRealtime()` hook SHALL provide subscription
+callbacks for character, quest, reward, boss quest, and
+**achievement unlock** updates. The realtime channel
+SHALL remain connected across auth token refreshes and
+SHALL only be destroyed and recreated when the user's
+`family_id` changes. The channel lifecycle MUST NOT
+depend on the `session` or `user` objects from the auth
+context.
+
+#### Scenario: Channel survives auth token refresh
+
+- **WHEN** the Supabase auth client fires a
+  `TOKEN_REFRESHED` event while a family realtime
+  channel is active
+- **THEN** the existing channel MUST remain connected
+  and continue receiving `postgres_changes` events
+  without interruption
+
+#### Scenario: Channel reconnects on family change
+
+- **WHEN** the user's `profile.family_id` changes
+  (e.g., joining a different family)
+- **THEN** the old channel MUST be removed via
+  `supabase.removeChannel()` and a new channel MUST be
+  created for the new family
+
+#### Scenario: Channel removed on logout
+
+- **WHEN** the user logs out and `profile` becomes null
+- **THEN** the channel MUST be removed and listener
+  registries MUST be cleared
+
+#### Scenario: Components subscribe to character updates
+
+- **WHEN** a component calls
+  `const { onCharacterUpdate } = useRealtime()`
+- **THEN** the callback fires with the realtime event
+  data when the character table receives an UPDATE event
+
+#### Scenario: Multiple components listen to same table updates
+
+- **WHEN** two components subscribe to quest updates via
+  `onQuestUpdate()`
+- **THEN** both components receive the realtime event
+  and can update independently
+
+#### Scenario: Components subscribe to achievement unlock events
+
+- **WHEN** a component calls
+  `const { onAchievementUnlockUpdate } = useRealtime()`
+- **THEN** the callback fires with the realtime event
+  data when the `character_achievements` table receives
+  an INSERT or UPDATE event
+
+## ADDED Requirements
+
+### Requirement: Achievement unlock realtime channel
+
+The realtime system SHALL subscribe to the
+`character_achievements` table and emit events through
+an `achievementUnlock` listener registry, following the
+existing one-channel-per-table pattern.
+
+#### Scenario: Channel created for character_achievements
+
+- **WHEN** the `RealtimeProvider` sets up channels for
+  a family
+- **THEN** a channel named
+  `family_{familyId}_character_achievements` SHALL be
+  created subscribing to all events on the
+  `character_achievements` table
+
+#### Scenario: No family_id filter on subscription
+
+- **WHEN** the `character_achievements` channel is
+  created
+- **THEN** the subscription SHALL NOT include a
+  `family_id` filter (the table has no `family_id`
+  column), matching the pattern used by
+  `reward_redemptions`
+
+#### Scenario: Events emitted to achievement listener registry
+
+- **WHEN** a postgres change event arrives on the
+  `character_achievements` channel
+- **THEN** the event SHALL be mapped to a
+  `RealtimeEvent` with type
+  `"achievement_unlock_updated"` and emitted to the
+  `achievementUnlock` listener registry
+
+### Requirement: Achievement unlock event type
+
+The realtime type system SHALL include an event type
+for achievement unlock table changes.
+
+#### Scenario: RealtimeEventType includes achievement type
+
+- **WHEN** the `RealtimeEventType` union is defined
+- **THEN** it SHALL include
+  `"achievement_unlock_updated"` as a valid member
+
+#### Scenario: RealtimeContextType exposes callback
+
+- **WHEN** the `RealtimeContextType` interface is
+  defined
+- **THEN** it SHALL include
+  `onAchievementUnlockUpdate: (callback: Listener) => () => void`

--- a/openspec/changes/achievement-notification-system/tasks.md
+++ b/openspec/changes/achievement-notification-system/tasks.md
@@ -2,100 +2,100 @@
 
 ## 1. Realtime Infrastructure
 
-- [ ] 1.1 Add `"achievement_unlock_updated"` to
+- [x] 1.1 Add `"achievement_unlock_updated"` to
   `RealtimeEventType` union in
   `lib/realtime/types.ts`
-- [ ] 1.2 Add `onAchievementUnlockUpdate` to
+- [x] 1.2 Add `onAchievementUnlockUpdate` to
   `RealtimeContextType` interface in
   `lib/realtime/types.ts`
-- [ ] 1.3 Add `achievementUnlock` to
+- [x] 1.3 Add `achievementUnlock` to
   `ChannelRegistries` type in
   `lib/realtime/channel-subscriptions.ts`
-- [ ] 1.4 Add `character_achievements` table
+- [x] 1.4 Add `character_achievements` table
   subscription to `createFamilyRealtimeChannels`
   (no family_id filter)
-- [ ] 1.5 Add `achievementUnlockListeners` registry
+- [x] 1.5 Add `achievementUnlockListeners` registry
   ref and wire up in `RealtimeProvider` (registry,
   clear, callback, context value)
-- [ ] 1.6 Add fallback `onAchievementUnlockUpdate`
+- [x] 1.6 Add fallback `onAchievementUnlockUpdate`
   to `useRealtime()` no-context return
-- [ ] 1.7 Write tests for realtime channel
+- [x] 1.7 Write tests for realtime channel
   subscription setup including new achievement
   channel
-- [ ] 1.8 Write tests for achievement unlock
+- [x] 1.8 Write tests for achievement unlock
   listener registration and event emission
 
 ## 2. Notified Update API Route
 
-- [ ] 2.1 Create API route at
+- [x] 2.1 Create API route at
   `app/api/character-achievements/[id]/notified/`
   with PATCH handler
-- [ ] 2.2 Implement auth check (return 401 if
+- [x] 2.2 Implement auth check (return 401 if
   unauthenticated)
-- [ ] 2.3 Implement record lookup (return 404 if
+- [x] 2.3 Implement record lookup (return 404 if
   not found)
-- [ ] 2.4 Update `character_achievements.notified`
+- [x] 2.4 Update `character_achievements.notified`
   to `true` using service-role client
-- [ ] 2.5 Write tests for PATCH success, 401, and
+- [x] 2.5 Write tests for PATCH success, 401, and
   404 scenarios
 
 ## 3. Achievement Notification Hook
 
-- [ ] 3.1 Create
+- [x] 3.1 Create
   `hooks/useAchievementNotifications.ts` with
   queue state and realtime subscription
-- [ ] 3.2 Implement unlock detection: filter UPDATE
+- [x] 3.2 Implement unlock detection: filter UPDATE
   events where `unlocked_at` transitions
   null to non-null and `notified = false`
-- [ ] 3.3 Implement character-scoped filtering
+- [x] 3.3 Implement character-scoped filtering
   (only current character's events)
-- [ ] 3.4 Implement notification queue (array-based,
+- [x] 3.4 Implement notification queue (array-based,
   show one at a time, advance on dismiss)
-- [ ] 3.5 Implement catch-up query on mount: fetch
+- [x] 3.5 Implement catch-up query on mount: fetch
   `character_achievements` where
   `unlocked_at IS NOT NULL AND notified = false`
-- [ ] 3.6 Implement deduplication between catch-up
+- [x] 3.6 Implement deduplication between catch-up
   results and realtime events by
   `achievement_id`
-- [ ] 3.7 Implement `notified` flag update via API
+- [x] 3.7 Implement `notified` flag update via API
   call when toast is displayed
-- [ ] 3.8 Clear queue and re-run catch-up on
+- [x] 3.8 Clear queue and re-run catch-up on
   character switch
-- [ ] 3.9 Write tests for unlock detection
+- [x] 3.9 Write tests for unlock detection
   (null to non-null transition filtering)
-- [ ] 3.10 Write tests for queue management
+- [x] 3.10 Write tests for queue management
   (enqueue, dequeue, sequential display)
-- [ ] 3.11 Write tests for catch-up query and
+- [x] 3.11 Write tests for catch-up query and
   deduplication
-- [ ] 3.12 Write tests for character-scoped
+- [x] 3.12 Write tests for character-scoped
   filtering and character switch behavior
 
 ## 4. Toast Component
 
-- [ ] 4.1 Create `AchievementUnlockToast.tsx` in
+- [x] 4.1 Create `AchievementUnlockToast.tsx` in
   `components/achievements/` with Framer Motion
   animations
-- [ ] 4.2 Render achievement name, description,
+- [x] 4.2 Render achievement name, description,
   icon, and XP/gold rewards
-- [ ] 4.3 Implement 5-second auto-dismiss timer
+- [x] 4.3 Implement 5-second auto-dismiss timer
   with `setTimeout`
-- [ ] 4.4 Implement manual dismiss button
-- [ ] 4.5 Add celebratory CSS entrance animation
+- [x] 4.4 Implement manual dismiss button
+- [x] 4.5 Add celebratory CSS entrance animation
   (slide-in/scale with gradient styling)
-- [ ] 4.6 Write tests for toast rendering with
+- [x] 4.6 Write tests for toast rendering with
   achievement data
-- [ ] 4.7 Write tests for auto-dismiss after
+- [x] 4.7 Write tests for auto-dismiss after
   5 seconds
-- [ ] 4.8 Write tests for manual dismiss callback
+- [x] 4.8 Write tests for manual dismiss callback
 
 ## 5. Integration
 
-- [ ] 5.1 Create
+- [x] 5.1 Create
   `AchievementNotificationManager.tsx` in
   `components/achievements/` that composes the
   hook and toast
-- [ ] 5.2 Mount `AchievementNotificationManager`
+- [x] 5.2 Mount `AchievementNotificationManager`
   inside `CharacterProvider` in layout
-- [ ] 5.3 Write integration test verifying
+- [x] 5.3 Write integration test verifying
   end-to-end flow: realtime event to queue to
   toast display to notified update

--- a/openspec/changes/achievement-notification-system/tasks.md
+++ b/openspec/changes/achievement-notification-system/tasks.md
@@ -1,0 +1,101 @@
+# Achievement Notification System — Tasks
+
+## 1. Realtime Infrastructure
+
+- [ ] 1.1 Add `"achievement_unlock_updated"` to
+  `RealtimeEventType` union in
+  `lib/realtime/types.ts`
+- [ ] 1.2 Add `onAchievementUnlockUpdate` to
+  `RealtimeContextType` interface in
+  `lib/realtime/types.ts`
+- [ ] 1.3 Add `achievementUnlock` to
+  `ChannelRegistries` type in
+  `lib/realtime/channel-subscriptions.ts`
+- [ ] 1.4 Add `character_achievements` table
+  subscription to `createFamilyRealtimeChannels`
+  (no family_id filter)
+- [ ] 1.5 Add `achievementUnlockListeners` registry
+  ref and wire up in `RealtimeProvider` (registry,
+  clear, callback, context value)
+- [ ] 1.6 Add fallback `onAchievementUnlockUpdate`
+  to `useRealtime()` no-context return
+- [ ] 1.7 Write tests for realtime channel
+  subscription setup including new achievement
+  channel
+- [ ] 1.8 Write tests for achievement unlock
+  listener registration and event emission
+
+## 2. Notified Update API Route
+
+- [ ] 2.1 Create API route at
+  `app/api/character-achievements/[id]/notified/`
+  with PATCH handler
+- [ ] 2.2 Implement auth check (return 401 if
+  unauthenticated)
+- [ ] 2.3 Implement record lookup (return 404 if
+  not found)
+- [ ] 2.4 Update `character_achievements.notified`
+  to `true` using service-role client
+- [ ] 2.5 Write tests for PATCH success, 401, and
+  404 scenarios
+
+## 3. Achievement Notification Hook
+
+- [ ] 3.1 Create
+  `hooks/useAchievementNotifications.ts` with
+  queue state and realtime subscription
+- [ ] 3.2 Implement unlock detection: filter UPDATE
+  events where `unlocked_at` transitions
+  null to non-null and `notified = false`
+- [ ] 3.3 Implement character-scoped filtering
+  (only current character's events)
+- [ ] 3.4 Implement notification queue (array-based,
+  show one at a time, advance on dismiss)
+- [ ] 3.5 Implement catch-up query on mount: fetch
+  `character_achievements` where
+  `unlocked_at IS NOT NULL AND notified = false`
+- [ ] 3.6 Implement deduplication between catch-up
+  results and realtime events by
+  `achievement_id`
+- [ ] 3.7 Implement `notified` flag update via API
+  call when toast is displayed
+- [ ] 3.8 Clear queue and re-run catch-up on
+  character switch
+- [ ] 3.9 Write tests for unlock detection
+  (null to non-null transition filtering)
+- [ ] 3.10 Write tests for queue management
+  (enqueue, dequeue, sequential display)
+- [ ] 3.11 Write tests for catch-up query and
+  deduplication
+- [ ] 3.12 Write tests for character-scoped
+  filtering and character switch behavior
+
+## 4. Toast Component
+
+- [ ] 4.1 Create `AchievementUnlockToast.tsx` in
+  `components/achievements/` with Framer Motion
+  animations
+- [ ] 4.2 Render achievement name, description,
+  icon, and XP/gold rewards
+- [ ] 4.3 Implement 5-second auto-dismiss timer
+  with `setTimeout`
+- [ ] 4.4 Implement manual dismiss button
+- [ ] 4.5 Add celebratory CSS entrance animation
+  (slide-in/scale with gradient styling)
+- [ ] 4.6 Write tests for toast rendering with
+  achievement data
+- [ ] 4.7 Write tests for auto-dismiss after
+  5 seconds
+- [ ] 4.8 Write tests for manual dismiss callback
+
+## 5. Integration
+
+- [ ] 5.1 Create
+  `AchievementNotificationManager.tsx` in
+  `components/achievements/` that composes the
+  hook and toast
+- [ ] 5.2 Mount `AchievementNotificationManager`
+  inside `CharacterProvider` in layout
+- [ ] 5.3 Write integration test verifying
+  end-to-end flow: realtime event to queue to
+  toast display to notified update

--- a/tests/unit/app/api/character-achievements.notified.test.ts
+++ b/tests/unit/app/api/character-achievements.notified.test.ts
@@ -55,7 +55,9 @@ function setupServiceRecord(
     ? {
         data: {
           id: VALID_UUID,
-          characters: familyId ? { family_id: familyId } : null,
+          characters: familyId
+            ? { user_profiles: { family_id: familyId } }
+            : null,
         },
         error: null,
       }

--- a/tests/unit/app/api/character-achievements.notified.test.ts
+++ b/tests/unit/app/api/character-achievements.notified.test.ts
@@ -1,0 +1,112 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/character-achievements/[id]/notified/route";
+
+const VALID_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+function makeRequest(auth: string | null = "Bearer token") {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (auth !== null) headers["authorization"] = auth;
+  return new NextRequest("http://localhost/test", {
+    method: "PATCH",
+    headers,
+  });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function setupAuth() {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+    error: null,
+  });
+  mockServerSupabase.from.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({
+      data: { role: "HERO", family_id: "fam-1" },
+      error: null,
+    }),
+  });
+}
+
+function setupServiceRecord(exists: boolean) {
+  const maybeSingleResult = exists
+    ? { data: { id: VALID_UUID }, error: null }
+    : { data: null, error: null };
+
+  const updateChain = {
+    eq: jest.fn().mockResolvedValue({ error: null }),
+  };
+
+  mockServiceSupabase.from.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(maybeSingleResult),
+    update: jest.fn().mockReturnValue(updateChain),
+  });
+}
+
+describe("PATCH /api/character-achievements/[id]/notified", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 and marks notified when authenticated and record exists", async () => {
+    setupAuth();
+    setupServiceRecord(true);
+
+    const res = await PATCH(makeRequest(), params(VALID_UUID));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 when no Authorization header is present", async () => {
+    const res = await PATCH(makeRequest(null), params(VALID_UUID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when auth token is invalid", async () => {
+    mockServerSupabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: "Invalid token" },
+    });
+    // No profile fetch needed since auth fails first
+    mockServerSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    });
+
+    const res = await PATCH(makeRequest(), params(VALID_UUID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the character achievement record does not exist", async () => {
+    setupAuth();
+    setupServiceRecord(false);
+
+    const res = await PATCH(makeRequest(), params("non-existent-id"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+});

--- a/tests/unit/app/api/character-achievements.notified.test.ts
+++ b/tests/unit/app/api/character-achievements.notified.test.ts
@@ -47,9 +47,18 @@ function setupAuth() {
   });
 }
 
-function setupServiceRecord(exists: boolean) {
+function setupServiceRecord(
+  exists: boolean,
+  familyId: string | null = "fam-1",
+) {
   const maybeSingleResult = exists
-    ? { data: { id: VALID_UUID }, error: null }
+    ? {
+        data: {
+          id: VALID_UUID,
+          characters: familyId ? { family_id: familyId } : null,
+        },
+        error: null,
+      }
     : { data: null, error: null };
 
   const updateChain = {
@@ -108,5 +117,21 @@ describe("PATCH /api/character-achievements/[id]/notified", () => {
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toMatch(/not found/i);
+  });
+
+  it("returns 403 when the character achievement belongs to a different family", async () => {
+    setupAuth(); // requesterProfile.family_id = "fam-1"
+    setupServiceRecord(true, "fam-other");
+
+    const res = await PATCH(makeRequest(), params(VALID_UUID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the character achievement has no associated character", async () => {
+    setupAuth();
+    setupServiceRecord(true, null);
+
+    const res = await PATCH(makeRequest(), params(VALID_UUID));
+    expect(res.status).toBe(403);
   });
 });


### PR DESCRIPTION
Closes #137

## Summary

- Implements real-time achievement unlock notifications via Supabase Realtime subscriptions
- Adds `useAchievementNotifications` hook for polling and queuing unlocked achievements
- Adds `AchievementUnlockToast` component for displaying toast notifications with character-scoped filtering
- Adds `/api/character-achievements/[id]/notified` endpoint to mark achievements as notified
- Includes catchup logic to surface previously-unnotified achievements on login/character switch
- Fixes auth gap and character-scoping races; guards `notified` state to only set on success

## Test plan

- [ ] All unit tests pass (`npm run test`)
- [ ] TypeScript compiles cleanly (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Toast appears when an achievement is unlocked in the app
- [ ] Switching characters does not show achievements from the previous character
- [ ] Catchup notifications appear for previously-unnotified achievements on load