### PR TITLE
feat: achievement categories & hidden achievements

### DIFF
--- a/app/api/admin/achievement-categories/[id]/route.ts
+++ b/app/api/admin/achievement-categories/[id]/route.ts
@@ -15,6 +15,28 @@ import {
   ValidationError,
 } from "@/lib/errors";
 
+async function verifyCategoryExists(
+  serviceSupabase: ReturnType<typeof createServiceSupabaseClient>,
+  id: string,
+) {
+  const { data: existing, error: fetchError } = await serviceSupabase
+    .from("achievement_categories")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (fetchError) {
+    throw new Error(`Failed to fetch category: ${fetchError.message}`);
+  }
+
+  if (!existing) {
+    throw new NotFoundError(
+      "Achievement category not found",
+      "CATEGORY_NOT_FOUND",
+    );
+  }
+}
+
 /**
  * PATCH /api/admin/achievement-categories/[id]
  *
@@ -57,23 +79,7 @@ export async function PATCH(
 
     const serviceSupabase = createServiceSupabaseClient();
 
-    // Verify category exists
-    const { data: existing, error: fetchError } = await serviceSupabase
-      .from("achievement_categories")
-      .select("id")
-      .eq("id", id)
-      .maybeSingle();
-
-    if (fetchError) {
-      throw new Error(`Failed to fetch category: ${fetchError.message}`);
-    }
-
-    if (!existing) {
-      throw new NotFoundError(
-        "Achievement category not found",
-        "CATEGORY_NOT_FOUND",
-      );
-    }
+    await verifyCategoryExists(serviceSupabase, id);
 
     const updateData: Record<string, unknown> = {};
     if (name !== undefined) updateData.name = name.trim();
@@ -127,23 +133,7 @@ export async function DELETE(
 
     const serviceSupabase = createServiceSupabaseClient();
 
-    // Verify category exists
-    const { data: existing, error: fetchError } = await serviceSupabase
-      .from("achievement_categories")
-      .select("id")
-      .eq("id", id)
-      .maybeSingle();
-
-    if (fetchError) {
-      throw new Error(`Failed to fetch category: ${fetchError.message}`);
-    }
-
-    if (!existing) {
-      throw new NotFoundError(
-        "Achievement category not found",
-        "CATEGORY_NOT_FOUND",
-      );
-    }
+    await verifyCategoryExists(serviceSupabase, id);
 
     // Check if category has achievements
     const { count, error: countError } = await serviceSupabase

--- a/app/api/admin/achievement-categories/[id]/route.ts
+++ b/app/api/admin/achievement-categories/[id]/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/errors";
+
+/**
+ * PATCH /api/admin/achievement-categories/[id]
+ *
+ * Updates an existing achievement category.
+ * Requires Guild Master role.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievement categories",
+        "ACHIEVEMENT_CATEGORY_FORBIDDEN",
+      );
+    }
+
+    const body = await request.json();
+    const { name, description, icon, display_order } = body;
+
+    if (
+      name !== undefined &&
+      (typeof name !== "string" || name.trim().length === 0)
+    ) {
+      throw new ValidationError(
+        "Category name cannot be empty",
+        "CATEGORY_NAME_REQUIRED",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    // Verify category exists
+    const { data: existing, error: fetchError } = await serviceSupabase
+      .from("achievement_categories")
+      .select("id")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (fetchError) {
+      throw new Error(`Failed to fetch category: ${fetchError.message}`);
+    }
+
+    if (!existing) {
+      throw new NotFoundError(
+        "Achievement category not found",
+        "CATEGORY_NOT_FOUND",
+      );
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (name !== undefined) updateData.name = name.trim();
+    if (description !== undefined) updateData.description = description;
+    if (icon !== undefined) updateData.icon = icon;
+    if (display_order !== undefined) updateData.display_order = display_order;
+
+    const { data: category, error: updateError } = await serviceSupabase
+      .from("achievement_categories")
+      .update(updateData)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (updateError) {
+      throw new Error(`Failed to update category: ${updateError.message}`);
+    }
+
+    return NextResponse.json({ success: true, category });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+/**
+ * DELETE /api/admin/achievement-categories/[id]
+ *
+ * Deletes an achievement category if it has no achievements assigned.
+ * Requires Guild Master role.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievement categories",
+        "ACHIEVEMENT_CATEGORY_FORBIDDEN",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    // Verify category exists
+    const { data: existing, error: fetchError } = await serviceSupabase
+      .from("achievement_categories")
+      .select("id")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (fetchError) {
+      throw new Error(`Failed to fetch category: ${fetchError.message}`);
+    }
+
+    if (!existing) {
+      throw new NotFoundError(
+        "Achievement category not found",
+        "CATEGORY_NOT_FOUND",
+      );
+    }
+
+    // Check if category has achievements
+    const { count, error: countError } = await serviceSupabase
+      .from("achievements")
+      .select("id", { count: "exact", head: true })
+      .eq("category_id", id);
+
+    if (countError) {
+      throw new Error(`Failed to check achievements: ${countError.message}`);
+    }
+
+    if (count && count > 0) {
+      throw new ConflictError(
+        "Cannot delete category with achievements assigned. Remove or reassign achievements first.",
+        "CATEGORY_HAS_ACHIEVEMENTS",
+      );
+    }
+
+    const { error: deleteError } = await serviceSupabase
+      .from("achievement_categories")
+      .delete()
+      .eq("id", id);
+
+    if (deleteError) {
+      throw new Error(`Failed to delete category: ${deleteError.message}`);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/api/admin/achievement-categories/route.ts
+++ b/app/api/admin/achievement-categories/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+import { ForbiddenError, ValidationError } from "@/lib/errors";
+
+/**
+ * GET /api/admin/achievement-categories
+ *
+ * Returns all achievement categories ordered by display_order.
+ * Requires Guild Master role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievement categories",
+        "ACHIEVEMENT_CATEGORY_FORBIDDEN",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    // Fetch categories with achievement counts
+    const { data: categories, error: catError } = await serviceSupabase
+      .from("achievement_categories")
+      .select("id, name, description, icon, display_order")
+      .order("display_order", { ascending: true });
+
+    if (catError) {
+      throw new Error(`Failed to fetch categories: ${catError.message}`);
+    }
+
+    // Get achievement counts per category
+    const { data: achievements, error: achError } = await serviceSupabase
+      .from("achievements")
+      .select("id, category_id");
+
+    if (achError) {
+      throw new Error(
+        `Failed to fetch achievement counts: ${achError.message}`,
+      );
+    }
+
+    const countByCategory = new Map<string, number>();
+    for (const a of achievements ?? []) {
+      countByCategory.set(
+        a.category_id,
+        (countByCategory.get(a.category_id) ?? 0) + 1,
+      );
+    }
+
+    const categoriesWithCounts = (categories ?? []).map((cat) => ({
+      ...cat,
+      achievement_count: countByCategory.get(cat.id) ?? 0,
+    }));
+
+    return NextResponse.json({ categories: categoriesWithCounts });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+/**
+ * POST /api/admin/achievement-categories
+ *
+ * Creates a new achievement category.
+ * Requires Guild Master role.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievement categories",
+        "ACHIEVEMENT_CATEGORY_FORBIDDEN",
+      );
+    }
+
+    const body = await request.json();
+    const { name, description, icon, display_order } = body;
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      throw new ValidationError(
+        "Category name is required",
+        "CATEGORY_NAME_REQUIRED",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    const { data: category, error: insertError } = await serviceSupabase
+      .from("achievement_categories")
+      .insert({
+        name: name.trim(),
+        description: description ?? null,
+        icon: icon ?? null,
+        display_order: display_order ?? 0,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      throw new Error(`Failed to create category: ${insertError.message}`);
+    }
+
+    return NextResponse.json({ success: true, category }, { status: 201 });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/api/admin/achievement-categories/route.ts
+++ b/app/api/admin/achievement-categories/route.ts
@@ -34,39 +34,24 @@ export async function GET(request: NextRequest) {
 
     const serviceSupabase = createServiceSupabaseClient();
 
-    // Fetch categories with achievement counts
-    const { data: categories, error: catError } = await serviceSupabase
+    // Fetch categories with achievement counts via join
+    const { data: categoriesData, error: catError } = await serviceSupabase
       .from("achievement_categories")
-      .select("id, name, description, icon, display_order")
+      .select("id, name, description, icon, display_order, achievements(count)")
       .order("display_order", { ascending: true });
 
     if (catError) {
       throw new Error(`Failed to fetch categories: ${catError.message}`);
     }
 
-    // Get achievement counts per category
-    const { data: achievements, error: achError } = await serviceSupabase
-      .from("achievements")
-      .select("id, category_id");
-
-    if (achError) {
-      throw new Error(
-        `Failed to fetch achievement counts: ${achError.message}`,
-      );
-    }
-
-    const countByCategory = new Map<string, number>();
-    for (const a of achievements ?? []) {
-      countByCategory.set(
-        a.category_id,
-        (countByCategory.get(a.category_id) ?? 0) + 1,
-      );
-    }
-
-    const categoriesWithCounts = (categories ?? []).map((cat) => ({
-      ...cat,
-      achievement_count: countByCategory.get(cat.id) ?? 0,
-    }));
+    const categoriesWithCounts = (categoriesData ?? []).map((cat) => {
+      const { achievements, ...rest } = cat;
+      return {
+        ...rest,
+        achievement_count:
+          (achievements as unknown as { count: number }[])?.[0]?.count ?? 0,
+      };
+    });
 
     return NextResponse.json({ categories: categoriesWithCounts });
   } catch (error) {

--- a/app/api/admin/achievements/[id]/route.ts
+++ b/app/api/admin/achievements/[id]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+import { ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
+
+/**
+ * PATCH /api/admin/achievements/[id]
+ *
+ * Updates an existing achievement (category, hidden flag, rewards, etc.).
+ * Requires Guild Master role.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievements",
+        "ACHIEVEMENT_ADMIN_FORBIDDEN",
+      );
+    }
+
+    const body = await request.json();
+    const {
+      name,
+      description,
+      icon,
+      category_id,
+      xp_reward,
+      gold_reward,
+      is_hidden,
+      criteria_type,
+      criteria_config,
+    } = body;
+
+    if (
+      name !== undefined &&
+      (typeof name !== "string" || name.trim().length === 0)
+    ) {
+      throw new ValidationError(
+        "Achievement name cannot be empty",
+        "ACHIEVEMENT_NAME_REQUIRED",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    // Verify achievement exists
+    const { data: existing, error: fetchError } = await serviceSupabase
+      .from("achievements")
+      .select("id")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (fetchError) {
+      throw new Error(`Failed to fetch achievement: ${fetchError.message}`);
+    }
+
+    if (!existing) {
+      throw new NotFoundError("Achievement not found", "ACHIEVEMENT_NOT_FOUND");
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (name !== undefined) updateData.name = name.trim();
+    if (description !== undefined) updateData.description = description;
+    if (icon !== undefined) updateData.icon = icon;
+    if (category_id !== undefined) updateData.category_id = category_id;
+    if (xp_reward !== undefined) updateData.xp_reward = xp_reward;
+    if (gold_reward !== undefined) updateData.gold_reward = gold_reward;
+    if (is_hidden !== undefined) updateData.is_hidden = is_hidden;
+    if (criteria_type !== undefined) updateData.criteria_type = criteria_type;
+    if (criteria_config !== undefined)
+      updateData.criteria_config = criteria_config;
+
+    const { data: achievement, error: updateError } = await serviceSupabase
+      .from("achievements")
+      .update(updateData)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (updateError) {
+      throw new Error(`Failed to update achievement: ${updateError.message}`);
+    }
+
+    return NextResponse.json({ success: true, achievement });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/api/admin/achievements/route.ts
+++ b/app/api/admin/achievements/route.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+import { ForbiddenError, ValidationError } from "@/lib/errors";
+
+/**
+ * GET /api/admin/achievements
+ *
+ * Returns all achievements with category names.
+ * Requires Guild Master role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievements",
+        "ACHIEVEMENT_ADMIN_FORBIDDEN",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    const { data: achievements, error: achError } = await serviceSupabase
+      .from("achievements")
+      .select(
+        "id, name, description, icon, category_id, xp_reward, gold_reward, is_hidden, criteria_type, criteria_config, family_id",
+      )
+      .order("name", { ascending: true });
+
+    if (achError) {
+      throw new Error(`Failed to fetch achievements: ${achError.message}`);
+    }
+
+    // Fetch category names for display
+    const { data: categories, error: catError } = await serviceSupabase
+      .from("achievement_categories")
+      .select("id, name")
+      .order("display_order", { ascending: true });
+
+    if (catError) {
+      throw new Error(`Failed to fetch categories: ${catError.message}`);
+    }
+
+    const categoryMap = new Map((categories ?? []).map((c) => [c.id, c.name]));
+
+    const achievementsWithCategory = (achievements ?? []).map((a) => ({
+      ...a,
+      category_name: categoryMap.get(a.category_id) ?? "Unknown",
+    }));
+
+    return NextResponse.json({
+      achievements: achievementsWithCategory,
+      categories: categories ?? [],
+    });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+/**
+ * POST /api/admin/achievements
+ *
+ * Creates a new achievement.
+ * Requires Guild Master role.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const token = extractBearerToken(request);
+    const userSupabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      userSupabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can manage achievements",
+        "ACHIEVEMENT_ADMIN_FORBIDDEN",
+      );
+    }
+
+    const body = await request.json();
+    const {
+      name,
+      description,
+      icon,
+      category_id,
+      xp_reward,
+      gold_reward,
+      is_hidden,
+      criteria_type,
+      criteria_config,
+    } = body;
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      throw new ValidationError(
+        "Achievement name is required",
+        "ACHIEVEMENT_NAME_REQUIRED",
+      );
+    }
+
+    if (!category_id) {
+      throw new ValidationError(
+        "Category is required",
+        "ACHIEVEMENT_CATEGORY_REQUIRED",
+      );
+    }
+
+    if (!criteria_type) {
+      throw new ValidationError(
+        "Criteria type is required",
+        "ACHIEVEMENT_CRITERIA_TYPE_REQUIRED",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    const { data: achievement, error: insertError } = await serviceSupabase
+      .from("achievements")
+      .insert({
+        name: name.trim(),
+        description: description ?? "",
+        icon: icon ?? null,
+        category_id,
+        xp_reward: xp_reward ?? 0,
+        gold_reward: gold_reward ?? 0,
+        is_hidden: is_hidden ?? false,
+        criteria_type,
+        criteria_config: criteria_config ?? {},
+        family_id: requesterProfile.family_id,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      throw new Error(`Failed to create achievement: ${insertError.message}`);
+    }
+
+    return NextResponse.json({ success: true, achievement }, { status: 201 });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/api/admin/achievements/route.ts
+++ b/app/api/admin/achievements/route.ts
@@ -34,10 +34,10 @@ export async function GET(request: NextRequest) {
 
     const serviceSupabase = createServiceSupabaseClient();
 
-    const { data: achievements, error: achError } = await serviceSupabase
+    const { data: achievementsData, error: achError } = await serviceSupabase
       .from("achievements")
       .select(
-        "id, name, description, icon, category_id, xp_reward, gold_reward, is_hidden, criteria_type, criteria_config, family_id",
+        "id, name, description, icon, category_id, xp_reward, gold_reward, is_hidden, criteria_type, criteria_config, family_id, achievement_categories(name)",
       )
       .order("name", { ascending: true });
 
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
       throw new Error(`Failed to fetch achievements: ${achError.message}`);
     }
 
-    // Fetch category names for display
+    // Fetch categories for the admin dropdown
     const { data: categories, error: catError } = await serviceSupabase
       .from("achievement_categories")
       .select("id, name")
@@ -55,12 +55,15 @@ export async function GET(request: NextRequest) {
       throw new Error(`Failed to fetch categories: ${catError.message}`);
     }
 
-    const categoryMap = new Map((categories ?? []).map((c) => [c.id, c.name]));
-
-    const achievementsWithCategory = (achievements ?? []).map((a) => ({
-      ...a,
-      category_name: categoryMap.get(a.category_id) ?? "Unknown",
-    }));
+    const achievementsWithCategory = (achievementsData ?? []).map((a) => {
+      const { achievement_categories, ...rest } = a;
+      return {
+        ...rest,
+        category_name:
+          (achievement_categories as { name: string } | null)?.name ??
+          "Unknown",
+      };
+    });
 
     return NextResponse.json({
       achievements: achievementsWithCategory,

--- a/components/achievements/AchievementDetailModal.test.tsx
+++ b/components/achievements/AchievementDetailModal.test.tsx
@@ -98,6 +98,24 @@ describe("AchievementDetailModal", () => {
     expect(screen.queryByText("First Quest")).not.toBeInTheDocument();
   });
 
+  it("renders hidden unlocked achievement with full details and rewards", () => {
+    render(
+      <AchievementDetailModal
+        achievement={makeAchievement({
+          is_hidden: true,
+          unlocked_at: "2026-03-20T10:00:00Z",
+        })}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("First Quest")).toBeInTheDocument();
+    expect(screen.getByText("Complete your first quest")).toBeInTheDocument();
+    expect(screen.getByText("+50 XP")).toBeInTheDocument();
+    expect(screen.getByText("+10 Gold")).toBeInTheDocument();
+    expect(screen.queryByText("???")).not.toBeInTheDocument();
+  });
+
   it("calls onClose when close button is clicked", async () => {
     const user = userEvent.setup();
     const onClose = jest.fn();

--- a/components/achievements/AchievementGrid.test.tsx
+++ b/components/achievements/AchievementGrid.test.tsx
@@ -210,6 +210,40 @@ describe("AchievementGrid", () => {
     expect(screen.getAllByText("Secrets (2/2)")[0]).toBeInTheDocument();
   });
 
+  it("resets to All tab when the active category is removed from categories", async () => {
+    const user = userEvent.setup();
+    const onCategoryChange = jest.fn();
+    const { rerender } = render(
+      <AchievementGrid
+        categories={MOCK_CATEGORIES}
+        onActiveCategoryChange={onCategoryChange}
+      />,
+    );
+
+    // Select cat-2 (Wealth)
+    await user.click(screen.getByTestId("achievement-tab-cat-2"));
+    expect(onCategoryChange).toHaveBeenLastCalledWith("cat-2");
+
+    // Re-render with cat-2 removed
+    rerender(
+      <AchievementGrid
+        categories={[MOCK_CATEGORIES[0]]}
+        onActiveCategoryChange={onCategoryChange}
+      />,
+    );
+
+    // Should auto-reset to All and call the callback with null
+    expect(screen.getByTestId("achievement-tab-all")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(onCategoryChange).toHaveBeenLastCalledWith(null);
+
+    // Remaining achievements should be visible
+    expect(screen.getByText("First Quest")).toBeInTheDocument();
+    expect(screen.queryByText("Rich Adventurer")).not.toBeInTheDocument();
+  });
+
   it("shows empty state when category has no achievements", async () => {
     const user = userEvent.setup();
     const emptyCategory: AchievementCategory[] = [

--- a/components/achievements/AchievementGrid.test.tsx
+++ b/components/achievements/AchievementGrid.test.tsx
@@ -77,13 +77,16 @@ describe("AchievementGrid", () => {
     expect(screen.getByText("Rich Adventurer")).toBeInTheDocument();
   });
 
-  it("shows category tabs with achievement counts", () => {
+  it("shows category tabs with completion counts", () => {
     render(<AchievementGrid categories={MOCK_CATEGORIES} />);
 
-    // Tab labels include counts (visible on larger screens)
-    expect(screen.getByText("All (3)")).toBeInTheDocument();
-    expect(screen.getByText("Adventurer (2)")).toBeInTheDocument();
-    expect(screen.getByText("Wealth (1)")).toBeInTheDocument();
+    // Tab labels include unlocked/total counts (visible on all screen sizes)
+    // Adventurer: 1 unlocked (ach-1), 2 total (both non-hidden)
+    // Wealth: 0 unlocked, 1 total
+    // All: 1 unlocked, 3 total
+    expect(screen.getAllByText("All (1/3)")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Adventurer (1/2)")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Wealth (0/1)")[0]).toBeInTheDocument();
   });
 
   it("filters achievements when a category tab is clicked", async () => {
@@ -133,6 +136,78 @@ describe("AchievementGrid", () => {
 
     await user.click(screen.getByTestId("achievement-badge-ach-1"));
     expect(onClick).toHaveBeenCalledWith(MOCK_CATEGORIES[0].achievements[0]);
+  });
+
+  it("calls onActiveCategoryChange when switching tabs", async () => {
+    const user = userEvent.setup();
+    const onCategoryChange = jest.fn();
+    render(
+      <AchievementGrid
+        categories={MOCK_CATEGORIES}
+        onActiveCategoryChange={onCategoryChange}
+      />,
+    );
+
+    await user.click(screen.getByTestId("achievement-tab-cat-2"));
+    expect(onCategoryChange).toHaveBeenCalledWith("cat-2");
+
+    await user.click(screen.getByTestId("achievement-tab-all"));
+    expect(onCategoryChange).toHaveBeenCalledWith(null);
+  });
+
+  it("excludes locked hidden achievements from completion total", () => {
+    const categoriesWithHidden: AchievementCategory[] = [
+      {
+        id: "cat-h",
+        name: "Secrets",
+        description: null,
+        icon: null,
+        display_order: 1,
+        achievements: [
+          {
+            id: "visible-1",
+            name: "Normal",
+            description: "A normal achievement",
+            icon: null,
+            xp_reward: 10,
+            gold_reward: 0,
+            is_hidden: false,
+            criteria_type: "test",
+            unlocked_at: "2026-03-20T10:00:00Z",
+            progress: null,
+          },
+          {
+            id: "hidden-locked",
+            name: "???",
+            description: "???",
+            icon: null,
+            xp_reward: 10,
+            gold_reward: 0,
+            is_hidden: true,
+            criteria_type: "test",
+            unlocked_at: null,
+            progress: null,
+          },
+          {
+            id: "hidden-unlocked",
+            name: "Secret Found",
+            description: "Found a secret",
+            icon: null,
+            xp_reward: 10,
+            gold_reward: 0,
+            is_hidden: true,
+            criteria_type: "test",
+            unlocked_at: "2026-03-20T10:00:00Z",
+            progress: null,
+          },
+        ],
+      },
+    ];
+    render(<AchievementGrid categories={categoriesWithHidden} />);
+
+    // 2 unlocked (visible-1 + hidden-unlocked), 2 total (excludes locked hidden)
+    expect(screen.getAllByText("All (2/2)")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Secrets (2/2)")[0]).toBeInTheDocument();
   });
 
   it("shows empty state when category has no achievements", async () => {

--- a/components/achievements/AchievementGrid.test.tsx
+++ b/components/achievements/AchievementGrid.test.tsx
@@ -244,6 +244,34 @@ describe("AchievementGrid", () => {
     expect(screen.queryByText("Rich Adventurer")).not.toBeInTheDocument();
   });
 
+  it("shows completion indicator only on fully-completed category tabs", () => {
+    // cat-full uses the already-unlocked ach-1 fixture so it is 1/1 complete
+    const categories: AchievementCategory[] = [
+      {
+        id: "cat-full",
+        name: "Done",
+        description: null,
+        icon: null,
+        display_order: 0,
+        achievements: [MOCK_CATEGORIES[0].achievements[0]],
+      },
+      ...MOCK_CATEGORIES,
+    ];
+    render(<AchievementGrid categories={categories} />);
+
+    // cat-full is 1/1 — should show indicator
+    expect(
+      screen.getByTestId("achievement-tab-cat-full-complete"),
+    ).toBeInTheDocument();
+    // Adventurer 1/2, Wealth 0/1 — incomplete, no indicator
+    expect(
+      screen.queryByTestId("achievement-tab-cat-1-complete"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("achievement-tab-cat-2-complete"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows empty state when category has no achievements", async () => {
     const user = userEvent.setup();
     const emptyCategory: AchievementCategory[] = [

--- a/components/achievements/AchievementGrid.tsx
+++ b/components/achievements/AchievementGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { LayoutGrid } from "lucide-react";
 import { TabBar, type TabItem } from "@/components/ui/tab-bar";
 import { AchievementBadge } from "./AchievementBadge";
@@ -46,6 +46,16 @@ export function AchievementGrid({
   onActiveCategoryChange,
 }: AchievementGridProps) {
   const [activeTab, setActiveTab] = useState(ALL_TAB_ID);
+
+  useEffect(() => {
+    if (
+      activeTab !== ALL_TAB_ID &&
+      !categories.find((c) => c.id === activeTab)
+    ) {
+      setActiveTab(ALL_TAB_ID);
+      onActiveCategoryChange?.(null);
+    }
+  }, [categories, activeTab, onActiveCategoryChange]);
 
   const handleTabChange = (tabId: string) => {
     setActiveTab(tabId);

--- a/components/achievements/AchievementGrid.tsx
+++ b/components/achievements/AchievementGrid.tsx
@@ -75,6 +75,7 @@ export function AchievementGrid({
         label: `${cat.name} (${counts.unlocked}/${counts.total})`,
         shortLabel: `${cat.name} (${counts.unlocked}/${counts.total})`,
         icon: getAchievementIcon(cat.icon),
+        complete: counts.total > 0 && counts.unlocked === counts.total,
         testId: `achievement-tab-${cat.id}`,
       };
     });

--- a/components/achievements/AchievementGrid.tsx
+++ b/components/achievements/AchievementGrid.tsx
@@ -12,37 +12,74 @@ import type {
 
 const ALL_TAB_ID = "__all__";
 
+export interface CategoryCompletionCounts {
+  unlocked: number;
+  total: number;
+}
+
+function computeCategoryCounts(
+  achievements: AchievementDisplay[],
+): CategoryCompletionCounts {
+  let unlocked = 0;
+  let total = 0;
+  for (const a of achievements) {
+    const isLockedHidden = a.is_hidden && !a.unlocked_at;
+    if (!isLockedHidden) {
+      total++;
+    }
+    if (a.unlocked_at) {
+      unlocked++;
+    }
+  }
+  return { unlocked, total };
+}
+
 interface AchievementGridProps {
   categories: AchievementCategory[];
   onBadgeClick?: (achievement: AchievementDisplay) => void;
+  onActiveCategoryChange?: (categoryId: string | null) => void;
 }
 
 export function AchievementGrid({
   categories,
   onBadgeClick,
+  onActiveCategoryChange,
 }: AchievementGridProps) {
   const [activeTab, setActiveTab] = useState(ALL_TAB_ID);
 
+  const handleTabChange = (tabId: string) => {
+    setActiveTab(tabId);
+    onActiveCategoryChange?.(tabId === ALL_TAB_ID ? null : tabId);
+  };
+
+  const allCounts = useMemo(
+    () => computeCategoryCounts(categories.flatMap((c) => c.achievements)),
+    [categories],
+  );
+
   const tabs: TabItem<string>[] = useMemo(() => {
-    const categoryTabs = categories.map((cat) => ({
-      id: cat.id,
-      label: `${cat.name} (${cat.achievements.length})`,
-      shortLabel: cat.name,
-      icon: getAchievementIcon(cat.icon),
-      testId: `achievement-tab-${cat.id}`,
-    }));
+    const categoryTabs = categories.map((cat) => {
+      const counts = computeCategoryCounts(cat.achievements);
+      return {
+        id: cat.id,
+        label: `${cat.name} (${counts.unlocked}/${counts.total})`,
+        shortLabel: `${cat.name} (${counts.unlocked}/${counts.total})`,
+        icon: getAchievementIcon(cat.icon),
+        testId: `achievement-tab-${cat.id}`,
+      };
+    });
 
     return [
       {
         id: ALL_TAB_ID,
-        label: `All (${categories.reduce((sum, c) => sum + c.achievements.length, 0)})`,
-        shortLabel: "All",
+        label: `All (${allCounts.unlocked}/${allCounts.total})`,
+        shortLabel: `All (${allCounts.unlocked}/${allCounts.total})`,
         icon: LayoutGrid,
         testId: "achievement-tab-all",
       },
       ...categoryTabs,
     ];
-  }, [categories]);
+  }, [categories, allCounts]);
 
   const filteredAchievements = useMemo(() => {
     if (activeTab === ALL_TAB_ID) {
@@ -57,7 +94,7 @@ export function AchievementGrid({
       <TabBar
         tabs={tabs}
         activeTab={activeTab}
-        onTabChange={setActiveTab}
+        onTabChange={handleTabChange}
         className="mb-4 rounded-t-lg"
       />
 
@@ -72,7 +109,10 @@ export function AchievementGrid({
       </div>
 
       {filteredAchievements.length === 0 && (
-        <p className="text-center text-gray-500 py-8">
+        <p
+          className="text-center text-gray-500 py-8"
+          data-testid="achievement-grid-empty"
+        >
           No achievements in this category.
         </p>
       )}

--- a/components/achievements/AchievementSummary.test.tsx
+++ b/components/achievements/AchievementSummary.test.tsx
@@ -164,4 +164,33 @@ describe("AchievementSummary", () => {
       "0/0 Achievements Unlocked",
     );
   });
+
+  it("shows category-scoped counts when selectedCategoryId is set", () => {
+    render(
+      <AchievementSummary
+        categories={MOCK_CATEGORIES}
+        selectedCategoryId="cat-1"
+      />,
+    );
+
+    // cat-1 (Adventurer): 1 unlocked (ach-1), 2 total (ach-1 + ach-2)
+    expect(screen.getByTestId("achievement-count")).toHaveTextContent(
+      "1/2 Achievements Unlocked",
+    );
+    expect(screen.getByText("Adventurer")).toBeInTheDocument();
+  });
+
+  it("shows all counts when selectedCategoryId is null", () => {
+    render(
+      <AchievementSummary
+        categories={MOCK_CATEGORIES}
+        selectedCategoryId={null}
+      />,
+    );
+
+    expect(screen.getByTestId("achievement-count")).toHaveTextContent(
+      "2/3 Achievements Unlocked",
+    );
+    expect(screen.getByText("Achievements")).toBeInTheDocument();
+  });
 });

--- a/components/achievements/AchievementSummary.tsx
+++ b/components/achievements/AchievementSummary.tsx
@@ -9,14 +9,22 @@ import type { AchievementCategory } from "@/hooks/useAchievements";
 
 interface AchievementSummaryProps {
   categories: AchievementCategory[];
+  selectedCategoryId?: string | null;
 }
 
-export function AchievementSummary({ categories }: AchievementSummaryProps) {
+export function AchievementSummary({
+  categories,
+  selectedCategoryId,
+}: AchievementSummaryProps) {
   const { unlocked, total } = useMemo(() => {
     let unlockedCount = 0;
     let totalCount = 0;
 
-    for (const category of categories) {
+    const filteredCategories = selectedCategoryId
+      ? categories.filter((c) => c.id === selectedCategoryId)
+      : categories;
+
+    for (const category of filteredCategories) {
       for (const achievement of category.achievements) {
         const isLockedHidden =
           achievement.is_hidden && !achievement.unlocked_at;
@@ -31,7 +39,11 @@ export function AchievementSummary({ categories }: AchievementSummaryProps) {
     }
 
     return { unlocked: unlockedCount, total: totalCount };
-  }, [categories]);
+  }, [categories, selectedCategoryId]);
+
+  const label = selectedCategoryId
+    ? (categories.find((c) => c.id === selectedCategoryId)?.name ?? "Category")
+    : "Achievements";
 
   return (
     <FantasyCard
@@ -42,7 +54,7 @@ export function AchievementSummary({ categories }: AchievementSummaryProps) {
       <div className="flex items-center gap-3 mb-3">
         <FantasyIcon icon={Trophy} type="gold" size="lg" glow />
         <div>
-          <h3 className="font-fantasy text-lg text-gold-300">Achievements</h3>
+          <h3 className="font-fantasy text-lg text-gold-300">{label}</h3>
           <p className="text-sm text-gray-400" data-testid="achievement-count">
             {unlocked}/{total} Achievements Unlocked
           </p>

--- a/components/achievements/AchievementsSection.test.tsx
+++ b/components/achievements/AchievementsSection.test.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AchievementsSection } from "./AchievementsSection";
+
+jest.mock("@/hooks/useReducedMotion");
+
+const mockRetry = jest.fn();
+const mockUseAchievements = jest.fn();
+jest.mock("@/hooks/useAchievements", () => ({
+  useAchievements: (...args: unknown[]) => mockUseAchievements(...args),
+}));
+
+const CAT_A = {
+  id: "cat-a",
+  name: "Adventurer",
+  description: null,
+  icon: "sword",
+  display_order: 1,
+  achievements: [
+    {
+      id: "ach-1",
+      name: "First Quest",
+      description: "Complete first quest",
+      icon: "sword",
+      xp_reward: 50,
+      gold_reward: 10,
+      is_hidden: false,
+      criteria_type: "quest_complete",
+      unlocked_at: "2026-03-20T10:00:00Z",
+      progress: null,
+    },
+  ],
+};
+
+const CAT_B = {
+  id: "cat-b",
+  name: "Builder",
+  description: null,
+  icon: "hammer",
+  display_order: 2,
+  achievements: [
+    {
+      id: "ach-2",
+      name: "First Build",
+      description: "Build something",
+      icon: "hammer",
+      xp_reward: 50,
+      gold_reward: 10,
+      is_hidden: false,
+      criteria_type: "quest_complete",
+      unlocked_at: null,
+      progress: null,
+    },
+  ],
+};
+
+describe("AchievementsSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders loading state", () => {
+    mockUseAchievements.mockReturnValue({
+      categories: [],
+      isLoading: true,
+      error: null,
+      retry: mockRetry,
+    });
+
+    render(<AchievementsSection characterId="char-1" />);
+
+    expect(screen.getByTestId("achievements-loading")).toBeInTheDocument();
+  });
+
+  it("renders error state with retry button", async () => {
+    mockUseAchievements.mockReturnValue({
+      categories: [],
+      isLoading: false,
+      error: "Failed to load achievements",
+      retry: mockRetry,
+    });
+
+    render(<AchievementsSection characterId="char-1" />);
+
+    expect(screen.getByTestId("achievements-error")).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("achievements-retry"));
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders achievements section", () => {
+    mockUseAchievements.mockReturnValue({
+      categories: [CAT_A],
+      isLoading: false,
+      error: null,
+      retry: mockRetry,
+    });
+
+    render(<AchievementsSection characterId="char-1" />);
+
+    expect(screen.getByTestId("achievements-section")).toBeInTheDocument();
+    expect(screen.getByTestId("achievement-summary")).toBeInTheDocument();
+  });
+
+  it("resets selectedCategoryId to null when categories change and selected category no longer exists", () => {
+    mockUseAchievements.mockReturnValue({
+      categories: [CAT_A, CAT_B],
+      isLoading: false,
+      error: null,
+      retry: mockRetry,
+    });
+
+    const { rerender } = render(<AchievementsSection characterId="char-1" />);
+
+    // Simulate selecting cat-b via AchievementGrid's onActiveCategoryChange
+    // by re-rendering with a dataset that no longer contains cat-b
+    act(() => {
+      mockUseAchievements.mockReturnValue({
+        categories: [CAT_A],
+        isLoading: false,
+        error: null,
+        retry: mockRetry,
+      });
+      rerender(<AchievementsSection characterId="char-1" />);
+    });
+
+    // Summary should show overall totals (cat-a: 1/1) rather than 0/0 for stale category
+    expect(screen.getByTestId("achievement-count")).toHaveTextContent(
+      "1/1 Achievements Unlocked",
+    );
+    expect(screen.getByText("Achievements")).toBeInTheDocument();
+  });
+
+  it("keeps selectedCategoryId when the category still exists after data refresh", () => {
+    mockUseAchievements.mockReturnValue({
+      categories: [CAT_A, CAT_B],
+      isLoading: false,
+      error: null,
+      retry: mockRetry,
+    });
+
+    const { rerender } = render(<AchievementsSection characterId="char-1" />);
+
+    // Refresh with both categories still present
+    act(() => {
+      mockUseAchievements.mockReturnValue({
+        categories: [CAT_A, CAT_B],
+        isLoading: false,
+        error: null,
+        retry: mockRetry,
+      });
+      rerender(<AchievementsSection characterId="char-1" />);
+    });
+
+    // Summary defaults to overall when no tab has been selected
+    expect(screen.getByText("Achievements")).toBeInTheDocument();
+  });
+});

--- a/components/achievements/AchievementsSection.tsx
+++ b/components/achievements/AchievementsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RefreshCw } from "lucide-react";
 import { useAchievements } from "@/hooks/useAchievements";
 import { LoadingSpinner, Button } from "@/components/ui";
@@ -17,6 +17,18 @@ export function AchievementsSection({ characterId }: AchievementsSectionProps) {
   const { categories, isLoading, error, retry } = useAchievements(characterId);
   const [selectedAchievement, setSelectedAchievement] =
     useState<AchievementDisplay | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (
+      selectedCategoryId !== null &&
+      !categories.some((c) => c.id === selectedCategoryId)
+    ) {
+      setSelectedCategoryId(null);
+    }
+  }, [categories, selectedCategoryId]);
 
   if (isLoading) {
     return (
@@ -53,10 +65,14 @@ export function AchievementsSection({ characterId }: AchievementsSectionProps) {
 
   return (
     <div data-testid="achievements-section">
-      <AchievementSummary categories={categories} />
+      <AchievementSummary
+        categories={categories}
+        selectedCategoryId={selectedCategoryId}
+      />
       <AchievementGrid
         categories={categories}
         onBadgeClick={setSelectedAchievement}
+        onActiveCategoryChange={setSelectedCategoryId}
       />
       <AchievementDetailModal
         achievement={selectedAchievement}

--- a/components/admin/achievement-admin/AchievementAdmin.test.tsx
+++ b/components/admin/achievement-admin/AchievementAdmin.test.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AchievementAdmin from "./index";
+
+const mockAchievements = [
+  {
+    id: "ach-1",
+    name: "First Quest",
+    description: "Complete your first quest",
+    icon: "sword",
+    category_id: "cat-1",
+    category_name: "Adventurer",
+    xp_reward: 50,
+    gold_reward: 10,
+    is_hidden: false,
+    criteria_type: "quest_complete",
+    criteria_config: {},
+    family_id: "fam-1",
+  },
+  {
+    id: "ach-2",
+    name: "Hidden Treasure",
+    description: "Find the hidden treasure",
+    icon: "gem",
+    category_id: "cat-2",
+    category_name: "Wealth",
+    xp_reward: 100,
+    gold_reward: 50,
+    is_hidden: true,
+    criteria_type: "gold_earned",
+    criteria_config: { threshold: 1000 },
+    family_id: "fam-1",
+  },
+];
+
+const mockCategories = [
+  { id: "cat-1", name: "Adventurer" },
+  { id: "cat-2", name: "Wealth" },
+];
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({
+        data: { session: { access_token: "test-token" } },
+      }),
+    },
+  },
+}));
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      achievements: mockAchievements,
+      categories: mockCategories,
+    }),
+  }) as jest.Mock;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("AchievementAdmin", () => {
+  it("renders achievement list after loading", async () => {
+    render(<AchievementAdmin />);
+
+    expect(screen.getByText("Loading achievements...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Hidden Treasure")).toBeInTheDocument();
+  });
+
+  it("shows hidden icon for hidden achievements", async () => {
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("visible-icon-ach-1")).toBeInTheDocument();
+    expect(screen.getByTestId("hidden-icon-ach-2")).toBeInTheDocument();
+  });
+
+  it("opens create form when clicking create button", async () => {
+    const user = userEvent.setup();
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("create-achievement-button"));
+    expect(screen.getByTestId("achievement-form")).toBeInTheDocument();
+  });
+
+  it("opens edit form when clicking edit button", async () => {
+    const user = userEvent.setup();
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("edit-achievement-ach-1"));
+    expect(screen.getByTestId("achievement-form")).toBeInTheDocument();
+    expect(screen.getByTestId("achievement-name-input")).toHaveValue(
+      "First Quest",
+    );
+  });
+
+  it("filters achievements by category", async () => {
+    const user = userEvent.setup();
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    await user.selectOptions(
+      screen.getByTestId("achievement-category-filter"),
+      "cat-2",
+    );
+
+    expect(screen.queryByText("First Quest")).not.toBeInTheDocument();
+    expect(screen.getByText("Hidden Treasure")).toBeInTheDocument();
+  });
+
+  it("shows category dropdown in form", async () => {
+    const user = userEvent.setup();
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("create-achievement-button"));
+    const select = screen.getByTestId("achievement-category-select");
+    expect(select).toBeInTheDocument();
+
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(3); // "Select category" + 2 categories
+  });
+
+  it("shows hidden toggle in form", async () => {
+    const user = userEvent.setup();
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("create-achievement-button"));
+    expect(screen.getByTestId("achievement-hidden-toggle")).toBeInTheDocument();
+  });
+
+  it("validates required fields", async () => {
+    const user = userEvent.setup();
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("First Quest")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("create-achievement-button"));
+    const submitButton = screen.getByTestId("achievement-submit-button");
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("shows error when API fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Access denied" }),
+    }) as jest.Mock;
+
+    render(<AchievementAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Access denied")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/admin/achievement-admin/AchievementForm.tsx
+++ b/components/admin/achievement-admin/AchievementForm.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Button } from "@/components/ui";
+import type {
+  AchievementFormData,
+  AdminCategoryOption,
+} from "./useAchievementAdmin";
+
+interface AchievementFormProps {
+  mode: "create" | "edit";
+  formData: AchievementFormData;
+  categories: AdminCategoryOption[];
+  actionLoading: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+  onChange: (field: keyof AchievementFormData, value: string | boolean) => void;
+}
+
+export function AchievementForm({
+  mode,
+  formData,
+  categories,
+  actionLoading,
+  onSubmit,
+  onCancel,
+  onChange,
+}: AchievementFormProps) {
+  const title = mode === "create" ? "Create Achievement" : "Edit Achievement";
+  const submitText = mode === "create" ? "Create Achievement" : "Save Changes";
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  const isValid =
+    formData.name.trim().length > 0 &&
+    formData.category_id.length > 0 &&
+    formData.criteria_type.trim().length > 0;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div
+        className="fantasy-card p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto"
+        data-testid="achievement-form"
+      >
+        <h3 className="text-xl font-fantasy text-gold-400 mb-4">{title}</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => onChange("name", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              placeholder="e.g., First Quest"
+              data-testid="achievement-name-input"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Description
+            </label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => onChange("description", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              placeholder="Achievement description"
+              rows={2}
+              data-testid="achievement-description-input"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">
+                Category <span className="text-red-400">*</span>
+              </label>
+              <select
+                value={formData.category_id}
+                onChange={(e) => onChange("category_id", e.target.value)}
+                className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+                data-testid="achievement-category-select"
+              >
+                <option value="">Select category</option>
+                {categories.map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">
+                Icon
+              </label>
+              <input
+                type="text"
+                value={formData.icon}
+                onChange={(e) => onChange("icon", e.target.value)}
+                className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+                placeholder="e.g., sword"
+                data-testid="achievement-icon-input"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">
+                XP Reward
+              </label>
+              <input
+                type="number"
+                value={formData.xp_reward}
+                onChange={(e) => onChange("xp_reward", e.target.value)}
+                className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+                data-testid="achievement-xp-input"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">
+                Gold Reward
+              </label>
+              <input
+                type="number"
+                value={formData.gold_reward}
+                onChange={(e) => onChange("gold_reward", e.target.value)}
+                className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+                data-testid="achievement-gold-input"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Criteria Type <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={formData.criteria_type}
+              onChange={(e) => onChange("criteria_type", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              placeholder="e.g., quest_complete"
+              data-testid="achievement-criteria-type-input"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Criteria Config (JSON)
+            </label>
+            <textarea
+              value={formData.criteria_config}
+              onChange={(e) => onChange("criteria_config", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 font-mono text-sm focus:border-gold-500 focus:outline-none"
+              placeholder='{"count": 1}'
+              rows={3}
+              data-testid="achievement-criteria-config-input"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_hidden"
+              checked={formData.is_hidden}
+              onChange={(e) => onChange("is_hidden", e.target.checked)}
+              className="rounded border-gray-600 bg-dark-700 text-gold-500 focus:ring-gold-500"
+              data-testid="achievement-hidden-toggle"
+            />
+            <label htmlFor="is_hidden" className="text-sm text-gray-300">
+              Hidden achievement (shows as &ldquo;???&rdquo; until unlocked)
+            </label>
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <div className="flex-1">
+              <Button
+                onClick={onCancel}
+                disabled={actionLoading}
+                variant="secondary"
+                size="sm"
+                fullWidth
+                type="button"
+              >
+                Cancel
+              </Button>
+            </div>
+            <div className="flex-1">
+              <Button
+                type="submit"
+                disabled={!isValid || actionLoading}
+                isLoading={actionLoading}
+                variant="gold"
+                size="sm"
+                fullWidth
+                data-testid="achievement-submit-button"
+              >
+                {submitText}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/achievement-admin/AchievementList.tsx
+++ b/components/admin/achievement-admin/AchievementList.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Pencil, Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui";
+import type {
+  AdminAchievement,
+  AdminCategoryOption,
+} from "./useAchievementAdmin";
+
+interface AchievementListProps {
+  achievements: AdminAchievement[];
+  categories: AdminCategoryOption[];
+  categoryFilter: string;
+  onEdit: (achievement: AdminAchievement) => void;
+  onCategoryFilterChange: (categoryId: string) => void;
+}
+
+export function AchievementList({
+  achievements,
+  categories,
+  categoryFilter,
+  onEdit,
+  onCategoryFilterChange,
+}: AchievementListProps) {
+  return (
+    <div data-testid="achievement-list">
+      <div className="mb-4">
+        <select
+          value={categoryFilter}
+          onChange={(e) => onCategoryFilterChange(e.target.value)}
+          className="bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 text-sm focus:border-gold-500 focus:outline-none"
+          data-testid="achievement-category-filter"
+        >
+          <option value="all">All Categories</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {achievements.length === 0 ? (
+        <div
+          className="text-center py-8 text-gray-400"
+          data-testid="achievement-empty-state"
+        >
+          <p className="text-lg mb-2">No achievements found</p>
+          <p className="text-sm">
+            {categoryFilter !== "all"
+              ? "No achievements in this category."
+              : "Create your first achievement to get started."}
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-700 text-left text-sm text-gray-400">
+                <th className="pb-2 pr-4">Name</th>
+                <th className="pb-2 pr-4">Category</th>
+                <th className="pb-2 pr-4">Hidden</th>
+                <th className="pb-2 pr-4">XP</th>
+                <th className="pb-2 pr-4">Gold</th>
+                <th className="pb-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {achievements.map((achievement) => (
+                <tr
+                  key={achievement.id}
+                  className="border-b border-gray-700/50 text-gray-200"
+                  data-testid={`achievement-row-${achievement.id}`}
+                >
+                  <td className="py-3 pr-4 font-medium">{achievement.name}</td>
+                  <td className="py-3 pr-4 text-sm text-gray-400">
+                    {achievement.category_name}
+                  </td>
+                  <td className="py-3 pr-4">
+                    {achievement.is_hidden ? (
+                      <EyeOff
+                        size={16}
+                        className="text-yellow-400"
+                        data-testid={`hidden-icon-${achievement.id}`}
+                      />
+                    ) : (
+                      <Eye
+                        size={16}
+                        className="text-gray-500"
+                        data-testid={`visible-icon-${achievement.id}`}
+                      />
+                    )}
+                  </td>
+                  <td className="py-3 pr-4 text-sm">
+                    {achievement.xp_reward ?? 0}
+                  </td>
+                  <td className="py-3 pr-4 text-sm">
+                    {achievement.gold_reward ?? 0}
+                  </td>
+                  <td className="py-3">
+                    <Button
+                      onClick={() => onEdit(achievement)}
+                      variant="secondary"
+                      size="sm"
+                      data-testid={`edit-achievement-${achievement.id}`}
+                    >
+                      <Pencil size={14} />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/achievement-admin/index.tsx
+++ b/components/admin/achievement-admin/index.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Trophy } from "lucide-react";
+import { Button } from "@/components/ui";
+import { useAchievementAdmin } from "./useAchievementAdmin";
+import { AchievementList } from "./AchievementList";
+import { AchievementForm } from "./AchievementForm";
+
+export default function AchievementAdmin() {
+  const {
+    achievements,
+    categories,
+    loading,
+    error,
+    showForm,
+    editingAchievement,
+    formData,
+    actionLoading,
+    categoryFilter,
+    setCategoryFilter,
+    handleCreate,
+    handleEdit,
+    handleFormChange,
+    handleSubmit,
+    handleCancelForm,
+  } = useAchievementAdmin();
+
+  if (loading) {
+    return <div className="text-center py-8">Loading achievements...</div>;
+  }
+
+  return (
+    <div className="space-y-6" data-testid="achievement-admin">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-fantasy text-gray-100 flex items-center gap-2">
+          <Trophy size={28} />
+          Achievement Management
+        </h2>
+        <Button
+          onClick={handleCreate}
+          variant="gold"
+          size="sm"
+          data-testid="create-achievement-button"
+        >
+          Create Achievement
+        </Button>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/20 border border-red-500 rounded-lg p-4 text-red-200">
+          {error}
+        </div>
+      )}
+
+      <AchievementList
+        achievements={achievements}
+        categories={categories}
+        categoryFilter={categoryFilter}
+        onEdit={handleEdit}
+        onCategoryFilterChange={setCategoryFilter}
+      />
+
+      {showForm && (
+        <AchievementForm
+          mode={editingAchievement ? "edit" : "create"}
+          formData={formData}
+          categories={categories}
+          actionLoading={actionLoading}
+          onSubmit={handleSubmit}
+          onCancel={handleCancelForm}
+          onChange={handleFormChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/admin/achievement-admin/useAchievementAdmin.ts
+++ b/components/admin/achievement-admin/useAchievementAdmin.ts
@@ -1,0 +1,208 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+
+export interface AdminAchievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string | null;
+  category_id: string;
+  category_name: string;
+  xp_reward: number | null;
+  gold_reward: number | null;
+  is_hidden: boolean | null;
+  criteria_type: string;
+  criteria_config: Record<string, unknown>;
+  family_id: string | null;
+}
+
+export interface AdminCategoryOption {
+  id: string;
+  name: string;
+}
+
+export interface AchievementFormData {
+  name: string;
+  description: string;
+  icon: string;
+  category_id: string;
+  xp_reward: string;
+  gold_reward: string;
+  is_hidden: boolean;
+  criteria_type: string;
+  criteria_config: string;
+}
+
+const EMPTY_FORM: AchievementFormData = {
+  name: "",
+  description: "",
+  icon: "",
+  category_id: "",
+  xp_reward: "0",
+  gold_reward: "0",
+  is_hidden: false,
+  criteria_type: "",
+  criteria_config: "{}",
+};
+
+async function getAuthToken(): Promise<string> {
+  const session = (await supabase.auth.getSession()).data.session;
+  if (!session?.access_token) throw new Error("Not authenticated");
+  return session.access_token;
+}
+
+async function apiFetch(
+  path: string,
+  method: string,
+  body?: Record<string, unknown>,
+) {
+  const token = await getAuthToken();
+  const res = await fetch(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
+  return data;
+}
+
+export function useAchievementAdmin() {
+  const [achievements, setAchievements] = useState<AdminAchievement[]>([]);
+  const [categories, setCategories] = useState<AdminCategoryOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingAchievement, setEditingAchievement] =
+    useState<AdminAchievement | null>(null);
+  const [formData, setFormData] = useState<AchievementFormData>(EMPTY_FORM);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+
+  const fetchAchievements = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await apiFetch("/api/admin/achievements", "GET");
+      setAchievements(data.achievements);
+      setCategories(data.categories);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load achievements",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAchievements();
+  }, [fetchAchievements]);
+
+  const filteredAchievements =
+    categoryFilter === "all"
+      ? achievements
+      : achievements.filter((a) => a.category_id === categoryFilter);
+
+  const handleCreate = () => {
+    setEditingAchievement(null);
+    setFormData(EMPTY_FORM);
+    setShowForm(true);
+  };
+
+  const handleEdit = (achievement: AdminAchievement) => {
+    setEditingAchievement(achievement);
+    setFormData({
+      name: achievement.name,
+      description: achievement.description,
+      icon: achievement.icon ?? "",
+      category_id: achievement.category_id,
+      xp_reward: String(achievement.xp_reward ?? 0),
+      gold_reward: String(achievement.gold_reward ?? 0),
+      is_hidden: achievement.is_hidden ?? false,
+      criteria_type: achievement.criteria_type,
+      criteria_config: JSON.stringify(achievement.criteria_config ?? {}),
+    });
+    setShowForm(true);
+  };
+
+  const handleFormChange = (
+    field: keyof AchievementFormData,
+    value: string | boolean,
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async () => {
+    setActionLoading(true);
+    try {
+      let parsedConfig: Record<string, unknown> = {};
+      try {
+        parsedConfig = JSON.parse(formData.criteria_config);
+      } catch {
+        // Keep empty object if invalid JSON
+      }
+
+      const payload = {
+        name: formData.name,
+        description: formData.description || "",
+        icon: formData.icon || null,
+        category_id: formData.category_id,
+        xp_reward: parseInt(formData.xp_reward, 10) || 0,
+        gold_reward: parseInt(formData.gold_reward, 10) || 0,
+        is_hidden: formData.is_hidden,
+        criteria_type: formData.criteria_type,
+        criteria_config: parsedConfig,
+      };
+
+      if (editingAchievement) {
+        await apiFetch(
+          `/api/admin/achievements/${editingAchievement.id}`,
+          "PATCH",
+          payload,
+        );
+      } else {
+        await apiFetch("/api/admin/achievements", "POST", payload);
+      }
+
+      setShowForm(false);
+      setEditingAchievement(null);
+      setFormData(EMPTY_FORM);
+      await fetchAchievements();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to save achievement",
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleCancelForm = () => {
+    setShowForm(false);
+    setEditingAchievement(null);
+    setFormData(EMPTY_FORM);
+  };
+
+  return {
+    achievements: filteredAchievements,
+    categories,
+    loading,
+    error,
+    showForm,
+    editingAchievement,
+    formData,
+    actionLoading,
+    categoryFilter,
+    setCategoryFilter,
+    handleCreate,
+    handleEdit,
+    handleFormChange,
+    handleSubmit,
+    handleCancelForm,
+  };
+}

--- a/components/admin/achievement-category-admin/AchievementCategoryAdmin.test.tsx
+++ b/components/admin/achievement-category-admin/AchievementCategoryAdmin.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AchievementCategoryAdmin from "./index";
+
+const mockCategories = [
+  {
+    id: "cat-1",
+    name: "Adventurer",
+    description: "Quest achievements",
+    icon: "sword",
+    display_order: 1,
+    achievement_count: 5,
+  },
+  {
+    id: "cat-2",
+    name: "Wealth",
+    description: "Gold achievements",
+    icon: "coins",
+    display_order: 2,
+    achievement_count: 0,
+  },
+];
+
+const mockGetSession = jest.fn().mockResolvedValue({
+  data: { session: { access_token: "test-token" } },
+});
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+    },
+  },
+}));
+
+let fetchMockResponses: Array<{ ok: boolean; json: () => Promise<unknown> }> =
+  [];
+let fetchCallIndex = 0;
+
+beforeEach(() => {
+  fetchCallIndex = 0;
+  fetchMockResponses = [
+    {
+      ok: true,
+      json: async () => ({ categories: mockCategories }),
+    },
+  ];
+  global.fetch = jest.fn(() => {
+    const response =
+      fetchMockResponses[fetchCallIndex] ?? fetchMockResponses[0];
+    fetchCallIndex++;
+    return Promise.resolve(response);
+  }) as jest.Mock;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("AchievementCategoryAdmin", () => {
+  it("renders category list after loading", async () => {
+    render(<AchievementCategoryAdmin />);
+
+    expect(screen.getByText("Loading categories...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Wealth")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no categories", async () => {
+    fetchMockResponses = [{ ok: true, json: async () => ({ categories: [] }) }];
+
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("category-empty-state")).toBeInTheDocument();
+    });
+  });
+
+  it("opens create form when clicking create button", async () => {
+    const user = userEvent.setup();
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("create-category-button"));
+    expect(screen.getByTestId("category-form")).toBeInTheDocument();
+    expect(screen.getByText("Create Achievement Category")).toBeInTheDocument();
+  });
+
+  it("opens edit form when clicking edit button", async () => {
+    const user = userEvent.setup();
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("edit-category-cat-1"));
+    expect(screen.getByTestId("category-form")).toBeInTheDocument();
+    expect(screen.getByTestId("category-name-input")).toHaveValue("Adventurer");
+  });
+
+  it("shows delete dialog when clicking delete button", async () => {
+    const user = userEvent.setup();
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("delete-category-cat-1"));
+    expect(screen.getByTestId("delete-category-dialog")).toBeInTheDocument();
+  });
+
+  it("shows protection message for categories with achievements", async () => {
+    const user = userEvent.setup();
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("delete-category-cat-1"));
+    expect(screen.getByText(/Cannot delete/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Remove or reassign achievements/),
+    ).toBeInTheDocument();
+  });
+
+  it("validates that name is required in form", async () => {
+    const user = userEvent.setup();
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("create-category-button"));
+    const submitButton = screen.getByTestId("category-submit-button");
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("shows error when API request fails", async () => {
+    fetchMockResponses = [
+      {
+        ok: false,
+        json: async () => ({ error: "Something went wrong" }),
+      },
+    ];
+
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+  });
+
+  it("displays achievement counts in the table", async () => {
+    render(<AchievementCategoryAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Adventurer")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});

--- a/components/admin/achievement-category-admin/CategoryForm.tsx
+++ b/components/admin/achievement-category-admin/CategoryForm.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Button } from "@/components/ui";
+import type { CategoryFormData } from "./useAchievementCategoryAdmin";
+
+interface CategoryFormProps {
+  mode: "create" | "edit";
+  formData: CategoryFormData;
+  actionLoading: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+  onChange: (field: keyof CategoryFormData, value: string) => void;
+}
+
+export function CategoryForm({
+  mode,
+  formData,
+  actionLoading,
+  onSubmit,
+  onCancel,
+  onChange,
+}: CategoryFormProps) {
+  const title =
+    mode === "create" ? "Create Achievement Category" : "Edit Category";
+  const submitText = mode === "create" ? "Create Category" : "Save Changes";
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  const isValid = formData.name.trim().length > 0;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div
+        className="fantasy-card p-6 max-w-md w-full"
+        data-testid="category-form"
+      >
+        <h3 className="text-xl font-fantasy text-gold-400 mb-4">{title}</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => onChange("name", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              placeholder="e.g., Adventurer"
+              data-testid="category-name-input"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Description
+            </label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => onChange("description", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              placeholder="Category description"
+              rows={2}
+              data-testid="category-description-input"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Icon
+            </label>
+            <input
+              type="text"
+              value={formData.icon}
+              onChange={(e) => onChange("icon", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              placeholder="e.g., sword"
+              data-testid="category-icon-input"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Display Order
+            </label>
+            <input
+              type="number"
+              value={formData.display_order}
+              onChange={(e) => onChange("display_order", e.target.value)}
+              className="w-full bg-dark-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 focus:border-gold-500 focus:outline-none"
+              data-testid="category-order-input"
+            />
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <div className="flex-1">
+              <Button
+                onClick={onCancel}
+                disabled={actionLoading}
+                variant="secondary"
+                size="sm"
+                fullWidth
+                type="button"
+              >
+                Cancel
+              </Button>
+            </div>
+            <div className="flex-1">
+              <Button
+                type="submit"
+                disabled={!isValid || actionLoading}
+                isLoading={actionLoading}
+                variant="gold"
+                size="sm"
+                fullWidth
+                data-testid="category-submit-button"
+              >
+                {submitText}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/achievement-category-admin/CategoryList.tsx
+++ b/components/admin/achievement-category-admin/CategoryList.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui";
+import type { AdminCategory } from "./useAchievementCategoryAdmin";
+
+interface CategoryListProps {
+  categories: AdminCategory[];
+  onEdit: (category: AdminCategory) => void;
+  onDelete: (category: AdminCategory) => void;
+}
+
+export function CategoryList({
+  categories,
+  onEdit,
+  onDelete,
+}: CategoryListProps) {
+  if (categories.length === 0) {
+    return (
+      <div
+        className="text-center py-8 text-gray-400"
+        data-testid="category-empty-state"
+      >
+        <p className="text-lg mb-2">No achievement categories yet</p>
+        <p className="text-sm">
+          Create your first category to organize achievements.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto" data-testid="category-list">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-gray-700 text-left text-sm text-gray-400">
+            <th className="pb-2 pr-4">Order</th>
+            <th className="pb-2 pr-4">Name</th>
+            <th className="pb-2 pr-4">Description</th>
+            <th className="pb-2 pr-4">Icon</th>
+            <th className="pb-2 pr-4">Achievements</th>
+            <th className="pb-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {categories.map((category) => (
+            <tr
+              key={category.id}
+              className="border-b border-gray-700/50 text-gray-200"
+              data-testid={`category-row-${category.id}`}
+            >
+              <td className="py-3 pr-4 text-sm text-gray-400">
+                {category.display_order ?? 0}
+              </td>
+              <td className="py-3 pr-4 font-medium">{category.name}</td>
+              <td className="py-3 pr-4 text-sm text-gray-400">
+                {category.description || "—"}
+              </td>
+              <td className="py-3 pr-4 text-sm">{category.icon || "—"}</td>
+              <td className="py-3 pr-4 text-sm">
+                {category.achievement_count}
+              </td>
+              <td className="py-3">
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => onEdit(category)}
+                    variant="secondary"
+                    size="sm"
+                    data-testid={`edit-category-${category.id}`}
+                  >
+                    <Pencil size={14} />
+                  </Button>
+                  <Button
+                    onClick={() => onDelete(category)}
+                    variant="destructive"
+                    size="sm"
+                    data-testid={`delete-category-${category.id}`}
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/admin/achievement-category-admin/DeleteCategoryDialog.tsx
+++ b/components/admin/achievement-category-admin/DeleteCategoryDialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Button } from "@/components/ui";
+import type { AdminCategory } from "./useAchievementCategoryAdmin";
+
+interface DeleteCategoryDialogProps {
+  category: AdminCategory;
+  isOpen: boolean;
+  isLoading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteCategoryDialog({
+  category,
+  isOpen,
+  isLoading,
+  onCancel,
+  onConfirm,
+}: DeleteCategoryDialogProps) {
+  if (!isOpen) return null;
+
+  const hasAchievements = category.achievement_count > 0;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div
+        className="fantasy-card p-6 max-w-md w-full"
+        data-testid="delete-category-dialog"
+      >
+        <h3 className="text-xl font-fantasy text-red-400 mb-4">
+          Delete Category?
+        </h3>
+        {hasAchievements ? (
+          <>
+            <p className="text-gray-300 mb-4">
+              Cannot delete{" "}
+              <span className="font-semibold text-gray-100">
+                &ldquo;{category.name}&rdquo;
+              </span>{" "}
+              because it has{" "}
+              <span className="font-semibold text-gold-400">
+                {category.achievement_count}
+              </span>{" "}
+              achievement{category.achievement_count !== 1 ? "s" : ""} assigned.
+            </p>
+            <p className="text-sm text-gray-400 mb-6">
+              Remove or reassign achievements before deleting this category.
+            </p>
+            <Button onClick={onCancel} variant="secondary" size="sm" fullWidth>
+              Close
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className="text-gray-300 mb-6">
+              Are you sure you want to delete{" "}
+              <span className="font-semibold text-gray-100">
+                &ldquo;{category.name}&rdquo;
+              </span>
+              ? This action cannot be undone.
+            </p>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <Button
+                  onClick={onCancel}
+                  disabled={isLoading}
+                  variant="secondary"
+                  size="sm"
+                  fullWidth
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div className="flex-1">
+                <Button
+                  onClick={onConfirm}
+                  isLoading={isLoading}
+                  variant="destructive"
+                  size="sm"
+                  fullWidth
+                  data-testid="confirm-delete-category"
+                >
+                  {isLoading ? "Deleting..." : "Delete"}
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/achievement-category-admin/index.tsx
+++ b/components/admin/achievement-category-admin/index.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { FolderOpen } from "lucide-react";
+import { Button } from "@/components/ui";
+import { useAchievementCategoryAdmin } from "./useAchievementCategoryAdmin";
+import { CategoryList } from "./CategoryList";
+import { CategoryForm } from "./CategoryForm";
+import { DeleteCategoryDialog } from "./DeleteCategoryDialog";
+
+export default function AchievementCategoryAdmin() {
+  const {
+    categories,
+    loading,
+    error,
+    showForm,
+    editingCategory,
+    formData,
+    showDeleteConfirm,
+    deleteTarget,
+    actionLoading,
+    handleCreate,
+    handleEdit,
+    handleFormChange,
+    handleSubmit,
+    handleCancelForm,
+    handleDeleteClick,
+    handleConfirmDelete,
+    handleCancelDelete,
+  } = useAchievementCategoryAdmin();
+
+  if (loading) {
+    return <div className="text-center py-8">Loading categories...</div>;
+  }
+
+  return (
+    <div className="space-y-6" data-testid="achievement-category-admin">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-fantasy text-gray-100 flex items-center gap-2">
+          <FolderOpen size={28} />
+          Achievement Categories
+        </h2>
+        <Button
+          onClick={handleCreate}
+          variant="gold"
+          size="sm"
+          data-testid="create-category-button"
+        >
+          Create Category
+        </Button>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/20 border border-red-500 rounded-lg p-4 text-red-200">
+          {error}
+        </div>
+      )}
+
+      <CategoryList
+        categories={categories}
+        onEdit={handleEdit}
+        onDelete={handleDeleteClick}
+      />
+
+      {showForm && (
+        <CategoryForm
+          mode={editingCategory ? "edit" : "create"}
+          formData={formData}
+          actionLoading={actionLoading}
+          onSubmit={handleSubmit}
+          onCancel={handleCancelForm}
+          onChange={handleFormChange}
+        />
+      )}
+
+      {showDeleteConfirm && deleteTarget && (
+        <DeleteCategoryDialog
+          category={deleteTarget}
+          isOpen={showDeleteConfirm}
+          isLoading={actionLoading}
+          onCancel={handleCancelDelete}
+          onConfirm={handleConfirmDelete}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/admin/achievement-category-admin/useAchievementCategoryAdmin.ts
+++ b/components/admin/achievement-category-admin/useAchievementCategoryAdmin.ts
@@ -1,0 +1,192 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+
+export interface AdminCategory {
+  id: string;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  display_order: number | null;
+  achievement_count: number;
+}
+
+export interface CategoryFormData {
+  name: string;
+  description: string;
+  icon: string;
+  display_order: string;
+}
+
+const EMPTY_FORM: CategoryFormData = {
+  name: "",
+  description: "",
+  icon: "",
+  display_order: "0",
+};
+
+async function getAuthToken(): Promise<string> {
+  const session = (await supabase.auth.getSession()).data.session;
+  if (!session?.access_token) throw new Error("Not authenticated");
+  return session.access_token;
+}
+
+async function apiFetch(
+  path: string,
+  method: string,
+  body?: Record<string, unknown>,
+) {
+  const token = await getAuthToken();
+  const res = await fetch(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
+  return data;
+}
+
+export function useAchievementCategoryAdmin() {
+  const [categories, setCategories] = useState<AdminCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<AdminCategory | null>(
+    null,
+  );
+  const [formData, setFormData] = useState<CategoryFormData>(EMPTY_FORM);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<AdminCategory | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const fetchCategories = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await apiFetch("/api/admin/achievement-categories", "GET");
+      setCategories(data.categories);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load categories",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  const handleCreate = () => {
+    setEditingCategory(null);
+    setFormData(EMPTY_FORM);
+    setShowForm(true);
+  };
+
+  const handleEdit = (category: AdminCategory) => {
+    setEditingCategory(category);
+    setFormData({
+      name: category.name,
+      description: category.description ?? "",
+      icon: category.icon ?? "",
+      display_order: String(category.display_order ?? 0),
+    });
+    setShowForm(true);
+  };
+
+  const handleFormChange = (field: keyof CategoryFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async () => {
+    setActionLoading(true);
+    try {
+      const payload = {
+        name: formData.name,
+        description: formData.description || null,
+        icon: formData.icon || null,
+        display_order: parseInt(formData.display_order, 10) || 0,
+      };
+
+      if (editingCategory) {
+        await apiFetch(
+          `/api/admin/achievement-categories/${editingCategory.id}`,
+          "PATCH",
+          payload,
+        );
+      } else {
+        await apiFetch("/api/admin/achievement-categories", "POST", payload);
+      }
+
+      setShowForm(false);
+      setEditingCategory(null);
+      setFormData(EMPTY_FORM);
+      await fetchCategories();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save category");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleCancelForm = () => {
+    setShowForm(false);
+    setEditingCategory(null);
+    setFormData(EMPTY_FORM);
+  };
+
+  const handleDeleteClick = (category: AdminCategory) => {
+    setDeleteTarget(category);
+    setShowDeleteConfirm(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setActionLoading(true);
+    try {
+      await apiFetch(
+        `/api/admin/achievement-categories/${deleteTarget.id}`,
+        "DELETE",
+      );
+      setShowDeleteConfirm(false);
+      setDeleteTarget(null);
+      await fetchCategories();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to delete category",
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setShowDeleteConfirm(false);
+    setDeleteTarget(null);
+  };
+
+  return {
+    categories,
+    loading,
+    error,
+    showForm,
+    editingCategory,
+    formData,
+    showDeleteConfirm,
+    deleteTarget,
+    actionLoading,
+    handleCreate,
+    handleEdit,
+    handleFormChange,
+    handleSubmit,
+    handleCancelForm,
+    handleDeleteClick,
+    handleConfirmDelete,
+    handleCancelDelete,
+  };
+}

--- a/components/admin/admin-dashboard.tsx
+++ b/components/admin/admin-dashboard.tsx
@@ -9,6 +9,8 @@ import {
   Trophy,
   Crown,
   Settings,
+  FolderOpen,
+  Medal,
 } from "lucide-react";
 import StatisticsPanel from "./statistics-panel";
 import ActivityFeed from "./activity-feed";
@@ -17,6 +19,8 @@ import FamilySettings from "@/components/family/family-settings";
 import { QuestTemplateManager } from "@/components/quests/quest-template-manager";
 import RewardManager from "@/components/rewards/reward-manager";
 import { QuestManagementTab } from "./quest-management-tab";
+import AchievementCategoryAdmin from "./achievement-category-admin";
+import AchievementAdmin from "./achievement-admin";
 import { useTabNavigation } from "@/hooks/useTabNavigation";
 
 type TabName =
@@ -24,6 +28,8 @@ type TabName =
   | "quests"
   | "quest-templates"
   | "rewards"
+  | "achievement-categories"
+  | "achievements"
   | "guild-masters"
   | "family-settings";
 
@@ -34,6 +40,8 @@ const TAB_ICONS = {
   Trophy,
   Crown,
   Settings,
+  FolderOpen,
+  Medal,
 };
 
 export function AdminDashboard() {
@@ -49,6 +57,12 @@ export function AdminDashboard() {
           icon: "ScrollText",
         },
         { name: "rewards", label: "Rewards", icon: "Trophy" },
+        {
+          name: "achievement-categories",
+          label: "Achievement Categories",
+          icon: "FolderOpen",
+        },
+        { name: "achievements", label: "Achievements", icon: "Medal" },
         { name: "guild-masters", label: "Guild Masters", icon: "Crown" },
         { name: "family-settings", label: "Family Settings", icon: "Settings" },
       ],
@@ -107,6 +121,16 @@ export function AdminDashboard() {
           {/* Rewards Tab */}
           <TabPanel unmount={false}>
             <RewardManager />
+          </TabPanel>
+
+          {/* Achievement Categories Tab */}
+          <TabPanel unmount={false}>
+            <AchievementCategoryAdmin />
+          </TabPanel>
+
+          {/* Achievements Tab */}
+          <TabPanel unmount={false}>
+            <AchievementAdmin />
           </TabPanel>
 
           {/* Guild Masters Tab */}

--- a/components/ui/tab-bar.tsx
+++ b/components/ui/tab-bar.tsx
@@ -1,3 +1,4 @@
+import { CheckCircle2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -6,6 +7,7 @@ export interface TabItem<T extends string> {
   label: string;
   shortLabel?: string;
   icon: LucideIcon;
+  complete?: boolean;
   testId?: string;
 }
 
@@ -56,6 +58,16 @@ export function TabBar<T extends string>({
             <Icon size={18} className="flex-shrink-0" />
             <span className="hidden sm:inline">{tab.label}</span>
             <span className="sm:hidden text-xs">{mobileLabel}</span>
+            {tab.complete && (
+              <CheckCircle2
+                size={14}
+                className="flex-shrink-0 text-gold-400"
+                aria-label="Category complete"
+                {...(tab.testId
+                  ? { "data-testid": `${tab.testId}-complete` }
+                  : {})}
+              />
+            )}
           </button>
         );
       })}

--- a/openspec/changes/achievement-categories-hidden/.openspec.yaml
+++ b/openspec/changes/achievement-categories-hidden/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/achievement-categories-hidden/design.md
+++ b/openspec/changes/achievement-categories-hidden/design.md
@@ -1,0 +1,121 @@
+# Design: Achievement Categories & Hidden Achievements
+
+## Context
+
+The achievement system schema already includes
+`achievement_categories` and `achievements` tables with
+`is_hidden`, `category_id`, and `display_order` fields.
+The UI has `AchievementGrid` with a category tab structure
+and `AchievementBadge` with a hidden state. However, no
+admin CRUD exists for categories/achievements, category
+filtering isn't wired up with real data, and category
+completion tracking is missing.
+
+The admin panel uses HeadlessUI tabs, service-role Supabase
+client for writes, and RLS policies enforcing Guild Master
+access.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Admin can create, edit, reorder, and delete achievement
+  categories
+- Admin can create and edit achievements with category
+  assignment and hidden flag
+- Players can filter achievements by category tab
+- Players see category completion counts (e.g., "3/8")
+- Hidden achievements show "???" when locked, full details
+  when unlocked
+
+**Non-Goals:**
+
+- Bulk import/export of achievements
+- Achievement category icons customization beyond existing
+  icon field
+- Player-facing category reordering or preferences
+- Achievement deletion from admin (soft-delete is future)
+
+## Decisions
+
+### 1. Admin UI as new AdminDashboard tabs
+
+Add two new tabs: "Achievement Categories" and
+"Achievements" to the existing `AdminDashboard` component.
+
+**Why**: Follows the established admin pattern (HeadlessUI
+tabs, `useTabNavigation` hook, URL-synced state). Avoids
+introducing a separate admin routing structure.
+
+**Alternative considered**: Separate admin pages with
+Next.js routing. Rejected because the existing tab pattern
+is well-established and keeps related admin functions
+together.
+
+### 2. API routes with service-role client
+
+Create new API routes under `/api/admin/achievement-categories`
+and `/api/admin/achievements` using the service-role
+Supabase client.
+
+**Why**: RLS policies restrict category/achievement writes
+to service role only. Admin API routes already use this
+pattern for other CRUD operations.
+
+**Alternative considered**: Direct client-side Supabase
+calls with RLS policy changes. Rejected because it would
+weaken the security model.
+
+### 3. Category filtering via client-side filter
+
+Fetch all achievements with their categories in one query,
+then filter client-side based on selected category tab.
+
+**Why**: The total achievement count is small (tens, not
+thousands). Client-side filtering is simpler and avoids
+extra network requests when switching tabs. The data is
+already fetched for the grid display.
+
+**Alternative considered**: Server-side filtering with
+separate queries per category. Rejected as unnecessary
+overhead for the expected data volume.
+
+### 4. Category completion tracking in AchievementGrid
+
+Compute completion counts by grouping fetched achievements
+by `category_id` and counting unlocked vs total per
+category. Display as "N/M" badge on each category tab.
+
+**Why**: All data needed is already available from the
+existing achievements fetch (which includes unlock status).
+No additional queries or database changes needed.
+
+### 5. Hidden achievement enforcement in display layer
+
+The `AchievementBadge` component already handles a hidden
+state. Ensure the data layer passes `is_hidden` through
+and the badge/modal components mask name and description
+for locked hidden achievements.
+
+**Why**: Display-layer enforcement keeps the API simple
+(return all achievements) and lets the UI decide
+presentation. The badge component already has the visual
+states implemented.
+
+## Risks / Trade-offs
+
+- **Category deletion with linked achievements**: Deleting
+  a category that has achievements assigned would break
+  references. Mitigation: prevent deletion if category has
+  achievements, show error message to admin.
+
+- **Display order conflicts**: Multiple admins reordering
+  simultaneously could cause conflicts. Mitigation:
+  acceptable for now given single-family admin usage.
+  Optimistic UI with refetch on save.
+
+- **Hidden achievement data exposure**: Achievement details
+  are sent to the client even for hidden achievements.
+  Mitigation: acceptable because the data isn't sensitive
+  (game achievements, not security secrets). If needed
+  later, server-side filtering can be added.

--- a/openspec/changes/achievement-categories-hidden/proposal.md
+++ b/openspec/changes/achievement-categories-hidden/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: Achievement Categories & Hidden Achievements
+
+## Why
+
+Achievement categories and hidden achievements exist in the
+database schema and are partially supported in the UI (badge
+display handles hidden state, grid has category tab structure),
+but there is no admin interface to manage categories or
+achievements, no category filtering logic wired up, and no
+category completion tracking. Admins need CRUD interfaces to
+organize achievements, and players need browseable category
+tabs with completion progress.
+
+## What Changes
+
+- Add admin tab for achievement category CRUD (create, edit,
+  reorder, delete) following existing admin panel patterns
+- Add admin tab for achievement CRUD with category assignment
+  and hidden flag toggle
+- Wire up category filter/tab UI on the achievement grid to
+  fetch and filter by category
+- Implement hidden achievement display logic: show "???" name
+  and placeholder description for locked hidden achievements,
+  reveal full details only after unlocking
+- Add category completion tracking (e.g., "Questing: 3/8")
+  to the achievement grid
+
+## Capabilities
+
+### New Capabilities
+
+- `achievement-category-admin`: Admin CRUD interface for
+  managing achievement categories (create, edit, reorder,
+  delete) and achievements (create, edit with category
+  assignment and hidden flag)
+- `achievement-category-filtering`: Category tab filtering
+  on the achievement grid with completion tracking per
+  category
+
+### Modified Capabilities
+
+- `achievement-badge-display`: Add enforcement of hidden
+  achievement display rules (locked hidden shows "???",
+  unlocked hidden shows full details) and category
+  completion counts
+
+## Impact
+
+- **Admin UI**: New admin tabs added to `AdminDashboard`
+  component following existing HeadlessUI tab pattern
+- **API routes**: New API routes for admin CRUD operations
+  on categories and achievements (service-role client)
+- **Achievement grid**: Enhanced with category filtering
+  and completion tracking
+- **Badge display**: Hidden achievement logic enforced in
+  display layer
+- **Dependencies**: Builds on achievement schema (#134) and
+  badge display (#138), both already merged

--- a/openspec/changes/achievement-categories-hidden/specs/achievement-badge-display/spec.md
+++ b/openspec/changes/achievement-categories-hidden/specs/achievement-badge-display/spec.md
@@ -1,0 +1,70 @@
+# Achievement Badge Display (Delta)
+
+## MODIFIED Requirements
+
+### Requirement: Achievement grid with category filtering
+
+The AchievementGrid component SHALL display all achievements
+in a responsive grid layout organized by category tabs. Each
+category tab SHALL include a completion count badge showing
+unlocked/total for that category.
+
+#### Scenario: Default view shows all achievements
+
+- **WHEN** the achievement grid loads
+- **THEN** an "All" tab is selected by default showing
+  every achievement, and category tabs are displayed
+  with each category's icon, achievement count, and
+  completion count badge
+
+#### Scenario: Category tab filtering
+
+- **WHEN** a user selects a category tab
+- **THEN** only achievements in that category are displayed
+  in the grid
+
+#### Scenario: Responsive grid layout
+
+- **WHEN** the achievement grid is rendered
+- **THEN** it displays in a responsive grid with 1 column
+  on mobile, 2 columns on medium screens, and 3 columns
+  on large screens
+
+#### Scenario: Category ordering
+
+- **WHEN** categories are displayed as tabs
+- **THEN** they are ordered by display_order from the
+  achievement_categories table
+
+### Requirement: Achievement count summary
+
+The system SHALL display an achievement progress summary
+above the achievement grid. When a specific category is
+selected, the summary SHALL reflect that category's
+counts.
+
+#### Scenario: Display unlock count
+
+- **WHEN** the achievement section renders
+- **THEN** a summary displays the count of unlocked
+  achievements out of total non-hidden achievements
+  (e.g., "12/30 Achievements Unlocked")
+
+#### Scenario: Display overall progress bar
+
+- **WHEN** the achievement section renders
+- **THEN** a progress bar shows the overall unlock
+  percentage based on unlocked count vs total count
+
+#### Scenario: Hidden achievements excluded from count
+
+- **WHEN** calculating the summary counts
+- **THEN** hidden achievements that are still locked
+  are excluded from the total count, but hidden
+  achievements that are unlocked are included
+
+#### Scenario: Category-scoped summary
+
+- **WHEN** a specific category tab is selected
+- **THEN** the summary updates to show counts for only
+  that category's achievements

--- a/openspec/changes/achievement-categories-hidden/specs/achievement-category-admin/spec.md
+++ b/openspec/changes/achievement-categories-hidden/specs/achievement-category-admin/spec.md
@@ -1,0 +1,171 @@
+# Achievement Category Admin
+
+## ADDED Requirements
+
+### Requirement: Admin category list view
+
+The admin panel SHALL display a tab showing all achievement
+categories in a table ordered by display_order, with columns
+for name, description, icon, achievement count, and actions
+(edit, delete).
+
+#### Scenario: View categories list
+
+- **WHEN** an admin navigates to the Achievement Categories
+  tab in the admin panel
+- **THEN** all categories are displayed in a table sorted
+  by display_order, showing name, description, icon, and
+  the count of achievements in each category
+
+#### Scenario: Empty categories state
+
+- **WHEN** no achievement categories exist
+- **THEN** the tab displays an empty state message with a
+  prompt to create the first category
+
+### Requirement: Admin category create
+
+The admin panel SHALL provide a form to create new
+achievement categories with name, description, icon, and
+display_order fields.
+
+#### Scenario: Create a new category
+
+- **WHEN** an admin fills in the category form with a name,
+  description, icon, and display_order and submits
+- **THEN** a new category is created via POST to
+  `/api/admin/achievement-categories` and the list refreshes
+  to include the new category
+
+#### Scenario: Validation on required fields
+
+- **WHEN** an admin submits the category form without a name
+- **THEN** a validation error is displayed and the form is
+  not submitted
+
+### Requirement: Admin category edit
+
+The admin panel SHALL allow editing existing achievement
+categories inline or via a form.
+
+#### Scenario: Edit an existing category
+
+- **WHEN** an admin clicks edit on a category, modifies
+  fields, and saves
+- **THEN** the category is updated via PATCH to
+  `/api/admin/achievement-categories/[id]` and the list
+  refreshes with the updated values
+
+### Requirement: Admin category reorder
+
+The admin panel SHALL allow reordering categories by
+updating their display_order values.
+
+#### Scenario: Reorder categories
+
+- **WHEN** an admin changes the display_order of a category
+  and saves
+- **THEN** the category's display_order is updated and the
+  list re-sorts to reflect the new ordering
+
+### Requirement: Admin category delete
+
+The admin panel SHALL allow deleting categories that have
+no achievements assigned.
+
+#### Scenario: Delete an empty category
+
+- **WHEN** an admin clicks delete on a category with zero
+  achievements
+- **THEN** the category is deleted via DELETE to
+  `/api/admin/achievement-categories/[id]` and removed
+  from the list
+
+#### Scenario: Prevent deletion of category with achievements
+
+- **WHEN** an admin clicks delete on a category that has
+  achievements assigned
+- **THEN** an error message is displayed explaining the
+  category cannot be deleted while it has achievements
+
+### Requirement: Admin achievement list view
+
+The admin panel SHALL display a tab showing all achievements
+in a table with columns for name, category, hidden status,
+rewards, and actions.
+
+#### Scenario: View achievements list
+
+- **WHEN** an admin navigates to the Achievements tab in
+  the admin panel
+- **THEN** all achievements are displayed in a table showing
+  name, category name, is_hidden flag, xp_reward,
+  gold_reward, and action buttons (edit)
+
+#### Scenario: Filter achievements by category
+
+- **WHEN** an admin selects a category filter on the
+  achievements tab
+- **THEN** only achievements in that category are shown
+
+### Requirement: Admin achievement create
+
+The admin panel SHALL provide a form to create new
+achievements with all required fields including category
+assignment and hidden flag.
+
+#### Scenario: Create a new achievement
+
+- **WHEN** an admin fills in the achievement form with name,
+  description, category, icon, xp_reward, gold_reward,
+  is_hidden, criteria_type, criteria_config and submits
+- **THEN** a new achievement is created via POST to
+  `/api/admin/achievements` and the list refreshes
+
+#### Scenario: Category selection dropdown
+
+- **WHEN** an admin opens the achievement creation form
+- **THEN** a dropdown lists all available categories for
+  assignment ordered by display_order
+
+### Requirement: Admin achievement edit
+
+The admin panel SHALL allow editing existing achievements.
+
+#### Scenario: Edit an existing achievement
+
+- **WHEN** an admin clicks edit on an achievement, modifies
+  fields (including category and hidden flag), and saves
+- **THEN** the achievement is updated via PATCH to
+  `/api/admin/achievements/[id]` and the list refreshes
+
+#### Scenario: Toggle hidden flag
+
+- **WHEN** an admin toggles the is_hidden checkbox on an
+  achievement and saves
+- **THEN** the achievement's is_hidden value is updated in
+  the database
+
+### Requirement: Admin API authentication
+
+All admin achievement API routes SHALL require Guild Master
+role authentication.
+
+#### Scenario: Authenticated Guild Master request
+
+- **WHEN** a Guild Master sends a request to any
+  `/api/admin/achievement-categories` or
+  `/api/admin/achievements` endpoint
+- **THEN** the request is processed successfully
+
+#### Scenario: Non-admin request rejected
+
+- **WHEN** a non-Guild-Master user sends a request to any
+  admin achievement endpoint
+- **THEN** the response is 403 Forbidden
+
+#### Scenario: Unauthenticated request rejected
+
+- **WHEN** an unauthenticated request is sent to any admin
+  achievement endpoint
+- **THEN** the response is 401 Unauthorized

--- a/openspec/changes/achievement-categories-hidden/specs/achievement-category-filtering/spec.md
+++ b/openspec/changes/achievement-categories-hidden/specs/achievement-category-filtering/spec.md
@@ -1,0 +1,80 @@
+# Achievement Category Filtering
+
+## ADDED Requirements
+
+### Requirement: Category tab completion counts
+
+Each category tab on the achievement grid SHALL display a
+completion count showing how many achievements the character
+has unlocked out of the total in that category.
+
+#### Scenario: Category with partial completion
+
+- **WHEN** a character has unlocked 3 out of 8 achievements
+  in the "Questing" category
+- **THEN** the Questing tab displays "3/8" as a completion
+  badge
+
+#### Scenario: Category with full completion
+
+- **WHEN** a character has unlocked all achievements in a
+  category
+- **THEN** the tab displays the full count (e.g., "8/8")
+  with a visual indicator of completion
+
+#### Scenario: Category with no progress
+
+- **WHEN** a character has unlocked zero achievements in a
+  category
+- **THEN** the tab displays "0/N" where N is the total
+  achievement count in that category
+
+#### Scenario: Hidden achievements in count
+
+- **WHEN** a category contains hidden achievements
+- **THEN** locked hidden achievements are excluded from
+  the total count, but unlocked hidden achievements are
+  included in both unlocked and total counts
+
+### Requirement: All tab completion count
+
+The "All" tab SHALL display overall completion counts
+across all categories.
+
+#### Scenario: Overall completion displayed
+
+- **WHEN** the "All" tab is active or visible
+- **THEN** it displays the total unlocked count out of
+  total non-hidden-locked achievements across all
+  categories
+
+### Requirement: Client-side category filtering
+
+Category filtering SHALL operate client-side on the
+already-fetched achievement data without additional API
+requests.
+
+#### Scenario: Switch between category tabs
+
+- **WHEN** a user clicks a category tab
+- **THEN** the grid immediately filters to show only
+  achievements in that category without a loading state
+  or network request
+
+#### Scenario: Return to All tab
+
+- **WHEN** a user clicks the "All" tab after viewing a
+  specific category
+- **THEN** all achievements are immediately displayed
+
+### Requirement: Empty category display
+
+The grid SHALL handle categories with no matching
+achievements gracefully.
+
+#### Scenario: Category with no achievements
+
+- **WHEN** a user selects a category tab that has no
+  achievements assigned
+- **THEN** an empty state message is displayed within
+  the grid area

--- a/openspec/changes/achievement-categories-hidden/tasks.md
+++ b/openspec/changes/achievement-categories-hidden/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Achievement Categories & Hidden Achievements
+
+## 1. Admin API Routes
+
+- [ ] 1.1 Create POST/GET `/api/admin/achievement-categories`
+  route with Guild Master auth check and service-role client
+- [ ] 1.2 Create PATCH/DELETE
+  `/api/admin/achievement-categories/[id]` route with
+  delete protection for categories with achievements
+- [ ] 1.3 Create POST/GET `/api/admin/achievements` route
+  with Guild Master auth check and service-role client
+- [ ] 1.4 Create PATCH `/api/admin/achievements/[id]` route
+  for editing achievements (category, hidden flag, rewards)
+- [ ] 1.5 Write tests for admin API routes (auth checks,
+  CRUD operations, delete protection)
+
+## 2. Admin Category Management UI
+
+- [ ] 2.1 Create `AchievementCategoryAdmin` component with
+  category list table (name, description, icon, count,
+  actions)
+- [ ] 2.2 Add category create/edit form with validation
+  (name required, display_order)
+- [ ] 2.3 Add category reorder controls (display_order
+  editing)
+- [ ] 2.4 Add category delete with confirmation and
+  protection for non-empty categories
+- [ ] 2.5 Write tests for category admin component (list,
+  create, edit, delete, validation)
+
+## 3. Admin Achievement Management UI
+
+- [ ] 3.1 Create `AchievementAdmin` component with
+  achievement list table (name, category, hidden,
+  rewards, actions)
+- [ ] 3.2 Add achievement create/edit form with category
+  dropdown, hidden flag toggle, criteria fields
+- [ ] 3.3 Add category filter on achievement list
+- [ ] 3.4 Write tests for achievement admin component
+  (list, create, edit, filter, hidden toggle)
+
+## 4. Admin Dashboard Integration
+
+- [ ] 4.1 Add Achievement Categories and Achievements tabs
+  to AdminDashboard with icons and useTabNavigation
+
+## 5. Category Filtering & Completion Tracking
+
+- [ ] 5.1 Update AchievementGrid to compute per-category
+  completion counts (unlocked/total, excluding locked
+  hidden)
+- [ ] 5.2 Add completion count badges to category tabs
+  (e.g., "3/8")
+- [ ] 5.3 Implement client-side category filtering without
+  network requests on tab switch
+- [ ] 5.4 Update AchievementSummary to reflect selected
+  category counts when a category tab is active
+- [ ] 5.5 Handle empty category state in grid
+- [ ] 5.6 Write tests for category filtering logic and
+  completion count calculations
+
+## 6. Hidden Achievement Display Enforcement
+
+- [ ] 6.1 Verify AchievementBadge masks name/description
+  for locked hidden achievements ("???", placeholder text)
+- [ ] 6.2 Verify AchievementDetailModal masks details for
+  locked hidden achievements
+- [ ] 6.3 Write tests for hidden achievement display rules
+  (locked hidden vs unlocked hidden vs non-hidden)

--- a/openspec/changes/achievement-categories-hidden/tasks.md
+++ b/openspec/changes/achievement-categories-hidden/tasks.md
@@ -2,68 +2,68 @@
 
 ## 1. Admin API Routes
 
-- [ ] 1.1 Create POST/GET `/api/admin/achievement-categories`
+- [x] 1.1 Create POST/GET `/api/admin/achievement-categories`
   route with Guild Master auth check and service-role client
-- [ ] 1.2 Create PATCH/DELETE
+- [x] 1.2 Create PATCH/DELETE
   `/api/admin/achievement-categories/[id]` route with
   delete protection for categories with achievements
-- [ ] 1.3 Create POST/GET `/api/admin/achievements` route
+- [x] 1.3 Create POST/GET `/api/admin/achievements` route
   with Guild Master auth check and service-role client
-- [ ] 1.4 Create PATCH `/api/admin/achievements/[id]` route
+- [x] 1.4 Create PATCH `/api/admin/achievements/[id]` route
   for editing achievements (category, hidden flag, rewards)
-- [ ] 1.5 Write tests for admin API routes (auth checks,
+- [x] 1.5 Write tests for admin API routes (auth checks,
   CRUD operations, delete protection)
 
 ## 2. Admin Category Management UI
 
-- [ ] 2.1 Create `AchievementCategoryAdmin` component with
+- [x] 2.1 Create `AchievementCategoryAdmin` component with
   category list table (name, description, icon, count,
   actions)
-- [ ] 2.2 Add category create/edit form with validation
+- [x] 2.2 Add category create/edit form with validation
   (name required, display_order)
-- [ ] 2.3 Add category reorder controls (display_order
+- [x] 2.3 Add category reorder controls (display_order
   editing)
-- [ ] 2.4 Add category delete with confirmation and
+- [x] 2.4 Add category delete with confirmation and
   protection for non-empty categories
-- [ ] 2.5 Write tests for category admin component (list,
+- [x] 2.5 Write tests for category admin component (list,
   create, edit, delete, validation)
 
 ## 3. Admin Achievement Management UI
 
-- [ ] 3.1 Create `AchievementAdmin` component with
+- [x] 3.1 Create `AchievementAdmin` component with
   achievement list table (name, category, hidden,
   rewards, actions)
-- [ ] 3.2 Add achievement create/edit form with category
+- [x] 3.2 Add achievement create/edit form with category
   dropdown, hidden flag toggle, criteria fields
-- [ ] 3.3 Add category filter on achievement list
-- [ ] 3.4 Write tests for achievement admin component
+- [x] 3.3 Add category filter on achievement list
+- [x] 3.4 Write tests for achievement admin component
   (list, create, edit, filter, hidden toggle)
 
 ## 4. Admin Dashboard Integration
 
-- [ ] 4.1 Add Achievement Categories and Achievements tabs
+- [x] 4.1 Add Achievement Categories and Achievements tabs
   to AdminDashboard with icons and useTabNavigation
 
 ## 5. Category Filtering & Completion Tracking
 
-- [ ] 5.1 Update AchievementGrid to compute per-category
+- [x] 5.1 Update AchievementGrid to compute per-category
   completion counts (unlocked/total, excluding locked
   hidden)
-- [ ] 5.2 Add completion count badges to category tabs
+- [x] 5.2 Add completion count badges to category tabs
   (e.g., "3/8")
-- [ ] 5.3 Implement client-side category filtering without
+- [x] 5.3 Implement client-side category filtering without
   network requests on tab switch
-- [ ] 5.4 Update AchievementSummary to reflect selected
+- [x] 5.4 Update AchievementSummary to reflect selected
   category counts when a category tab is active
-- [ ] 5.5 Handle empty category state in grid
-- [ ] 5.6 Write tests for category filtering logic and
+- [x] 5.5 Handle empty category state in grid
+- [x] 5.6 Write tests for category filtering logic and
   completion count calculations
 
 ## 6. Hidden Achievement Display Enforcement
 
-- [ ] 6.1 Verify AchievementBadge masks name/description
+- [x] 6.1 Verify AchievementBadge masks name/description
   for locked hidden achievements ("???", placeholder text)
-- [ ] 6.2 Verify AchievementDetailModal masks details for
+- [x] 6.2 Verify AchievementDetailModal masks details for
   locked hidden achievements
-- [ ] 6.3 Write tests for hidden achievement display rules
+- [x] 6.3 Write tests for hidden achievement display rules
   (locked hidden vs unlocked hidden vs non-hidden)

--- a/tests/unit/app/api/admin/achievement-categories-id.test.ts
+++ b/tests/unit/app/api/admin/achievement-categories-id.test.ts
@@ -1,0 +1,237 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import {
+  PATCH,
+  DELETE,
+} from "@/app/api/admin/achievement-categories/[id]/route";
+
+function makeRequest(
+  method: string,
+  auth: string | null = "Bearer token",
+  body?: Record<string, unknown>,
+) {
+  const url = new URL("http://localhost/api/admin/achievement-categories/id");
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (auth !== null) headers["authorization"] = auth;
+
+  return new NextRequest(url, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function setupAuth(role: string = "GUILD_MASTER") {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+    error: null,
+  });
+  mockServerSupabase.from.mockImplementation((table: string) => {
+    if (table === "user_profiles") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { role, family_id: "fam-1" },
+          error: null,
+        }),
+      };
+    }
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+}
+
+function setupServiceForPatch() {
+  mockServiceSupabase.from.mockImplementation((table: string) => {
+    if (table === "achievement_categories") {
+      return {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { id: "cat-1", name: "Adventurer" },
+              error: null,
+            }),
+          }),
+        }),
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            select: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { id: "cat-1", name: "Updated" },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+    return { select: jest.fn().mockReturnThis() };
+  });
+}
+
+describe("PATCH /api/admin/achievement-categories/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates a category and returns 200", async () => {
+    setupAuth();
+    setupServiceForPatch();
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when category does not exist", async () => {
+    setupAuth();
+    mockServiceSupabase.from.mockImplementation((table: string) => {
+      if (table === "achievement_categories") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest
+                .fn()
+                .mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return { select: jest.fn().mockReturnThis() };
+    });
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "nonexistent" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when name is empty string", async () => {
+    setupAuth();
+    setupServiceForPatch();
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/admin/achievement-categories/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deletes a category with no achievements", async () => {
+    setupAuth();
+    mockServiceSupabase.from.mockImplementation((table: string) => {
+      if (table === "achievement_categories") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: "cat-1" },
+                error: null,
+              }),
+            }),
+          }),
+          delete: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ error: null }),
+          }),
+        };
+      }
+      if (table === "achievements") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ count: 0, error: null }),
+          }),
+        };
+      }
+      return { select: jest.fn().mockReturnThis() };
+    });
+
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 409 when category has achievements", async () => {
+    setupAuth();
+    mockServiceSupabase.from.mockImplementation((table: string) => {
+      if (table === "achievement_categories") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: "cat-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "achievements") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ count: 3, error: null }),
+          }),
+        };
+      }
+      return { select: jest.fn().mockReturnThis() };
+    });
+
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/app/api/admin/achievement-categories.test.ts
+++ b/tests/unit/app/api/admin/achievement-categories.test.ts
@@ -1,0 +1,185 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/admin/achievement-categories/route";
+
+function makeRequest(
+  method: string,
+  auth: string | null = "Bearer token",
+  body?: Record<string, unknown>,
+) {
+  const url = new URL("http://localhost/api/admin/achievement-categories");
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (auth !== null) headers["authorization"] = auth;
+
+  return new NextRequest(url, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function setupAuth(role: string = "GUILD_MASTER") {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+    error: null,
+  });
+  mockServerSupabase.from.mockImplementation((table: string) => {
+    if (table === "user_profiles") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { role, family_id: "fam-1" },
+          error: null,
+        }),
+      };
+    }
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+}
+
+const MOCK_CATEGORIES = [
+  {
+    id: "cat-1",
+    name: "Adventurer",
+    description: "Questing achievements",
+    icon: "sword",
+    display_order: 1,
+  },
+  {
+    id: "cat-2",
+    name: "Wealth",
+    description: "Gold achievements",
+    icon: "coins",
+    display_order: 2,
+  },
+];
+
+function setupServiceCategories(categories = MOCK_CATEGORIES) {
+  const orderFn = jest.fn().mockResolvedValue({
+    data: categories,
+    error: null,
+  });
+
+  mockServiceSupabase.from.mockImplementation((table: string) => {
+    if (table === "achievement_categories") {
+      return {
+        select: jest.fn().mockReturnValue({
+          order: orderFn,
+        }),
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { id: "cat-new", name: "New Category", display_order: 3 },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "achievements") {
+      return {
+        select: jest.fn().mockResolvedValue({
+          data: [{ id: "ach-1", category_id: "cat-1" }],
+          error: null,
+        }),
+      };
+    }
+    return { select: jest.fn().mockReturnThis() };
+  });
+}
+
+describe("GET /api/admin/achievement-categories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with categories and achievement counts", async () => {
+    setupAuth();
+    setupServiceCategories();
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.categories).toBeDefined();
+    expect(Array.isArray(body.categories)).toBe(true);
+  });
+
+  it("returns 401 when authorization header missing", async () => {
+    const res = await GET(makeRequest("GET", null));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/admin/achievement-categories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a category and returns 201", async () => {
+    setupAuth();
+    setupServiceCategories();
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        name: "New Category",
+        description: "A test category",
+        icon: "star",
+        display_order: 3,
+      }),
+    );
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.category).toBeDefined();
+  });
+
+  it("returns 400 when name is missing", async () => {
+    setupAuth();
+    setupServiceCategories();
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        description: "No name provided",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", { name: "Test" }),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/app/api/admin/achievement-categories.test.ts
+++ b/tests/unit/app/api/admin/achievement-categories.test.ts
@@ -64,6 +64,7 @@ const MOCK_CATEGORIES = [
     description: "Questing achievements",
     icon: "sword",
     display_order: 1,
+    achievements: [{ count: 1 }],
   },
   {
     id: "cat-2",
@@ -71,6 +72,7 @@ const MOCK_CATEGORIES = [
     description: "Gold achievements",
     icon: "coins",
     display_order: 2,
+    achievements: [{ count: 0 }],
   },
 ];
 
@@ -93,14 +95,6 @@ function setupServiceCategories(categories = MOCK_CATEGORIES) {
               error: null,
             }),
           }),
-        }),
-      };
-    }
-    if (table === "achievements") {
-      return {
-        select: jest.fn().mockResolvedValue({
-          data: [{ id: "ach-1", category_id: "cat-1" }],
-          error: null,
         }),
       };
     }

--- a/tests/unit/app/api/admin/achievements-id.test.ts
+++ b/tests/unit/app/api/admin/achievements-id.test.ts
@@ -1,0 +1,151 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/admin/achievements/[id]/route";
+
+function makeRequest(
+  method: string,
+  auth: string | null = "Bearer token",
+  body?: Record<string, unknown>,
+) {
+  const url = new URL("http://localhost/api/admin/achievements/id");
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (auth !== null) headers["authorization"] = auth;
+
+  return new NextRequest(url, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function setupAuth(role: string = "GUILD_MASTER") {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+    error: null,
+  });
+  mockServerSupabase.from.mockImplementation((table: string) => {
+    if (table === "user_profiles") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { role, family_id: "fam-1" },
+          error: null,
+        }),
+      };
+    }
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+}
+
+function setupServiceForPatch() {
+  mockServiceSupabase.from.mockImplementation((table: string) => {
+    if (table === "achievements") {
+      return {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { id: "ach-1", name: "First Quest" },
+              error: null,
+            }),
+          }),
+        }),
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            select: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { id: "ach-1", name: "Updated" },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+    return { select: jest.fn().mockReturnThis() };
+  });
+}
+
+describe("PATCH /api/admin/achievements/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates an achievement and returns 200", async () => {
+    setupAuth();
+    setupServiceForPatch();
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when achievement does not exist", async () => {
+    setupAuth();
+    mockServiceSupabase.from.mockImplementation((table: string) => {
+      if (table === "achievements") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest
+                .fn()
+                .mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return { select: jest.fn().mockReturnThis() };
+    });
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "nonexistent" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("updates hidden flag successfully", async () => {
+    setupAuth();
+    setupServiceForPatch();
+
+    const req = makeRequest("PATCH", "Bearer token", { is_hidden: true });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/unit/app/api/admin/achievements.test.ts
+++ b/tests/unit/app/api/admin/achievements.test.ts
@@ -70,6 +70,7 @@ const MOCK_ACHIEVEMENTS = [
     criteria_type: "quest_complete",
     criteria_config: {},
     family_id: "fam-1",
+    achievement_categories: { name: "Adventurer" },
   },
 ];
 

--- a/tests/unit/app/api/admin/achievements.test.ts
+++ b/tests/unit/app/api/admin/achievements.test.ts
@@ -1,0 +1,237 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/admin/achievements/route";
+
+function makeRequest(
+  method: string,
+  auth: string | null = "Bearer token",
+  body?: Record<string, unknown>,
+) {
+  const url = new URL("http://localhost/api/admin/achievements");
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (auth !== null) headers["authorization"] = auth;
+
+  return new NextRequest(url, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function setupAuth(role: string = "GUILD_MASTER") {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+    error: null,
+  });
+  mockServerSupabase.from.mockImplementation((table: string) => {
+    if (table === "user_profiles") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { role, family_id: "fam-1" },
+          error: null,
+        }),
+      };
+    }
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+}
+
+const MOCK_ACHIEVEMENTS = [
+  {
+    id: "ach-1",
+    name: "First Quest",
+    description: "Complete your first quest",
+    icon: "sword",
+    category_id: "cat-1",
+    xp_reward: 50,
+    gold_reward: 10,
+    is_hidden: false,
+    criteria_type: "quest_complete",
+    criteria_config: {},
+    family_id: "fam-1",
+  },
+];
+
+const MOCK_CATEGORIES = [
+  { id: "cat-1", name: "Adventurer" },
+  { id: "cat-2", name: "Wealth" },
+];
+
+function setupServiceAchievements() {
+  mockServiceSupabase.from.mockImplementation((table: string) => {
+    if (table === "achievements") {
+      return {
+        select: jest.fn().mockReturnValue({
+          order: jest.fn().mockResolvedValue({
+            data: MOCK_ACHIEVEMENTS,
+            error: null,
+          }),
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: MOCK_ACHIEVEMENTS[0],
+              error: null,
+            }),
+          }),
+        }),
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { id: "ach-new", ...MOCK_ACHIEVEMENTS[0] },
+              error: null,
+            }),
+          }),
+        }),
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            select: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { ...MOCK_ACHIEVEMENTS[0], name: "Updated" },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "achievement_categories") {
+      return {
+        select: jest.fn().mockReturnValue({
+          order: jest.fn().mockResolvedValue({
+            data: MOCK_CATEGORIES,
+            error: null,
+          }),
+        }),
+      };
+    }
+    return { select: jest.fn().mockReturnThis() };
+  });
+}
+
+describe("GET /api/admin/achievements", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with achievements and categories", async () => {
+    setupAuth();
+    setupServiceAchievements();
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.achievements).toBeDefined();
+    expect(body.categories).toBeDefined();
+  });
+
+  it("returns 401 when authorization header missing", async () => {
+    const res = await GET(makeRequest("GET", null));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/admin/achievements", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates an achievement and returns 201", async () => {
+    setupAuth();
+    setupServiceAchievements();
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        name: "New Achievement",
+        description: "A test achievement",
+        category_id: "cat-1",
+        criteria_type: "quest_complete",
+        criteria_config: { count: 1 },
+      }),
+    );
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.achievement).toBeDefined();
+  });
+
+  it("returns 400 when name is missing", async () => {
+    setupAuth();
+    setupServiceAchievements();
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        category_id: "cat-1",
+        criteria_type: "quest_complete",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when category_id is missing", async () => {
+    setupAuth();
+    setupServiceAchievements();
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        name: "Test",
+        criteria_type: "quest_complete",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when criteria_type is missing", async () => {
+    setupAuth();
+    setupServiceAchievements();
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        name: "Test",
+        category_id: "cat-1",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
+
+    const res = await POST(
+      makeRequest("POST", "Bearer token", {
+        name: "Test",
+        category_id: "cat-1",
+        criteria_type: "quest_complete",
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/components/admin-dashboard.content.test.tsx
+++ b/tests/unit/components/admin-dashboard.content.test.tsx
@@ -86,6 +86,8 @@ describe("AdminDashboard content", () => {
         "Quest Management",
         "Quest Templates",
         "Rewards",
+        "Achievement Categories",
+        "Achievements",
         "Guild Masters",
         "Family Settings",
       ]);


### PR DESCRIPTION
## Summary

- Add admin API routes for achievement categories (CRUD with delete protection for non-empty categories) and achievements (CRUD with hidden flag, category assignment, and rewards editing)
- Add `AchievementCategoryAdmin` and `AchievementAdmin` components with list views, create/edit forms, category filtering, and delete confirmation
- Integrate both into `AdminDashboard` with new tabs (Achievement Categories, Achievements)
- Update `AchievementSummary` to scope unlocked/total counts to the selected category tab
- Fix category tab completion counts, mobile tab labels, and active tab reset when categories change
- Full test coverage for all new API routes and admin components

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm run lint` — zero lint warnings/errors
- [ ] `npm run test` — all unit tests pass
- [ ] Admin dashboard shows Achievement Categories and Achievements tabs
- [ ] Category CRUD works with delete protection (can't delete category with achievements)
- [ ] Achievement CRUD works with hidden flag toggle and category assignment
- [ ] Achievement summary counts update when switching category tabs