### PR TITLE
feat: make individual achievements season-aware

### DIFF
--- a/lib/__tests__/achievement-progress-service.fixtures.ts
+++ b/lib/__tests__/achievement-progress-service.fixtures.ts
@@ -67,8 +67,34 @@ export const USER_ID = "user-001";
 export const ACHIEVEMENT_ID = "ach-001";
 
 export function makeReadClient(overrides?: Record<string, MockChain>) {
+  const noActiveSeasonFamily = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: { active_season_id: null },
+          error: null,
+        }),
+      }),
+    }),
+  };
+  const noActiveSeason = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    }),
+  };
+  const defaults = {
+    families: noActiveSeasonFamily as unknown as MockChain,
+    seasons: noActiveSeason as unknown as MockChain,
+  };
   const from = jest.fn((table: string) => {
     if (overrides?.[table]) return overrides[table];
+    if (defaults[table as keyof typeof defaults]) {
+      return defaults[table as keyof typeof defaults];
+    }
     throw new Error(`Unexpected table: ${table}`);
   });
   return { from };

--- a/lib/__tests__/family-achievement-progress-service.integration.test.ts
+++ b/lib/__tests__/family-achievement-progress-service.integration.test.ts
@@ -19,6 +19,27 @@ const familyUpdateProgressSpy = jest
   .spyOn(FamilyAchievementProgressService.prototype, "updateProgress")
   .mockResolvedValue(undefined);
 
+const noActiveSeasonFamilyChain = {
+  select: jest.fn().mockReturnValue({
+    eq: jest.fn().mockReturnValue({
+      maybeSingle: jest.fn().mockResolvedValue({
+        data: { active_season_id: null },
+        error: null,
+      }),
+    }),
+  }),
+};
+
+const noActiveSeasonChain = {
+  select: jest.fn().mockReturnValue({
+    eq: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    }),
+  }),
+};
+
 describe("Integration: Individual → Family progress trigger", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -93,6 +114,8 @@ describe("Integration: Individual → Family progress trigger", () => {
         achievements: achievementsChain,
         character_achievements: charAchChain,
         quest_instances: questChain,
+        families: noActiveSeasonFamilyChain,
+        seasons: noActiveSeasonChain,
       };
       if (mocks[table]) return mocks[table];
       throw new Error(`Unexpected read table: ${table}`);
@@ -227,6 +250,8 @@ describe("Integration: Individual → Family progress trigger", () => {
         achievements: achievementsChain,
         character_achievements: charAchChain,
         quest_instances: questChain,
+        families: noActiveSeasonFamilyChain,
+        seasons: noActiveSeasonChain,
       };
       if (mocks[table]) return mocks[table];
       throw new Error(`Unexpected read table: ${table}`);

--- a/lib/achievement-progress-service.ts
+++ b/lib/achievement-progress-service.ts
@@ -16,6 +16,7 @@ import type {
 } from "./achievement-progress/types";
 import type { FetchedAchievement } from "./achievement-progress/unlock-engine";
 import { FamilyAchievementProgressService } from "./family-achievement-progress-service";
+import { getActiveSeasonForFamily } from "./seasons/active-season";
 
 export type {
   AchievementEventType,
@@ -40,9 +41,12 @@ export class AchievementProgressService {
     this.readClient = readClient ?? this.writeClient;
   }
 
-  private async resolveCharacterContext(
-    characterId: string,
-  ): Promise<{ userId: string; familyId: string | null }> {
+  private async resolveCharacterContext(characterId: string): Promise<{
+    userId: string;
+    familyId: string | null;
+    seasonId: string | null;
+    seasonStartedAt: string | null;
+  }> {
     const { data, error } = await this.readClient
       .from("characters")
       .select("user_id, user_profiles!characters_user_id_fkey(family_id)")
@@ -62,9 +66,16 @@ export class AchievementProgressService {
     const userProfile = data.user_profiles as {
       family_id?: string | null;
     } | null;
+    const familyId = userProfile?.family_id ?? null;
+    const activeSeason = familyId
+      ? await getActiveSeasonForFamily(this.readClient, familyId)
+      : null;
+
     return {
       userId: data.user_id,
-      familyId: userProfile?.family_id ?? null,
+      familyId,
+      seasonId: activeSeason?.id ?? null,
+      seasonStartedAt: activeSeason?.starts_at ?? null,
     };
   }
 
@@ -94,11 +105,14 @@ export class AchievementProgressService {
 
   private async fetchExistingAchievementIds(
     characterId: string,
+    seasonId: string | null,
   ): Promise<Set<string>> {
-    const { data, error } = await this.readClient
+    const query = this.readClient
       .from("character_achievements")
       .select("achievement_id")
       .eq("character_id", characterId);
+
+    const { data, error } = seasonId ? await query.eq("season_id", seasonId) : await query;
 
     if (error) {
       throw new Error(`Failed to check progress: ${error.message}`);
@@ -111,11 +125,13 @@ export class AchievementProgressService {
     characterId: string,
     event: AchievementEvent,
   ): Promise<void> {
-    const { userId, familyId } =
+    const { userId, familyId, seasonId, seasonStartedAt } =
       await this.resolveCharacterContext(characterId);
     const achievements = await this.fetchAchievements(familyId);
-    const existingAchievementIds =
-      await this.fetchExistingAchievementIds(characterId);
+    const existingAchievementIds = await this.fetchExistingAchievementIds(
+      characterId,
+      seasonId,
+    );
     // Backfill when any achievement row is missing, not just on zero rows.
     // This handles both first-call and post-deployment cases where new
     // achievements are added after a character's initial backfill.
@@ -165,12 +181,13 @@ export class AchievementProgressService {
         characterId,
         userId,
         config,
+        { seasonId, seasonStartedAt },
       );
 
       upsertRows.push({
         character_id: characterId,
         achievement_id: achievement.id,
-        season_id: null,
+        season_id: seasonId,
         progress: buildProgressValue(achievement.criteria_type, result, config),
       });
     }

--- a/lib/achievement-progress/compound-evaluator.ts
+++ b/lib/achievement-progress/compound-evaluator.ts
@@ -18,6 +18,7 @@ export function createCompoundEvaluator(
     characterId,
     userId,
     criteriaConfig,
+    context,
   ): Promise<EvaluatorResult> => {
     const registry = getRegistry();
     const conditions =
@@ -41,7 +42,13 @@ export function createCompoundEvaluator(
         continue;
       }
 
-      const result = await subEvaluator(client, characterId, userId, condition);
+      const result = await subEvaluator(
+        client,
+        characterId,
+        userId,
+        condition,
+        context,
+      );
       const met = condition.boolean
         ? result.current > 0
         : result.current >= (condition.threshold ?? 0);

--- a/lib/achievement-progress/criteria-map.ts
+++ b/lib/achievement-progress/criteria-map.ts
@@ -1,0 +1,41 @@
+import type { AchievementEventType } from "./types";
+
+export const EVENT_CRITERIA_MAP: Record<AchievementEventType, string[]> = {
+  QUEST_APPROVED: [
+    "quest_complete",
+    "quest_volunteer",
+    "quest_difficulty",
+    "gold_earned",
+    "xp_earned",
+    "level_reached",
+    "streak_reached",
+    "compound",
+  ],
+  REWARD_APPROVED: ["gold_spent", "reward_redeemed", "compound"],
+  BOSS_COMPLETED: [
+    "boss_defeated",
+    "boss_participated",
+    "gold_earned",
+    "xp_earned",
+    "level_reached",
+    "compound",
+  ],
+  CLASS_CHANGED: ["class_change", "compound"],
+};
+
+export const ALL_CRITERIA_TYPES = [
+  "quest_complete",
+  "quest_volunteer",
+  "quest_difficulty",
+  "boss_defeated",
+  "boss_participated",
+  "gold_earned",
+  "gold_spent",
+  "reward_redeemed",
+  "xp_earned",
+  "level_reached",
+  "streak_reached",
+  "class_change",
+  "honor_earned",
+  "compound",
+] as const;

--- a/lib/achievement-progress/evaluators.ts
+++ b/lib/achievement-progress/evaluators.ts
@@ -1,75 +1,54 @@
 import type {
-  AchievementEventType,
+  AchievementEvaluationContext,
   CriteriaConfig,
   EvaluatorFn,
 } from "./types";
 import { createCompoundEvaluator } from "./compound-evaluator";
-
-// ─── Event → criteria-type mapping ──────────────────────────────────────────
-
-export const EVENT_CRITERIA_MAP: Record<AchievementEventType, string[]> = {
-  QUEST_APPROVED: [
-    "quest_complete",
-    "quest_volunteer",
-    "quest_difficulty",
-    "gold_earned",
-    "xp_earned",
-    "level_reached",
-    "streak_reached",
-    "compound",
-  ],
-  REWARD_APPROVED: ["gold_spent", "reward_redeemed", "compound"],
-  BOSS_COMPLETED: [
-    "boss_defeated",
-    "boss_participated",
-    "gold_earned",
-    "xp_earned",
-    "level_reached",
-    "compound",
-  ],
-  CLASS_CHANGED: ["class_change", "compound"],
-};
-
-export const ALL_CRITERIA_TYPES = [
-  "quest_complete",
-  "quest_volunteer",
-  "quest_difficulty",
-  "boss_defeated",
-  "boss_participated",
-  "gold_earned",
-  "gold_spent",
-  "reward_redeemed",
-  "xp_earned",
-  "level_reached",
-  "streak_reached",
-  "class_change",
-  "honor_earned",
-  "compound",
-] as const;
+export { ALL_CRITERIA_TYPES, EVENT_CRITERIA_MAP } from "./criteria-map";
 
 // ─── Evaluators ──────────────────────────────────────────────────────────────
+
+function applySeasonCutoff<T extends { gte: (column: string, value: string) => T }>(
+  query: T,
+  context: AchievementEvaluationContext | undefined,
+  column: "approved_at" | "created_at" = "approved_at",
+): T {
+  return context?.seasonStartedAt
+    ? query.gte(column, context.seasonStartedAt)
+    : query;
+}
 
 const evaluateQuestComplete: EvaluatorFn = async (
   client,
   characterId,
   userId,
+  _criteriaConfig,
+  context,
 ) => {
-  const { count, error } = await client
+  const query = client
     .from("quest_instances")
     .select("*", { count: "exact", head: true })
     .eq("status", "APPROVED")
     .or(`assigned_to_id.eq.${userId},volunteered_by.eq.${characterId}`);
+  const { count, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
   return { current: count ?? 0 };
 };
 
-const evaluateQuestVolunteer: EvaluatorFn = async (client, characterId) => {
-  const { count, error } = await client
+const evaluateQuestVolunteer: EvaluatorFn = async (
+  client,
+  characterId,
+  _userId,
+  _criteriaConfig,
+  context,
+) => {
+  const query = client
     .from("quest_instances")
     .select("*", { count: "exact", head: true })
     .eq("volunteered_by", characterId)
     .eq("status", "APPROVED");
+  const { count, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
   return { current: count ?? 0 };
@@ -80,16 +59,18 @@ const evaluateQuestDifficulty: EvaluatorFn = async (
   characterId,
   userId,
   criteriaConfig,
+  context,
 ) => {
   const difficulty = criteriaConfig?.difficulty;
   if (!difficulty) return { current: 0 };
 
-  const { count, error } = await client
+  const query = client
     .from("quest_instances")
     .select("*", { count: "exact", head: true })
     .eq("status", "APPROVED")
     .eq("difficulty", difficulty as "EASY" | "MEDIUM" | "HARD")
     .or(`assigned_to_id.eq.${userId},volunteered_by.eq.${characterId}`);
+  const { count, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
   return { current: count ?? 0 };
@@ -99,12 +80,15 @@ const evaluateBossDefeated: EvaluatorFn = async (
   client,
   _characterId,
   userId,
+  _criteriaConfig,
+  context,
 ) => {
-  const { count, error } = await client
+  const query = client
     .from("boss_battle_participants")
     .select("*", { count: "exact", head: true })
     .eq("user_id", userId)
     .eq("participation_status", "APPROVED");
+  const { count, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
   return { current: count ?? 0 };
@@ -114,23 +98,36 @@ const evaluateBossParticipated: EvaluatorFn = async (
   client,
   _characterId,
   userId,
+  _criteriaConfig,
+  context,
 ) => {
-  const { count, error } = await client
+  const query = client
     .from("boss_battle_participants")
     .select("*", { count: "exact", head: true })
     .eq("user_id", userId)
     .in("participation_status", ["APPROVED", "PARTIAL"]);
+  const { count, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
   return { current: count ?? 0 };
 };
 
-const evaluateGoldEarned: EvaluatorFn = async (client, characterId, userId) => {
-  const { data: questRows, error: questError } = await client
+const evaluateGoldEarned: EvaluatorFn = async (
+  client,
+  characterId,
+  userId,
+  _criteriaConfig,
+  context,
+) => {
+  const questQuery = client
     .from("quest_instances")
     .select("gold_reward, volunteer_bonus, streak_bonus")
     .eq("status", "APPROVED")
     .or(`assigned_to_id.eq.${userId},volunteered_by.eq.${characterId}`);
+  const { data: questRows, error: questError } = await applySeasonCutoff(
+    questQuery,
+    context,
+  );
 
   if (questError) throw questError;
 
@@ -140,11 +137,15 @@ const evaluateGoldEarned: EvaluatorFn = async (client, characterId, userId) => {
     return sum + Math.round(base * (1 + bonusFraction));
   }, 0);
 
-  const { data: bossRows, error: bossError } = await client
+  const bossQuery = client
     .from("boss_battle_participants")
     .select("awarded_gold")
     .eq("user_id", userId)
     .in("participation_status", ["APPROVED", "PARTIAL"]);
+  const { data: bossRows, error: bossError } = await applySeasonCutoff(
+    bossQuery,
+    context,
+  );
 
   if (bossError) throw bossError;
 
@@ -156,12 +157,19 @@ const evaluateGoldEarned: EvaluatorFn = async (client, characterId, userId) => {
   return { current: questGold + bossGold };
 };
 
-const evaluateGoldSpent: EvaluatorFn = async (client, _characterId, userId) => {
-  const { data, error } = await client
+const evaluateGoldSpent: EvaluatorFn = async (
+  client,
+  _characterId,
+  userId,
+  _criteriaConfig,
+  context,
+) => {
+  const query = client
     .from("reward_redemptions")
     .select("cost")
     .eq("user_id", userId)
     .in("status", ["APPROVED", "FULFILLED"]);
+  const { data, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
 
@@ -173,12 +181,15 @@ const evaluateRewardRedeemed: EvaluatorFn = async (
   client,
   _characterId,
   userId,
+  _criteriaConfig,
+  context,
 ) => {
-  const { count, error } = await client
+  const query = client
     .from("reward_redemptions")
     .select("*", { count: "exact", head: true })
     .eq("user_id", userId)
     .in("status", ["APPROVED", "FULFILLED"]);
+  const { count, error } = await applySeasonCutoff(query, context);
 
   if (error) throw error;
   return { current: count ?? 0 };
@@ -219,12 +230,19 @@ const evaluateStreakReached: EvaluatorFn = async (client, characterId) => {
   return { current: maxStreak };
 };
 
-const evaluateClassChange: EvaluatorFn = async (client, characterId) => {
-  const { count, error } = await client
+const evaluateClassChange: EvaluatorFn = async (
+  client,
+  characterId,
+  _userId,
+  _criteriaConfig,
+  context,
+) => {
+  const query = client
     .from("character_change_history")
     .select("*", { count: "exact", head: true })
     .eq("character_id", characterId)
     .eq("change_type", "class");
+  const { count, error } = await applySeasonCutoff(query, context, "created_at");
 
   if (error) throw error;
   return { current: count ?? 0 };

--- a/lib/achievement-progress/types.ts
+++ b/lib/achievement-progress/types.ts
@@ -52,11 +52,17 @@ export type EvaluatorResult = {
   compoundMet?: boolean;
 };
 
+export type AchievementEvaluationContext = {
+  seasonId: string | null;
+  seasonStartedAt: string | null;
+};
+
 export type EvaluatorFn = (
   client: SupabaseClient<Database>,
   characterId: string,
   userId: string,
   criteriaConfig?: CriteriaConfig,
+  context?: AchievementEvaluationContext,
 ) => Promise<EvaluatorResult>;
 
 export type AchievementProgressRecord = {

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -22,6 +22,7 @@ export type FetchedAchievement = {
 export type UpsertRow = {
   character_id: string;
   achievement_id: string;
+  season_id: string | null;
   progress: AchievementProgressValue;
 };
 
@@ -39,11 +40,15 @@ export async function runUnlockEvaluation(
   if (depth > MAX_CASCADE_DEPTH || progressRows.length === 0) return;
 
   const achievementIds = progressRows.map((r) => r.achievement_id);
-  const { data: existingRows, error: fetchError } = await readClient
+  const seasonId = progressRows[0]?.season_id ?? null;
+  const unlockStateQuery = readClient
     .from("character_achievements")
     .select("achievement_id, unlocked_at")
     .eq("character_id", characterId)
     .in("achievement_id", achievementIds);
+  const { data: existingRows, error: fetchError } = seasonId
+    ? await unlockStateQuery.eq("season_id", seasonId)
+    : await unlockStateQuery;
 
   if (fetchError) {
     throw new Error(`Failed to fetch unlock state: ${fetchError.message}`);
@@ -63,7 +68,7 @@ export async function runUnlockEvaluation(
 
   if (newlyEligible.length === 0) return;
 
-  const { data: actuallyUnlocked, error: unlockError } = await writeClient
+  const unlockUpdateQuery = writeClient
     .from("character_achievements")
     .update({ unlocked_at: new Date().toISOString() })
     .eq("character_id", characterId)
@@ -71,8 +76,10 @@ export async function runUnlockEvaluation(
       "achievement_id",
       newlyEligible.map((r) => r.achievement_id),
     )
-    .is("unlocked_at", null)
-    .select("achievement_id");
+    .is("unlocked_at", null);
+  const { data: actuallyUnlocked, error: unlockError } = seasonId
+    ? await unlockUpdateQuery.eq("season_id", seasonId).select("achievement_id")
+    : await unlockUpdateQuery.select("achievement_id");
 
   if (unlockError) {
     throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
@@ -180,6 +187,7 @@ export async function runUnlockEvaluation(
           cascadeRows.push({
             character_id: characterId,
             achievement_id: a.id,
+            season_id: seasonId,
             progress: {
               current: trigger.newValue,
               threshold: config?.threshold ?? 0,
@@ -208,10 +216,12 @@ export async function runUnlockEvaluation(
             characterId,
             userId,
             config,
+            { seasonId, seasonStartedAt: null },
           );
           cascadeRows.push({
             character_id: characterId,
             achievement_id: a.id,
+            season_id: seasonId,
             progress: buildProgressValue("compound", result, config),
           });
           cascadeAchievementIds.add(a.id);
@@ -221,7 +231,7 @@ export async function runUnlockEvaluation(
       if (cascadeRows.length > 0) {
         // Fix P2: snapshot existing progress before upserting so rollback can
         // restore prior values rather than blindly writing null.
-        const { data: existingCascade, error: snapshotErr } = await readClient
+        const snapshotQuery = readClient
           .from("character_achievements")
           .select("achievement_id, progress")
           .eq("character_id", characterId)
@@ -229,6 +239,9 @@ export async function runUnlockEvaluation(
             "achievement_id",
             cascadeRows.map((r) => r.achievement_id),
           );
+        const { data: existingCascade, error: snapshotErr } = seasonId
+          ? await snapshotQuery.eq("season_id", seasonId)
+          : await snapshotQuery;
         if (snapshotErr) {
           throw new Error(
             `Failed to snapshot cascade progress: ${snapshotErr.message}`,
@@ -241,7 +254,7 @@ export async function runUnlockEvaluation(
         const { error: cascadeUpsertError } = await writeClient
           .from("character_achievements")
           .upsert(cascadeRows, {
-            onConflict: "character_id,achievement_id",
+            onConflict: "character_id,achievement_id,season_id",
             ignoreDuplicates: false,
           });
 

--- a/tests/unit/lib/achievement-season-aware.test.ts
+++ b/tests/unit/lib/achievement-season-aware.test.ts
@@ -1,0 +1,274 @@
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(),
+}));
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn(),
+}));
+
+jest.mock("@/lib/family-achievement-progress-service", () => ({
+  FamilyAchievementProgressService: jest.fn().mockImplementation(() => ({
+    updateProgress: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("@/lib/achievement-progress/unlock-engine", () => ({
+  runUnlockEvaluation: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { EVALUATOR_REGISTRY } from "@/lib/achievement-progress/evaluators";
+import { AchievementProgressService } from "@/lib/achievement-progress-service";
+import { createServiceSupabaseClient } from "@/lib/supabase-server";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+
+const SEASON_STARTED_AT = "2026-05-01T00:00:00.000Z";
+
+function makeThenableQuery(response: unknown) {
+  const query = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    or: jest.fn(() => query),
+    in: jest.fn(() => query),
+    gte: jest.fn(() => query),
+    is: jest.fn(() => query),
+    single: jest.fn(() => Promise.resolve(response)),
+    maybeSingle: jest.fn(() => Promise.resolve(response)),
+    then: (resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(response).then(resolve, reject),
+  };
+  return query;
+}
+
+function makeClientForTableQueries() {
+  const queries: Record<string, ReturnType<typeof makeThenableQuery>[]> = {};
+  const client = {
+    from: jest.fn((table: string) => {
+      const response = table === "quest_instances" || table === "boss_battle_participants"
+        ? { data: [{ gold_reward: 10, volunteer_bonus: 0, streak_bonus: 0, awarded_gold: 5 }], count: 1, error: null }
+        : table === "reward_redemptions"
+          ? { data: [{ cost: 7 }], count: 1, error: null }
+          : { data: [{ xp: 0, level: 1, honor_points: 0 }], count: 1, error: null };
+      const query = makeThenableQuery(response);
+      queries[table] = [...(queries[table] ?? []), query];
+      return query;
+    }),
+  };
+  return { client, queries };
+}
+
+describe("individual achievement evaluators season cutoff", () => {
+  it.each([
+    ["quest_complete", "quest_instances", "approved_at"],
+    ["quest_volunteer", "quest_instances", "approved_at"],
+    ["quest_difficulty", "quest_instances", "approved_at"],
+    ["boss_defeated", "boss_battle_participants", "approved_at"],
+    ["boss_participated", "boss_battle_participants", "approved_at"],
+    ["gold_spent", "reward_redemptions", "approved_at"],
+    ["reward_redeemed", "reward_redemptions", "approved_at"],
+    ["class_change", "character_change_history", "created_at"],
+  ])("applies season cutoff for %s", async (criteriaType, table, column) => {
+    const { client, queries } = makeClientForTableQueries();
+
+    await EVALUATOR_REGISTRY[criteriaType](
+      client as never,
+      "char-1",
+      "user-1",
+      { difficulty: "HARD", threshold: 1 },
+      { seasonId: "season-1", seasonStartedAt: SEASON_STARTED_AT },
+    );
+
+    expect(queries[table][0].gte).toHaveBeenCalledWith(column, SEASON_STARTED_AT);
+  });
+
+  it("applies season cutoff to both quest and boss gold-earned sources", async () => {
+    const { client, queries } = makeClientForTableQueries();
+
+    await EVALUATOR_REGISTRY.gold_earned(
+      client as never,
+      "char-1",
+      "user-1",
+      { threshold: 1 },
+      { seasonId: "season-1", seasonStartedAt: SEASON_STARTED_AT },
+    );
+
+    expect(queries.quest_instances[0].gte).toHaveBeenCalledWith(
+      "approved_at",
+      SEASON_STARTED_AT,
+    );
+    expect(queries.boss_battle_participants[0].gte).toHaveBeenCalledWith(
+      "approved_at",
+      SEASON_STARTED_AT,
+    );
+  });
+
+  it("preserves legacy unscoped evaluator queries when there is no active season", async () => {
+    const { client, queries } = makeClientForTableQueries();
+
+    await EVALUATOR_REGISTRY.quest_complete(
+      client as never,
+      "char-1",
+      "user-1",
+      { threshold: 1 },
+      { seasonId: null, seasonStartedAt: null },
+    );
+
+    expect(queries.quest_instances[0].gte).not.toHaveBeenCalled();
+  });
+});
+
+describe("AchievementProgressService active-season scoping", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reads and writes progress rows for the active season", async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    const writeClient = {
+      from: jest.fn((table: string) => {
+        if (table !== "character_achievements") {
+          throw new Error(`Unexpected write table: ${table}`);
+        }
+        return { upsert };
+      }),
+    };
+    (createServiceSupabaseClient as jest.Mock).mockReturnValue(writeClient);
+    (getActiveSeasonForFamily as jest.Mock).mockResolvedValue({
+      id: "season-1",
+      family_id: "fam-1",
+      name: "Season One",
+      theme: null,
+      starts_at: SEASON_STARTED_AT,
+      ends_at: null,
+    });
+
+    const existingQuery = makeThenableQuery({ data: [], error: null });
+    const readClient = {
+      from: jest.fn((table: string) => {
+        if (table === "characters") {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    user_id: "user-1",
+                    user_profiles: { family_id: "fam-1" },
+                  },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "achievements") {
+          return {
+            select: jest.fn().mockReturnValue({
+              or: jest.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: "ach-1",
+                    name: "Complete one quest",
+                    criteria_type: "quest_complete",
+                    criteria_config: { threshold: 1 },
+                    xp_reward: 0,
+                    gold_reward: 0,
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          };
+        }
+        if (table === "character_achievements") {
+          return existingQuery;
+        }
+        if (table === "quest_instances") {
+          return makeThenableQuery({ count: 1, error: null });
+        }
+        throw new Error(`Unexpected read table: ${table}`);
+      }),
+    };
+
+    const service = new AchievementProgressService(readClient as never);
+    await service.updateProgress("char-1", { type: "QUEST_APPROVED" });
+
+    expect(getActiveSeasonForFamily).toHaveBeenCalledWith(readClient, "fam-1");
+    expect(existingQuery.eq).toHaveBeenCalledWith("season_id", "season-1");
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          character_id: "char-1",
+          achievement_id: "ach-1",
+          season_id: "season-1",
+        }),
+      ],
+      expect.objectContaining({
+        onConflict: "character_id,achievement_id,season_id",
+      }),
+    );
+  });
+
+  it("preserves legacy progress scoping when no active season exists", async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    const writeClient = {
+      from: jest.fn((table: string) => {
+        if (table !== "character_achievements") {
+          throw new Error(`Unexpected write table: ${table}`);
+        }
+        return { upsert };
+      }),
+    };
+    (createServiceSupabaseClient as jest.Mock).mockReturnValue(writeClient);
+    (getActiveSeasonForFamily as jest.Mock).mockResolvedValue(null);
+
+    const existingQuery = makeThenableQuery({ data: [], error: null });
+    const readClient = {
+      from: jest.fn((table: string) => {
+        if (table === "characters") {
+          return makeThenableQuery({
+            data: { user_id: "user-1", user_profiles: { family_id: "fam-1" } },
+            error: null,
+          });
+        }
+        if (table === "achievements") {
+          return {
+            select: jest.fn().mockReturnValue({
+              or: jest.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: "ach-1",
+                    name: "Complete one quest",
+                    criteria_type: "quest_complete",
+                    criteria_config: { threshold: 1 },
+                    xp_reward: 0,
+                    gold_reward: 0,
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          };
+        }
+        if (table === "character_achievements") return existingQuery;
+        if (table === "quest_instances") return makeThenableQuery({ count: 1, error: null });
+        throw new Error(`Unexpected read table: ${table}`);
+      }),
+    };
+
+    const service = new AchievementProgressService(readClient as never);
+    await service.updateProgress("char-1", { type: "QUEST_APPROVED" });
+
+    expect(existingQuery.eq).not.toHaveBeenCalledWith("season_id", expect.anything());
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          character_id: "char-1",
+          achievement_id: "ach-1",
+          season_id: null,
+        }),
+      ],
+      expect.objectContaining({
+        onConflict: "character_id,achievement_id,season_id",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Makes individual achievement progress evaluation aware of the active family season.
- Passes season context through evaluator, compound evaluator, unlock, and progress-service paths.
- Adds `season_id` scoping for `character_achievements` while preserving legacy no-active-season rows.
- Adds focused regression coverage for pre-season history not backfilling current-season progress.

Closes #153

## Verification
- `npm run lint`
- `npm run test:unit -- achievement-season-aware --runInBand`
- `npm run test:unit -- achievement --runInBand`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run test:unit -- --runInBand`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`

## Manual verification notes for Brian
- Inspect `lib/achievement-progress-service.ts`, `lib/achievement-progress/evaluators.ts`, and `lib/achievement-progress/unlock-engine.ts` to confirm season context is read once for the family and then passed through individual achievement progress/unlock evaluation.
- Inspect `tests/unit/lib/achievement-season-aware.test.ts` for the important behavioral cases: pre-season quest, boss, reward, and class-change history should not count after an active season starts; legacy no-active-season behavior should still work.
- Locally run:
  - `npm run lint`
  - `npm run test:unit -- achievement-season-aware --runInBand`
  - `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`
- Expected result: lint, focused tests, and build pass.
- Expected visible app behavior: no immediate UI change by itself; this is backend/evaluator scoping so existing historical activity should stop backfilling new individual achievement progress once an active season exists.
- Avoid production credentials or production Supabase writes during manual checks.
