### PR TITLE
feat: add seasons data model foundation

### DIFF
--- a/lib/__tests__/achievement-progress-service.service-upsert.test.ts
+++ b/lib/__tests__/achievement-progress-service.service-upsert.test.ts
@@ -28,7 +28,7 @@ describe("AchievementProgressService - service level", () => {
   });
 
   // 8.5 upsert behavior
-  it("upserts with onConflict character_id,achievement_id", async () => {
+  it("upserts with season-aware onConflict character_id,achievement_id,season_id", async () => {
     const questChain = {
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -66,9 +66,13 @@ describe("AchievementProgressService - service level", () => {
     await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
 
     expect(writeUpsert.upsert).toHaveBeenCalledWith(
-      expect.any(Array),
+      expect.arrayContaining([
+        expect.objectContaining({
+          season_id: null,
+        }),
+      ]),
       expect.objectContaining({
-        onConflict: "character_id,achievement_id",
+        onConflict: "character_id,achievement_id,season_id",
         ignoreDuplicates: false,
       }),
     );

--- a/lib/achievement-progress-service.ts
+++ b/lib/achievement-progress-service.ts
@@ -146,6 +146,7 @@ export class AchievementProgressService {
     const upsertRows: {
       character_id: string;
       achievement_id: string;
+      season_id: string | null;
       progress: AchievementProgressValue;
     }[] = [];
 
@@ -169,6 +170,7 @@ export class AchievementProgressService {
       upsertRows.push({
         character_id: characterId,
         achievement_id: achievement.id,
+        season_id: null,
         progress: buildProgressValue(achievement.criteria_type, result, config),
       });
     }
@@ -178,7 +180,7 @@ export class AchievementProgressService {
     const { error } = await this.writeClient
       .from("character_achievements")
       .upsert(upsertRows, {
-        onConflict: "character_id,achievement_id",
+        onConflict: "character_id,achievement_id,season_id",
         ignoreDuplicates: false,
       });
 

--- a/lib/family-achievement-progress-service.ts
+++ b/lib/family-achievement-progress-service.ts
@@ -218,6 +218,7 @@ export class FamilyAchievementProgressService {
     const upsertRows: {
       family_id: string;
       family_achievement_id: string;
+      season_id: string | null;
       progress: { current: number; threshold: number } & Record<string, number>;
     }[] = [];
 
@@ -248,6 +249,7 @@ export class FamilyAchievementProgressService {
       upsertRows.push({
         family_id: familyId,
         family_achievement_id: achievement.id,
+        season_id: null,
         progress: {
           current,
           threshold,
@@ -262,7 +264,7 @@ export class FamilyAchievementProgressService {
     const { error } = await this.writeClient
       .from("family_achievement_progress")
       .upsert(upsertRows, {
-        onConflict: "family_id,family_achievement_id",
+        onConflict: "family_id,family_achievement_id,season_id",
         ignoreDuplicates: false,
       });
 
@@ -292,9 +294,7 @@ export class FamilyAchievementProgressService {
     );
   }
 
-  async getProgress(
-    familyId: string,
-  ): Promise<FamilyAchievementProgressRecord[]> {
+  async getProgress(familyId: string): Promise<FamilyAchievementProgressRecord[]> {
     return getProgressImpl(this.readClient, familyId);
   }
 }

--- a/lib/family-achievement-progress/service-helpers.ts
+++ b/lib/family-achievement-progress/service-helpers.ts
@@ -87,6 +87,7 @@ export async function recomputeAchievementImpl(
       {
         family_id: familyId,
         family_achievement_id: achievementId,
+        season_id: null,
         progress: {
           current,
           threshold,

--- a/lib/seasons/active-season.ts
+++ b/lib/seasons/active-season.ts
@@ -1,0 +1,72 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/lib/types/database-generated";
+
+export type ActiveSeason = {
+  id: string;
+  family_id: string;
+  name: string;
+  theme: string | null;
+  starts_at: string;
+  ends_at: string | null;
+};
+
+type SeasonRow = Database["public"]["Tables"]["seasons"]["Row"];
+
+type FamilyActiveSeasonRow = Pick<
+  Database["public"]["Tables"]["families"]["Row"],
+  "active_season_id"
+>;
+
+function toActiveSeason(row: SeasonRow): ActiveSeason {
+  return {
+    id: row.id,
+    family_id: row.family_id,
+    name: row.name,
+    theme: row.theme,
+    starts_at: row.starts_at,
+    ends_at: row.ends_at,
+  };
+}
+
+export async function getActiveSeasonForFamily(
+  client: SupabaseClient<Database>,
+  familyId: string,
+): Promise<ActiveSeason | null> {
+  const { data: family, error: familyError } = await client
+    .from("families")
+    .select("active_season_id")
+    .eq("id", familyId)
+    .maybeSingle<FamilyActiveSeasonRow>();
+
+  if (familyError) {
+    throw new Error(`Failed to load family active season: ${familyError.message}`);
+  }
+
+  if (family?.active_season_id) {
+    const { data: season, error: seasonError } = await client
+      .from("seasons")
+      .select("id, family_id, name, theme, starts_at, ends_at")
+      .eq("id", family.active_season_id)
+      .maybeSingle<SeasonRow>();
+
+    if (seasonError) {
+      throw new Error(`Failed to load active season: ${seasonError.message}`);
+    }
+
+    return season ? toActiveSeason(season) : null;
+  }
+
+  const { data: fallbackSeason, error: fallbackError } = await client
+    .from("seasons")
+    .select("id, family_id, name, theme, starts_at, ends_at")
+    .eq("family_id", familyId)
+    .eq("is_active", true)
+    .maybeSingle<SeasonRow>();
+
+  if (fallbackError) {
+    throw new Error(`Failed to load active season: ${fallbackError.message}`);
+  }
+
+  return fallbackSeason ? toActiveSeason(fallbackSeason) : null;
+}

--- a/lib/seasons/active-season.ts
+++ b/lib/seasons/active-season.ts
@@ -48,6 +48,7 @@ export async function getActiveSeasonForFamily(
       .from("seasons")
       .select("id, family_id, name, theme, starts_at, ends_at")
       .eq("id", family.active_season_id)
+      .eq("family_id", familyId)
       .maybeSingle<SeasonRow>();
 
     if (seasonError) {

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -135,6 +135,7 @@ export type Database = {
           id: string;
           notified: boolean | null;
           progress: Json | null;
+          season_id: string | null;
           unlocked_at: string | null;
           updated_at: string | null;
         };
@@ -145,6 +146,7 @@ export type Database = {
           id?: string;
           notified?: boolean | null;
           progress?: Json | null;
+          season_id?: string | null;
           unlocked_at?: string | null;
           updated_at?: string | null;
         };
@@ -155,6 +157,7 @@ export type Database = {
           id?: string;
           notified?: boolean | null;
           progress?: Json | null;
+          season_id?: string | null;
           unlocked_at?: string | null;
           updated_at?: string | null;
         };
@@ -171,6 +174,13 @@ export type Database = {
             columns: ["character_id"];
             isOneToOne: false;
             referencedRelation: "characters";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "character_achievements_season_id_fkey";
+            columns: ["season_id"];
+            isOneToOne: false;
+            referencedRelation: "seasons";
             referencedColumns: ["id"];
           },
         ];
@@ -246,6 +256,7 @@ export type Database = {
           id: string;
           notified: boolean | null;
           progress: Json | null;
+          season_id: string | null;
           unlocked_at: string | null;
           updated_at: string | null;
         };
@@ -256,6 +267,7 @@ export type Database = {
           id?: string;
           notified?: boolean | null;
           progress?: Json | null;
+          season_id?: string | null;
           unlocked_at?: string | null;
           updated_at?: string | null;
         };
@@ -266,6 +278,7 @@ export type Database = {
           id?: string;
           notified?: boolean | null;
           progress?: Json | null;
+          season_id?: string | null;
           unlocked_at?: string | null;
           updated_at?: string | null;
         };
@@ -282,6 +295,13 @@ export type Database = {
             columns: ["family_achievement_id"];
             isOneToOne: false;
             referencedRelation: "family_achievements";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "family_achievement_progress_season_id_fkey";
+            columns: ["season_id"];
+            isOneToOne: false;
+            referencedRelation: "seasons";
             referencedColumns: ["id"];
           },
         ];
@@ -610,6 +630,7 @@ export type Database = {
       };
       families: {
         Row: {
+          active_season_id: string | null;
           code: string;
           created_at: string | null;
           id: string;
@@ -619,6 +640,7 @@ export type Database = {
           week_start_day: number | null;
         };
         Insert: {
+          active_season_id?: string | null;
           code: string;
           created_at?: string | null;
           id?: string;
@@ -628,6 +650,7 @@ export type Database = {
           week_start_day?: number | null;
         };
         Update: {
+          active_season_id?: string | null;
           code?: string;
           created_at?: string | null;
           id?: string;
@@ -636,7 +659,62 @@ export type Database = {
           updated_at?: string | null;
           week_start_day?: number | null;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "families_active_season_id_fkey";
+            columns: ["active_season_id"];
+            isOneToOne: false;
+            referencedRelation: "seasons";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      seasons: {
+        Row: {
+          created_at: string;
+          description: string | null;
+          ends_at: string | null;
+          family_id: string;
+          id: string;
+          is_active: boolean;
+          name: string;
+          starts_at: string;
+          theme: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          description?: string | null;
+          ends_at?: string | null;
+          family_id: string;
+          id?: string;
+          is_active?: boolean;
+          name: string;
+          starts_at: string;
+          theme?: string | null;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          description?: string | null;
+          ends_at?: string | null;
+          family_id?: string;
+          id?: string;
+          is_active?: boolean;
+          name?: string;
+          starts_at?: string;
+          theme?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "seasons_family_id_fkey";
+            columns: ["family_id"];
+            isOneToOne: false;
+            referencedRelation: "families";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       quest_instances: {
         Row: {

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -135,6 +135,7 @@ export type Database = {
           id: string;
           notified: boolean | null;
           progress: Json | null;
+          season_id: string | null;
           unlocked_at: string | null;
           updated_at: string | null;
         };
@@ -145,6 +146,7 @@ export type Database = {
           id?: string;
           notified?: boolean | null;
           progress?: Json | null;
+          season_id?: string | null;
           unlocked_at?: string | null;
           updated_at?: string | null;
         };
@@ -155,6 +157,7 @@ export type Database = {
           id?: string;
           notified?: boolean | null;
           progress?: Json | null;
+          season_id?: string | null;
           unlocked_at?: string | null;
           updated_at?: string | null;
         };
@@ -171,6 +174,13 @@ export type Database = {
             columns: ["character_id"];
             isOneToOne: false;
             referencedRelation: "characters";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "character_achievements_season_id_fkey";
+            columns: ["season_id"];
+            isOneToOne: false;
+            referencedRelation: "seasons";
             referencedColumns: ["id"];
           },
         ];
@@ -367,6 +377,7 @@ export type Database = {
       };
       families: {
         Row: {
+          active_season_id: string | null;
           code: string;
           created_at: string | null;
           id: string;
@@ -375,6 +386,7 @@ export type Database = {
           updated_at: string | null;
         };
         Insert: {
+          active_season_id?: string | null;
           code: string;
           created_at?: string | null;
           id?: string;
@@ -383,6 +395,7 @@ export type Database = {
           updated_at?: string | null;
         };
         Update: {
+          active_season_id?: string | null;
           code?: string;
           created_at?: string | null;
           id?: string;
@@ -390,7 +403,62 @@ export type Database = {
           timezone?: string;
           updated_at?: string | null;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "families_active_season_id_fkey";
+            columns: ["active_season_id"];
+            isOneToOne: false;
+            referencedRelation: "seasons";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      seasons: {
+        Row: {
+          created_at: string;
+          description: string | null;
+          ends_at: string | null;
+          family_id: string;
+          id: string;
+          is_active: boolean;
+          name: string;
+          starts_at: string;
+          theme: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          description?: string | null;
+          ends_at?: string | null;
+          family_id: string;
+          id?: string;
+          is_active?: boolean;
+          name: string;
+          starts_at: string;
+          theme?: string | null;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          description?: string | null;
+          ends_at?: string | null;
+          family_id?: string;
+          id?: string;
+          is_active?: boolean;
+          name?: string;
+          starts_at?: string;
+          theme?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "seasons_family_id_fkey";
+            columns: ["family_id"];
+            isOneToOne: false;
+            referencedRelation: "families";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       quest_instances: {
         Row: {

--- a/supabase/migrations/20260326000001_add_seasons.sql
+++ b/supabase/migrations/20260326000001_add_seasons.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS seasons (
 );
 
 ALTER TABLE families
-ADD COLUMN IF NOT EXISTS active_season_id UUID REFERENCES seasons(id);
+ADD COLUMN IF NOT EXISTS active_season_id UUID REFERENCES seasons(id) ON DELETE SET NULL;
 
 CREATE TRIGGER set_timestamp_seasons
   BEFORE UPDATE ON seasons

--- a/supabase/migrations/20260326000001_add_seasons.sql
+++ b/supabase/migrations/20260326000001_add_seasons.sql
@@ -1,0 +1,96 @@
+-- Seasons foundation for achievement reset baselines.
+-- Related: issue #152 (season-as-baseline infrastructure)
+
+-- ============================================================
+-- 1. Seasons table and family active-season pointer
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS seasons (
+  id          UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+  family_id   UUID        NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  name        TEXT        NOT NULL,
+  theme       TEXT,
+  description TEXT,
+  starts_at   TIMESTAMPTZ NOT NULL,
+  ends_at     TIMESTAMPTZ,
+  is_active   BOOLEAN     NOT NULL DEFAULT false,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT seasons_date_order CHECK (ends_at IS NULL OR ends_at > starts_at)
+);
+
+ALTER TABLE families
+ADD COLUMN IF NOT EXISTS active_season_id UUID REFERENCES seasons(id);
+
+CREATE TRIGGER set_timestamp_seasons
+  BEFORE UPDATE ON seasons
+  FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE INDEX IF NOT EXISTS idx_seasons_family_id ON seasons(family_id);
+CREATE INDEX IF NOT EXISTS idx_seasons_family_active ON seasons(family_id, is_active) WHERE is_active = true;
+CREATE INDEX IF NOT EXISTS idx_seasons_starts_at ON seasons(starts_at);
+
+-- Enforce at most one active season per family.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_seasons_one_active_per_family
+ON seasons(family_id)
+WHERE is_active = true;
+
+COMMENT ON TABLE seasons IS 'Family-scoped themed seasons. The active season start timestamp is used as the achievement baseline.';
+COMMENT ON COLUMN families.active_season_id IS 'Current season whose starts_at timestamp bounds achievement evaluation.';
+
+-- ============================================================
+-- 2. Season-scoped achievement progress
+-- ============================================================
+
+ALTER TABLE character_achievements
+ADD COLUMN IF NOT EXISTS season_id UUID REFERENCES seasons(id) ON DELETE CASCADE;
+
+ALTER TABLE family_achievement_progress
+ADD COLUMN IF NOT EXISTS season_id UUID REFERENCES seasons(id) ON DELETE CASCADE;
+
+ALTER TABLE character_achievements
+DROP CONSTRAINT IF EXISTS character_achievements_character_id_achievement_id_key;
+
+ALTER TABLE family_achievement_progress
+DROP CONSTRAINT IF EXISTS family_achievement_progress_family_id_family_achievement_id_key;
+
+-- New season-scoped uniqueness for season-aware writes. NULLS NOT DISTINCT
+-- keeps current legacy NULL-season upserts conflict-safe until evaluator cutoff
+-- work starts writing non-null active-season IDs.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_character_achievements_character_achievement_season
+ON character_achievements(character_id, achievement_id, season_id) NULLS NOT DISTINCT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_family_achievement_progress_family_achievement_season
+ON family_achievement_progress(family_id, family_achievement_id, season_id) NULLS NOT DISTINCT;
+
+CREATE INDEX IF NOT EXISTS idx_character_achievements_season_id ON character_achievements(season_id);
+CREATE INDEX IF NOT EXISTS idx_family_achievement_progress_season_id ON family_achievement_progress(season_id);
+
+COMMENT ON COLUMN character_achievements.season_id IS 'Season scope for achievement progress. NULL preserves legacy pre-season progress rows.';
+COMMENT ON COLUMN family_achievement_progress.season_id IS 'Season scope for family achievement progress. NULL preserves legacy pre-season progress rows.';
+
+-- ============================================================
+-- 3. Row Level Security
+-- ============================================================
+
+ALTER TABLE seasons ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Family members can view seasons"
+  ON seasons
+  FOR SELECT
+  USING (
+    auth.uid() IS NOT NULL
+    AND family_id = get_user_family_id()
+  );
+
+CREATE POLICY "Guild Masters can manage seasons"
+  ON seasons
+  FOR ALL
+  USING (
+    family_id = get_user_family_id()
+    AND EXISTS (
+      SELECT 1 FROM user_profiles
+      WHERE id = auth.uid()
+        AND role = 'GUILD_MASTER'
+    )
+  );

--- a/tests/unit/lib/active-season.test.ts
+++ b/tests/unit/lib/active-season.test.ts
@@ -52,6 +52,7 @@ describe("getActiveSeasonForFamily", () => {
     expect(familyQuery.select).toHaveBeenCalledWith("active_season_id");
     expect(familyQuery.eq).toHaveBeenCalledWith("id", "family-1");
     expect(seasonQuery.eq).toHaveBeenCalledWith("id", "season-1");
+    expect(seasonQuery.eq).toHaveBeenCalledWith("family_id", "family-1");
   });
 
   it("falls back to the family's is_active season when active_season_id is absent", async () => {

--- a/tests/unit/lib/active-season.test.ts
+++ b/tests/unit/lib/active-season.test.ts
@@ -1,0 +1,97 @@
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+
+type Query = Record<string, jest.Mock>;
+
+function createQuery(result: unknown): Query {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue(result),
+    maybeSingle: jest.fn().mockResolvedValue(result),
+    limit: jest.fn().mockReturnThis(),
+  };
+}
+
+describe("getActiveSeasonForFamily", () => {
+  it("uses families.active_season_id before falling back to season flags", async () => {
+    const familyQuery = createQuery({
+      data: { active_season_id: "season-1" },
+      error: null,
+    });
+    const seasonQuery = createQuery({
+      data: {
+        id: "season-1",
+        family_id: "family-1",
+        name: "Spring Training",
+        theme: "pirates",
+        starts_at: "2026-04-01T00:00:00.000Z",
+        ends_at: null,
+      },
+      error: null,
+    });
+    const client = {
+      from: jest.fn((table: string) => {
+        if (table === "families") return familyQuery;
+        if (table === "seasons") return seasonQuery;
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+
+    await expect(
+      getActiveSeasonForFamily(client as never, "family-1"),
+    ).resolves.toEqual({
+      id: "season-1",
+      family_id: "family-1",
+      name: "Spring Training",
+      theme: "pirates",
+      starts_at: "2026-04-01T00:00:00.000Z",
+      ends_at: null,
+    });
+
+    expect(client.from).toHaveBeenNthCalledWith(1, "families");
+    expect(familyQuery.select).toHaveBeenCalledWith("active_season_id");
+    expect(familyQuery.eq).toHaveBeenCalledWith("id", "family-1");
+    expect(seasonQuery.eq).toHaveBeenCalledWith("id", "season-1");
+  });
+
+  it("falls back to the family's is_active season when active_season_id is absent", async () => {
+    const familyQuery = createQuery({ data: { active_season_id: null }, error: null });
+    const seasonQuery = createQuery({
+      data: {
+        id: "season-2",
+        family_id: "family-1",
+        name: "Summer Reset",
+        theme: null,
+        starts_at: "2026-06-01T00:00:00.000Z",
+        ends_at: null,
+      },
+      error: null,
+    });
+    const client = {
+      from: jest.fn((table: string) =>
+        table === "families" ? familyQuery : seasonQuery,
+      ),
+    };
+
+    await expect(
+      getActiveSeasonForFamily(client as never, "family-1"),
+    ).resolves.toMatchObject({ id: "season-2" });
+
+    expect(seasonQuery.eq).toHaveBeenCalledWith("family_id", "family-1");
+    expect(seasonQuery.eq).toHaveBeenCalledWith("is_active", true);
+  });
+
+  it("returns null when the family has no active season", async () => {
+    const familyQuery = createQuery({ data: { active_season_id: null }, error: null });
+    const seasonQuery = createQuery({ data: null, error: null });
+    const client = {
+      from: jest.fn((table: string) =>
+        table === "families" ? familyQuery : seasonQuery,
+      ),
+    };
+
+    await expect(
+      getActiveSeasonForFamily(client as never, "family-1"),
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/unit/migrations/seasons-schema.test.ts
+++ b/tests/unit/migrations/seasons-schema.test.ts
@@ -1,0 +1,38 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase/migrations/20260326000001_add_seasons.sql",
+);
+
+const sql = () => fs.readFileSync(migrationPath, "utf8");
+
+describe("seasons schema migration", () => {
+  it("creates seasons and connects families to an active season", () => {
+    const migration = sql();
+
+    expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS seasons/i);
+    expect(migration).toMatch(/family_id\s+UUID\s+NOT NULL REFERENCES families\(id\) ON DELETE CASCADE/i);
+    expect(migration).toMatch(/starts_at\s+TIMESTAMPTZ NOT NULL/i);
+    expect(migration).toMatch(/CONSTRAINT seasons_date_order CHECK \(ends_at IS NULL OR ends_at > starts_at\)/i);
+    expect(migration).toMatch(/ALTER TABLE families\s+ADD COLUMN IF NOT EXISTS active_season_id UUID REFERENCES seasons\(id\)/i);
+  });
+
+  it("enforces one active season per family", () => {
+    expect(sql()).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS idx_seasons_one_active_per_family\s+ON seasons\(family_id\)\s+WHERE is_active = true/i,
+    );
+  });
+
+  it("adds nullable season scope to achievement progress with legacy null uniqueness", () => {
+    const migration = sql();
+
+    expect(migration).toMatch(/ALTER TABLE character_achievements\s+ADD COLUMN IF NOT EXISTS season_id UUID REFERENCES seasons\(id\) ON DELETE CASCADE/i);
+    expect(migration).toMatch(/ALTER TABLE family_achievement_progress\s+ADD COLUMN IF NOT EXISTS season_id UUID REFERENCES seasons\(id\) ON DELETE CASCADE/i);
+    expect(migration).toMatch(/DROP CONSTRAINT IF EXISTS character_achievements_character_id_achievement_id_key/i);
+    expect(migration).toMatch(/DROP CONSTRAINT IF EXISTS family_achievement_progress_family_id_family_achievement_id_key/i);
+    expect(migration).toMatch(/idx_character_achievements_character_achievement_season[\s\S]*NULLS NOT DISTINCT/i);
+    expect(migration).toMatch(/idx_family_achievement_progress_family_achievement_season[\s\S]*NULLS NOT DISTINCT/i);
+  });
+});

--- a/tests/unit/migrations/seasons-schema.test.ts
+++ b/tests/unit/migrations/seasons-schema.test.ts
@@ -16,7 +16,7 @@ describe("seasons schema migration", () => {
     expect(migration).toMatch(/family_id\s+UUID\s+NOT NULL REFERENCES families\(id\) ON DELETE CASCADE/i);
     expect(migration).toMatch(/starts_at\s+TIMESTAMPTZ NOT NULL/i);
     expect(migration).toMatch(/CONSTRAINT seasons_date_order CHECK \(ends_at IS NULL OR ends_at > starts_at\)/i);
-    expect(migration).toMatch(/ALTER TABLE families\s+ADD COLUMN IF NOT EXISTS active_season_id UUID REFERENCES seasons\(id\)/i);
+    expect(migration).toMatch(/ALTER TABLE families\s+ADD COLUMN IF NOT EXISTS active_season_id UUID REFERENCES seasons\(id\) ON DELETE SET NULL/i);
   });
 
   it("enforces one active season per family", () => {


### PR DESCRIPTION
## Summary
- Add seasons table, family active season pointer, RLS policies, and season-scoped progress columns/indexes.
- Add active season lookup helper with focused unit coverage.
- Preserve current progress behavior during rollout by writing legacy NULL season scope and using NULLS NOT DISTINCT uniqueness.

## Test Plan
- npm run test:unit -- --runTestsByPath tests/unit/migrations/seasons-schema.test.ts tests/unit/lib/active-season.test.ts tests/unit/migrations/achievement-system-schema.test.ts tests/unit/migrations/family-achievements.test.ts tests/unit/app/api/achievement-progress-evaluate.test.ts tests/unit/lib/family-achievement-update-progress.test.ts tests/unit/lib/family-achievement-recompute.test.ts --runInBand
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run test:unit -- --runInBand
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run lint
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build

Closes #152