### PR TITLE
fix: report release version from package metadata

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -2,6 +2,7 @@
 // Used by Docker health checks and load balancers
 
 import { NextResponse } from 'next/server';
+import { APP_VERSION } from '@/lib/app-version';
 import { supabase } from '@/lib/supabase';
 
 // Health check endpoint - no authentication required
@@ -21,7 +22,7 @@ export async function GET() {
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
       environment: process.env.NODE_ENV,
-      version: process.env.npm_package_version || '0.2.0',
+      version: APP_VERSION,
     };
 
     // Test database connection

--- a/lib/app-version.ts
+++ b/lib/app-version.ts
@@ -1,0 +1,3 @@
+import packageJson from '@/package.json';
+
+export const APP_VERSION = packageJson.version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chorequest",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chorequest",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "jest --coverage",
     "test:unit": "jest",
     "test:integration": "NODE_NO_WARNINGS=1 jest --config jest.integration.config.js",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "version": "npm install --package-lock-only --ignore-scripts && git add package-lock.json"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/tests/unit/app/api/health-route.test.ts
+++ b/tests/unit/app/api/health-route.test.ts
@@ -1,0 +1,45 @@
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+import packageJson from '@/package.json';
+import { GET } from '@/app/api/health/route';
+import { supabase } from '@/lib/supabase';
+
+const originalNpmPackageVersion = process.env.npm_package_version;
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    const mockLimit = jest.fn().mockResolvedValue({ error: null });
+    const mockSelect = jest.fn(() => ({ limit: mockLimit }));
+
+    jest.mocked(supabase.from).mockReturnValue({
+      select: mockSelect,
+    } as never);
+
+    delete process.env.npm_package_version;
+  });
+
+  afterEach(() => {
+    jest.mocked(supabase.from).mockReset();
+  });
+
+  afterAll(() => {
+    if (originalNpmPackageVersion === undefined) {
+      delete process.env.npm_package_version;
+    } else {
+      process.env.npm_package_version = originalNpmPackageVersion;
+    }
+  });
+
+  it('reports the tracked package version when npm_package_version is unavailable', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.version).toBe(packageJson.version);
+    expect(body.version).not.toBe('0.2.0');
+  });
+});

--- a/tests/unit/release-version-metadata.test.ts
+++ b/tests/unit/release-version-metadata.test.ts
@@ -1,0 +1,14 @@
+import packageJson from '@/package.json';
+import packageLock from '@/package-lock.json';
+
+describe('release version metadata', () => {
+  it('keeps package-lock root metadata synchronized with package.json', () => {
+    expect(packageLock.version).toBe(packageJson.version);
+    expect(packageLock.packages[''].version).toBe(packageJson.version);
+  });
+
+  it('automates lockfile metadata updates during npm version bumps', () => {
+    expect(packageJson.scripts.version).toContain('npm install --package-lock-only');
+    expect(packageJson.scripts.version).toContain('git add package-lock.json');
+  });
+});


### PR DESCRIPTION
## Summary
- reads the `/api/health` version from tracked `package.json` metadata instead of `npm_package_version` or a stale hard-coded fallback
- synchronizes `package-lock.json` root version metadata with `package.json`
- adds an `npm version` lifecycle script that refreshes and stages `package-lock.json` metadata during future version bumps

## Test Plan
- RED: `npm run test:unit -- --runTestsByPath tests/unit/app/api/health-route.test.ts` failed with `Expected: "0.7.0" Received: "0.2.0"`
- RED: `npm run test:unit -- --runTestsByPath tests/unit/release-version-metadata.test.ts` failed on stale lockfile metadata and missing version lifecycle script
- `npm run test:unit -- --runTestsByPath tests/unit/app/api/health-route.test.ts tests/unit/release-version-metadata.test.ts`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`

Fixes #151
