### PR TITLE
feat: make family achievement evaluation season-aware

### DIFF
--- a/lib/__tests__/family-achievement-progress-service.fixtures.ts
+++ b/lib/__tests__/family-achievement-progress-service.fixtures.ts
@@ -81,8 +81,30 @@ export const CHARACTER_IDS = ["char-001", "char-002"];
 export const FAMILY_ACHIEVEMENT_ID = "fach-001";
 
 export function makeReadClient(overrides?: Record<string, MockChain>) {
+  const noActiveSeasonFamilies = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: { active_season_id: null },
+          error: null,
+        }),
+      }),
+    }),
+  };
+  const noActiveSeasonSeasons = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    }),
+  };
+
   const from = jest.fn((table: string) => {
     if (overrides?.[table]) return overrides[table];
+    if (table === "families") return noActiveSeasonFamilies;
+    if (table === "seasons") return noActiveSeasonSeasons;
     throw new Error(`Unexpected table: ${table}`);
   });
   return { from };

--- a/lib/__tests__/family-achievement-season-aware.test.ts
+++ b/lib/__tests__/family-achievement-season-aware.test.ts
@@ -1,0 +1,222 @@
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(),
+}));
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn(),
+}));
+
+jest.mock("@/lib/family-achievement-progress/service-helpers", () => ({
+  ...jest.requireActual("@/lib/family-achievement-progress/service-helpers"),
+  evaluateUnlocksImpl: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { FAMILY_EVALUATOR_REGISTRY } from "@/lib/family-achievement-progress/family-evaluators";
+import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
+import { evaluateUnlocksImpl } from "@/lib/family-achievement-progress/service-helpers";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+import { createServiceSupabaseClient } from "@/lib/supabase-server";
+
+const SEASON_ID = "season-154";
+const SEASON_STARTED_AT = "2026-05-01T00:00:00.000Z";
+const FAMILY_ID = "family-154";
+
+function makeThenableQuery(response: unknown) {
+  const query = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    or: jest.fn(() => query),
+    in: jest.fn(() => query),
+    gte: jest.fn(() => query),
+    is: jest.fn(() => query),
+    single: jest.fn(() => Promise.resolve(response)),
+    maybeSingle: jest.fn(() => Promise.resolve(response)),
+    then: (resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(response).then(resolve, reject),
+  };
+  return query;
+}
+
+function makeEvaluatorClient() {
+  const queries: Record<string, ReturnType<typeof makeThenableQuery>[]> = {};
+  const client = {
+    from: jest.fn((table: string) => {
+      const response =
+        table === "quest_instances"
+          ? { data: [{ gold_reward: 10, volunteer_bonus: 0, streak_bonus: 0 }], count: 1, error: null }
+          : table === "boss_battle_participants"
+            ? { data: [{ awarded_gold: 5 }], count: 1, error: null }
+            : table === "reward_redemptions"
+              ? { data: [{ cost: 7 }], count: 1, error: null }
+              : { data: [], count: 0, error: null };
+      const query = makeThenableQuery(response);
+      queries[table] = [...(queries[table] ?? []), query];
+      return query;
+    }),
+  };
+  return { client, queries };
+}
+
+describe("family achievement evaluators season cutoff", () => {
+  it.each([
+    ["quest_complete", "quest_instances", "approved_at"],
+    ["quest_volunteer", "quest_instances", "approved_at"],
+    ["quest_difficulty", "quest_instances", "approved_at"],
+    ["boss_defeated", "boss_battle_participants", "approved_at"],
+    ["boss_participated", "boss_battle_participants", "approved_at"],
+    ["gold_spent", "reward_redemptions", "approved_at"],
+    ["reward_redeemed", "reward_redemptions", "approved_at"],
+    ["class_change", "character_change_history", "created_at"],
+  ])("applies season cutoff for %s", async (criteriaType, table, column) => {
+    const { client, queries } = makeEvaluatorClient();
+
+    await FAMILY_EVALUATOR_REGISTRY[criteriaType](
+      client as never,
+      FAMILY_ID,
+      ["user-1"],
+      ["char-1"],
+      ["user-1"],
+      "sum",
+      [{ userId: "user-1", characterIds: ["char-1"] }],
+      { difficulty: "HARD", threshold: 1 },
+      { seasonId: SEASON_ID, seasonStartedAt: SEASON_STARTED_AT },
+    );
+
+    expect(queries[table][0].gte).toHaveBeenCalledWith(column, SEASON_STARTED_AT);
+  });
+
+  it("applies season cutoff to both family gold-earned sources", async () => {
+    const { client, queries } = makeEvaluatorClient();
+
+    await FAMILY_EVALUATOR_REGISTRY.gold_earned(
+      client as never,
+      FAMILY_ID,
+      ["user-1"],
+      ["char-1"],
+      ["user-1"],
+      "sum",
+      [{ userId: "user-1", characterIds: ["char-1"] }],
+      { threshold: 1 },
+      { seasonId: SEASON_ID, seasonStartedAt: SEASON_STARTED_AT },
+    );
+
+    expect(queries.quest_instances[0].gte).toHaveBeenCalledWith(
+      "approved_at",
+      SEASON_STARTED_AT,
+    );
+    expect(queries.boss_battle_participants[0].gte).toHaveBeenCalledWith(
+      "approved_at",
+      SEASON_STARTED_AT,
+    );
+  });
+
+  it("preserves legacy unscoped family evaluator queries when there is no active season", async () => {
+    const { client, queries } = makeEvaluatorClient();
+
+    await FAMILY_EVALUATOR_REGISTRY.quest_complete(
+      client as never,
+      FAMILY_ID,
+      ["user-1"],
+      ["char-1"],
+      ["user-1"],
+      "sum",
+      [{ userId: "user-1", characterIds: ["char-1"] }],
+      { threshold: 1 },
+      { seasonId: null, seasonStartedAt: null },
+    );
+
+    expect(queries.quest_instances[0].gte).not.toHaveBeenCalled();
+  });
+});
+
+describe("FamilyAchievementProgressService active-season scoping", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reads and writes family progress rows for the active season", async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    const writeClient = {
+      from: jest.fn((table: string) => {
+        if (table !== "family_achievement_progress") {
+          throw new Error(`Unexpected write table: ${table}`);
+        }
+        return { upsert };
+      }),
+    };
+    (createServiceSupabaseClient as jest.Mock).mockReturnValue(writeClient);
+    (getActiveSeasonForFamily as jest.Mock).mockResolvedValue({
+      id: SEASON_ID,
+      family_id: FAMILY_ID,
+      name: "Season 154",
+      theme: null,
+      starts_at: SEASON_STARTED_AT,
+      ends_at: null,
+    });
+
+    const existingProgressQuery = makeThenableQuery({ data: [], error: null });
+    const questQuery = makeThenableQuery({ count: 2, error: null });
+    const readClient = {
+      from: jest.fn((table: string) => {
+        if (table === "user_profiles") {
+          return makeThenableQuery({
+            data: [
+              { id: "user-1", characters: [{ id: "char-1" }] },
+              { id: "user-2", characters: [{ id: "char-2" }] },
+            ],
+            error: null,
+          });
+        }
+        if (table === "family_achievements") {
+          return makeThenableQuery({
+            data: [
+              {
+                id: "family-ach-1",
+                name: "Family quest",
+                criteria_type: "quest_complete",
+                criteria_config: { threshold: 2 },
+                xp_reward: 0,
+                gold_reward: 0,
+              },
+            ],
+            error: null,
+          });
+        }
+        if (table === "family_achievement_progress") {
+          return existingProgressQuery;
+        }
+        if (table === "quest_instances") {
+          return questQuery;
+        }
+        throw new Error(`Unexpected read table: ${table}`);
+      }),
+    };
+
+    const service = new FamilyAchievementProgressService(readClient as never);
+    await service.updateProgress(FAMILY_ID, null);
+
+    expect(getActiveSeasonForFamily).toHaveBeenCalledWith(readClient, FAMILY_ID);
+    expect(existingProgressQuery.eq).toHaveBeenCalledWith("season_id", SEASON_ID);
+    expect(questQuery.gte).toHaveBeenCalledWith("approved_at", SEASON_STARTED_AT);
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          family_id: FAMILY_ID,
+          family_achievement_id: "family-ach-1",
+          season_id: SEASON_ID,
+        }),
+      ],
+      expect.objectContaining({
+        onConflict: "family_id,family_achievement_id,season_id",
+      }),
+    );
+    expect(evaluateUnlocksImpl).toHaveBeenCalledWith(
+      readClient,
+      writeClient,
+      FAMILY_ID,
+      expect.arrayContaining([
+        expect.objectContaining({ season_id: SEASON_ID }),
+      ]),
+    );
+  });
+});

--- a/lib/family-achievement-progress-service.ts
+++ b/lib/family-achievement-progress-service.ts
@@ -12,18 +12,22 @@ import type {
   FetchedFamilyAchievement,
   FamilyCriteriaConfig,
   FamilyAchievementProgressRecord,
+  FamilyAchievementEvaluationContext,
 } from "./family-achievement-progress/types";
 import {
   recomputeAchievementImpl,
-  getProgressImpl,
   evaluateUnlocksImpl,
 } from "./family-achievement-progress/service-helpers";
+import { resolveFamilyCharacters } from "./family-achievement-progress/family-context";
+import { getProgressImpl } from "./family-achievement-progress/progress-reader";
+import { getActiveSeasonForFamily } from "./seasons/active-season";
 
 export type {
   AchievementEvent,
   FetchedFamilyAchievement,
   FamilyCriteriaConfig,
   FamilyAchievementProgressRecord,
+  FamilyAchievementEvaluationContext,
 } from "./family-achievement-progress/types";
 
 // ─── Service class ───────────────────────────────────────────────────────────
@@ -37,61 +41,6 @@ export class FamilyAchievementProgressService {
     this.readClient = readClient ?? this.writeClient;
   }
 
-  private async resolveFamilyCharacters(familyId: string): Promise<{
-    userIds: string[];
-    characterIds: string[];
-    allUserIds: string[];
-    totalMemberCount: number;
-    membersWithCharCount: number;
-    memberPairs: import("./family-achievement-progress/types").FamilyMemberPair[];
-  }> {
-    const { data, error } = await this.readClient
-      .from("user_profiles")
-      .select("id, characters(id)")
-      .eq("family_id", familyId);
-
-    if (error) {
-      throw new Error(`Failed to resolve family characters: ${error.message}`);
-    }
-
-    if (!data || data.length === 0) {
-      throw new Error(`No members found for family: ${familyId}`);
-    }
-
-    const userIds: string[] = [];
-    const characterIds: string[] = [];
-    const allUserIds: string[] = [];
-    const usersWithChars = new Set<string>();
-    const memberPairs: import("./family-achievement-progress/types").FamilyMemberPair[] =
-      [];
-
-    for (const profile of data) {
-      allUserIds.push(profile.id);
-      const chars = Array.isArray(profile.characters)
-        ? profile.characters
-        : profile.characters
-          ? [profile.characters]
-          : [];
-      const charIds: string[] = [];
-      for (const char of chars) {
-        const charId = (char as { id: string }).id;
-        userIds.push(profile.id);
-        characterIds.push(charId);
-        usersWithChars.add(profile.id);
-        charIds.push(charId);
-      }
-      memberPairs.push({ userId: profile.id, characterIds: charIds });
-    }
-
-    return {
-      userIds,
-      characterIds,
-      allUserIds,
-      totalMemberCount: data.length,
-      membersWithCharCount: usersWithChars.size,
-      memberPairs,
-    };
-  }
 
   private async fetchFamilyAchievements(
     familyId: string,
@@ -112,11 +61,16 @@ export class FamilyAchievementProgressService {
 
   private async fetchExistingProgressIds(
     familyId: string,
+    seasonId: string | null,
   ): Promise<Set<string>> {
-    const { data, error } = await this.readClient
+    const query = this.readClient
       .from("family_achievement_progress")
       .select("family_achievement_id")
       .eq("family_id", familyId);
+
+    const { data, error } = seasonId
+      ? await query.eq("season_id", seasonId)
+      : await query;
 
     if (error) {
       throw new Error(`Failed to check family progress: ${error.message}`);
@@ -186,9 +140,17 @@ export class FamilyAchievementProgressService {
       totalMemberCount,
       membersWithCharCount,
       memberPairs,
-    } = await this.resolveFamilyCharacters(familyId);
+    } = await resolveFamilyCharacters(this.readClient, familyId);
     const achievements = await this.fetchFamilyAchievements(familyId);
-    const existingProgressIds = await this.fetchExistingProgressIds(familyId);
+    const activeSeason = await getActiveSeasonForFamily(this.readClient, familyId);
+    const evaluationContext: FamilyAchievementEvaluationContext = {
+      seasonId: activeSeason?.id ?? null,
+      seasonStartedAt: activeSeason?.starts_at ?? null,
+    };
+    const existingProgressIds = await this.fetchExistingProgressIds(
+      familyId,
+      evaluationContext.seasonId,
+    );
 
     if (achievements.length === 0) return;
 
@@ -239,6 +201,7 @@ export class FamilyAchievementProgressService {
         mode,
         memberPairs,
         config,
+        evaluationContext,
       );
       const guardFails =
         mode === "all" &&
@@ -249,7 +212,7 @@ export class FamilyAchievementProgressService {
       upsertRows.push({
         family_id: familyId,
         family_achievement_id: achievement.id,
-        season_id: null,
+        season_id: evaluationContext.seasonId,
         progress: {
           current,
           threshold,
@@ -284,13 +247,18 @@ export class FamilyAchievementProgressService {
     familyId: string,
     achievementId: string,
   ): Promise<void> {
-    const familyContext = await this.resolveFamilyCharacters(familyId);
+    const familyContext = await resolveFamilyCharacters(this.readClient, familyId);
+    const activeSeason = await getActiveSeasonForFamily(this.readClient, familyId);
     await recomputeAchievementImpl(
       this.readClient,
       this.writeClient,
       familyId,
       achievementId,
       familyContext,
+      {
+        seasonId: activeSeason?.id ?? null,
+        seasonStartedAt: activeSeason?.starts_at ?? null,
+      },
     );
   }
 

--- a/lib/family-achievement-progress/family-context.ts
+++ b/lib/family-achievement-progress/family-context.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database-generated";
+import type { FamilyMemberPair } from "./types";
+
+type ReadClient = SupabaseClient<Database>;
+
+export type FamilyCharacterContext = {
+  userIds: string[];
+  characterIds: string[];
+  allUserIds: string[];
+  totalMemberCount: number;
+  membersWithCharCount: number;
+  memberPairs: FamilyMemberPair[];
+};
+
+export async function resolveFamilyCharacters(
+  readClient: ReadClient,
+  familyId: string,
+): Promise<FamilyCharacterContext> {
+  const { data, error } = await readClient
+    .from("user_profiles")
+    .select("id, characters(id)")
+    .eq("family_id", familyId);
+
+  if (error) {
+    throw new Error(`Failed to resolve family characters: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    throw new Error(`No members found for family: ${familyId}`);
+  }
+
+  const userIds: string[] = [];
+  const characterIds: string[] = [];
+  const allUserIds: string[] = [];
+  const usersWithChars = new Set<string>();
+  const memberPairs: FamilyMemberPair[] = [];
+
+  for (const profile of data) {
+    allUserIds.push(profile.id);
+    const chars = Array.isArray(profile.characters)
+      ? profile.characters
+      : profile.characters
+        ? [profile.characters]
+        : [];
+    const charIds: string[] = [];
+    for (const char of chars) {
+      const charId = (char as { id: string }).id;
+      userIds.push(profile.id);
+      characterIds.push(charId);
+      usersWithChars.add(profile.id);
+      charIds.push(charId);
+    }
+    memberPairs.push({ userId: profile.id, characterIds: charIds });
+  }
+
+  return {
+    userIds,
+    characterIds,
+    allUserIds,
+    totalMemberCount: data.length,
+    membersWithCharCount: usersWithChars.size,
+    memberPairs,
+  };
+}

--- a/lib/family-achievement-progress/family-evaluators-stats.ts
+++ b/lib/family-achievement-progress/family-evaluators-stats.ts
@@ -1,5 +1,18 @@
-import type { FamilyEvaluatorFn } from "./types";
+import type {
+  FamilyAchievementEvaluationContext,
+  FamilyEvaluatorFn,
+} from "./types";
 import { aggregate } from "./family-evaluator-utils";
+
+function applySeasonCutoff<T extends { gte: (column: string, value: string) => T }>(
+  query: T,
+  context: FamilyAchievementEvaluationContext | undefined,
+  column: "approved_at" | "created_at" = "approved_at",
+): T {
+  return context?.seasonStartedAt
+    ? query.gte(column, context.seasonStartedAt)
+    : query;
+}
 
 export const evaluateGoldEarned: FamilyEvaluatorFn = async (
   client,
@@ -9,6 +22,8 @@ export const evaluateGoldEarned: FamilyEvaluatorFn = async (
   _allUserIds,
   mode,
   memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const { userId, characterIds } of memberPairs) {
@@ -16,12 +31,16 @@ export const evaluateGoldEarned: FamilyEvaluatorFn = async (
       .from("quest_instances")
       .select("gold_reward, volunteer_bonus, streak_bonus")
       .eq("status", "APPROVED");
-    const { data: questRows, error: questError } =
+    const questQuery =
       characterIds.length > 0
-        ? await base.or(
+        ? base.or(
             `assigned_to_id.eq.${userId},volunteered_by.in.(${characterIds.join(",")})`,
           )
-        : await base.eq("assigned_to_id", userId);
+        : base.eq("assigned_to_id", userId);
+    const { data: questRows, error: questError } = await applySeasonCutoff(
+      questQuery,
+      context,
+    );
     if (questError) throw questError;
 
     const questGold = (questRows ?? []).reduce((sum, row) => {
@@ -31,11 +50,15 @@ export const evaluateGoldEarned: FamilyEvaluatorFn = async (
       return sum + Math.round(base * (1 + bonusFraction));
     }, 0);
 
-    const { data: bossRows, error: bossError } = await client
+    const bossQuery = client
       .from("boss_battle_participants")
       .select("awarded_gold")
       .eq("user_id", userId)
       .in("participation_status", ["APPROVED", "PARTIAL"]);
+    const { data: bossRows, error: bossError } = await applySeasonCutoff(
+      bossQuery,
+      context,
+    );
     if (bossError) throw bossError;
 
     const bossGold = (bossRows ?? []).reduce(
@@ -55,14 +78,18 @@ export const evaluateGoldSpent: FamilyEvaluatorFn = async (
   _characterIds,
   allUserIds,
   mode,
+  _memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const userId of allUserIds) {
-    const { data, error } = await client
+    const query = client
       .from("reward_redemptions")
       .select("cost")
       .eq("user_id", userId)
       .in("status", ["APPROVED", "FULFILLED"]);
+    const { data, error } = await applySeasonCutoff(query, context);
     if (error) throw error;
     const total = (data ?? []).reduce((sum, row) => sum + (row.cost ?? 0), 0);
     values.push(total);
@@ -77,14 +104,18 @@ export const evaluateRewardRedeemed: FamilyEvaluatorFn = async (
   _characterIds,
   allUserIds,
   mode,
+  _memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const userId of allUserIds) {
-    const { count, error } = await client
+    const query = client
       .from("reward_redemptions")
       .select("*", { count: "exact", head: true })
       .eq("user_id", userId)
       .in("status", ["APPROVED", "FULFILLED"]);
+    const { count, error } = await applySeasonCutoff(query, context);
     if (error) throw error;
     values.push(count ?? 0);
   }
@@ -194,16 +225,23 @@ export const evaluateClassChange: FamilyEvaluatorFn = async (
   _allUserIds,
   mode,
   memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const { characterIds } of memberPairs) {
     const charValues: number[] = [];
     for (const characterId of characterIds) {
-      const { count, error } = await client
+      const query = client
         .from("character_change_history")
         .select("*", { count: "exact", head: true })
         .eq("character_id", characterId)
         .eq("change_type", "class");
+      const { count, error } = await applySeasonCutoff(
+        query,
+        context,
+        "created_at",
+      );
       if (error) throw error;
       charValues.push(count ?? 0);
     }

--- a/lib/family-achievement-progress/family-evaluators.ts
+++ b/lib/family-achievement-progress/family-evaluators.ts
@@ -1,4 +1,7 @@
-import type { FamilyEvaluatorFn } from "./types";
+import type {
+  FamilyAchievementEvaluationContext,
+  FamilyEvaluatorFn,
+} from "./types";
 import type { AchievementEventType } from "../achievement-progress/types";
 import { aggregate } from "./family-evaluator-utils";
 import {
@@ -73,6 +76,16 @@ export const ALL_FAMILY_CRITERIA_TYPES = [
 
 // ─── Family evaluators ──────────────────────────────────────────────────────
 
+function applySeasonCutoff<T extends { gte: (column: string, value: string) => T }>(
+  query: T,
+  context: FamilyAchievementEvaluationContext | undefined,
+  column: "approved_at" | "created_at" = "approved_at",
+): T {
+  return context?.seasonStartedAt
+    ? query.gte(column, context.seasonStartedAt)
+    : query;
+}
+
 const evaluateQuestComplete: FamilyEvaluatorFn = async (
   client,
   _familyId,
@@ -81,6 +94,8 @@ const evaluateQuestComplete: FamilyEvaluatorFn = async (
   _allUserIds,
   mode,
   memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const { userId, characterIds } of memberPairs) {
@@ -88,12 +103,13 @@ const evaluateQuestComplete: FamilyEvaluatorFn = async (
       .from("quest_instances")
       .select("*", { count: "exact", head: true })
       .eq("status", "APPROVED");
-    const { count, error } =
+    const query =
       characterIds.length > 0
-        ? await base.or(
+        ? base.or(
             `assigned_to_id.eq.${userId},volunteered_by.in.(${characterIds.join(",")})`,
           )
-        : await base.eq("assigned_to_id", userId);
+        : base.eq("assigned_to_id", userId);
+    const { count, error } = await applySeasonCutoff(query, context);
     if (error) throw error;
     values.push(count ?? 0);
   }
@@ -108,6 +124,8 @@ const evaluateQuestVolunteer: FamilyEvaluatorFn = async (
   _allUserIds,
   mode,
   memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const { characterIds } of memberPairs) {
@@ -115,11 +133,12 @@ const evaluateQuestVolunteer: FamilyEvaluatorFn = async (
       // One value per member: max of their characters' volunteer counts
       let maxForMember = 0;
       for (const characterId of characterIds) {
-        const { count, error } = await client
+        const query = client
           .from("quest_instances")
           .select("*", { count: "exact", head: true })
           .eq("volunteered_by", characterId)
           .eq("status", "APPROVED");
+        const { count, error } = await applySeasonCutoff(query, context);
         if (error) throw error;
         maxForMember = Math.max(maxForMember, count ?? 0);
       }
@@ -127,11 +146,12 @@ const evaluateQuestVolunteer: FamilyEvaluatorFn = async (
     } else {
       // One value per character: sum across all characters
       for (const characterId of characterIds) {
-        const { count, error } = await client
+        const query = client
           .from("quest_instances")
           .select("*", { count: "exact", head: true })
           .eq("volunteered_by", characterId)
           .eq("status", "APPROVED");
+        const { count, error } = await applySeasonCutoff(query, context);
         if (error) throw error;
         values.push(count ?? 0);
       }
@@ -149,6 +169,7 @@ const evaluateQuestDifficulty: FamilyEvaluatorFn = async (
   mode,
   memberPairs,
   criteriaConfig,
+  context,
 ) => {
   const difficulty = (criteriaConfig.difficulty ?? "HARD") as
     | "EASY"
@@ -161,12 +182,13 @@ const evaluateQuestDifficulty: FamilyEvaluatorFn = async (
       .select("*", { count: "exact", head: true })
       .eq("status", "APPROVED")
       .eq("difficulty", difficulty);
-    const { count, error } =
+    const query =
       characterIds.length > 0
-        ? await base.or(
+        ? base.or(
             `assigned_to_id.eq.${userId},volunteered_by.in.(${characterIds.join(",")})`,
           )
-        : await base.eq("assigned_to_id", userId);
+        : base.eq("assigned_to_id", userId);
+    const { count, error } = await applySeasonCutoff(query, context);
     if (error) throw error;
     values.push(count ?? 0);
   }
@@ -180,14 +202,18 @@ const evaluateBossDefeated: FamilyEvaluatorFn = async (
   _characterIds,
   allUserIds,
   mode,
+  _memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const userId of allUserIds) {
-    const { count, error } = await client
+    const query = client
       .from("boss_battle_participants")
       .select("*", { count: "exact", head: true })
       .eq("user_id", userId)
       .eq("participation_status", "APPROVED");
+    const { count, error } = await applySeasonCutoff(query, context);
     if (error) throw error;
     values.push(count ?? 0);
   }
@@ -201,14 +227,18 @@ const evaluateBossParticipated: FamilyEvaluatorFn = async (
   _characterIds,
   allUserIds,
   mode,
+  _memberPairs,
+  _criteriaConfig,
+  context,
 ) => {
   const values: number[] = [];
   for (const userId of allUserIds) {
-    const { count, error } = await client
+    const query = client
       .from("boss_battle_participants")
       .select("*", { count: "exact", head: true })
       .eq("user_id", userId)
       .in("participation_status", ["APPROVED", "PARTIAL"]);
+    const { count, error } = await applySeasonCutoff(query, context);
     if (error) throw error;
     values.push(count ?? 0);
   }

--- a/lib/family-achievement-progress/progress-reader.ts
+++ b/lib/family-achievement-progress/progress-reader.ts
@@ -1,0 +1,51 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database-generated";
+import type { FamilyAchievementProgressRecord } from "./types";
+
+type ReadClient = SupabaseClient<Database>;
+
+export async function getProgressImpl(
+  readClient: ReadClient,
+  familyId: string,
+): Promise<FamilyAchievementProgressRecord[]> {
+  const { data, error } = await readClient
+    .from("family_achievement_progress")
+    .select(
+      `
+      family_id,
+      family_achievement_id,
+      unlocked_at,
+      progress,
+      notified,
+      family_achievements (
+        id,
+        name,
+        description,
+        criteria_type,
+        criteria_config
+      )
+    `,
+    )
+    .eq("family_id", familyId);
+
+  if (error) {
+    throw new Error(`Failed to fetch family progress: ${error.message}`);
+  }
+
+  if (!data) return [];
+
+  return data.map((row) => {
+    const achievement = Array.isArray(row.family_achievements)
+      ? row.family_achievements[0]
+      : row.family_achievements;
+    return {
+      family_id: row.family_id,
+      family_achievement_id: row.family_achievement_id,
+      unlocked_at: row.unlocked_at,
+      progress: row.progress as { current: number; threshold: number } | null,
+      notified: row.notified,
+      family_achievement:
+        achievement as FamilyAchievementProgressRecord["family_achievement"],
+    };
+  });
+}

--- a/lib/family-achievement-progress/service-helpers.ts
+++ b/lib/family-achievement-progress/service-helpers.ts
@@ -4,7 +4,7 @@ import { FAMILY_EVALUATOR_REGISTRY, isCharBased } from "./family-evaluators";
 import type {
   FetchedFamilyAchievement,
   FamilyCriteriaConfig,
-  FamilyAchievementProgressRecord,
+  FamilyAchievementEvaluationContext,
   FamilyMemberPair,
 } from "./types";
 
@@ -25,6 +25,10 @@ export async function recomputeAchievementImpl(
     totalMemberCount: number;
     membersWithCharCount: number;
     memberPairs: FamilyMemberPair[];
+  },
+  evaluationContext: FamilyAchievementEvaluationContext = {
+    seasonId: null,
+    seasonStartedAt: null,
   },
 ): Promise<void> {
   const { data: achievementData, error: achievementError } = await readClient
@@ -73,6 +77,7 @@ export async function recomputeAchievementImpl(
     mode,
     memberPairs,
     config,
+    evaluationContext,
   );
 
   const guardFails =
@@ -87,7 +92,7 @@ export async function recomputeAchievementImpl(
       {
         family_id: familyId,
         family_achievement_id: achievementId,
-        season_id: null,
+        season_id: evaluationContext.seasonId,
         progress: {
           current,
           threshold,
@@ -96,7 +101,7 @@ export async function recomputeAchievementImpl(
         },
       },
       {
-        onConflict: "family_id,family_achievement_id",
+        onConflict: "family_id,family_achievement_id,season_id",
         ignoreDuplicates: false,
       },
     );
@@ -106,12 +111,15 @@ export async function recomputeAchievementImpl(
   }
 
   if (current >= threshold) {
-    const { error: unlockError } = await writeClient
+    let unlockQuery = writeClient
       .from("family_achievement_progress")
       .update({ unlocked_at: new Date().toISOString() })
       .eq("family_id", familyId)
-      .eq("family_achievement_id", achievementId)
-      .is("unlocked_at", null);
+      .eq("family_achievement_id", achievementId);
+    if (evaluationContext.seasonId) {
+      unlockQuery = unlockQuery.eq("season_id", evaluationContext.seasonId);
+    }
+    const { error: unlockError } = await unlockQuery.is("unlocked_at", null);
 
     if (unlockError) {
       console.error(
@@ -120,11 +128,15 @@ export async function recomputeAchievementImpl(
       );
     }
   } else {
-    const { data: progressRow, error: clearError } = await writeClient
+    let clearQuery = writeClient
       .from("family_achievement_progress")
       .update({ unlocked_at: null })
       .eq("family_id", familyId)
-      .eq("family_achievement_id", achievementId)
+      .eq("family_achievement_id", achievementId);
+    if (evaluationContext.seasonId) {
+      clearQuery = clearQuery.eq("season_id", evaluationContext.seasonId);
+    }
+    const { data: progressRow, error: clearError } = await clearQuery
       .select("id")
       .maybeSingle();
 
@@ -158,6 +170,7 @@ export async function recomputeAchievementImpl(
 type ProgressRow = {
   family_id: string;
   family_achievement_id: string;
+  season_id?: string | null;
   progress: { current: number; threshold: number };
 };
 
@@ -167,6 +180,8 @@ export async function evaluateUnlocksImpl(
   familyId: string,
   progressRows: ProgressRow[],
 ): Promise<void> {
+  const seasonId = progressRows[0]?.season_id ?? null;
+
   // ── Unlock path ────────────────────────────────────────────────────────────
   const eligibleRows = progressRows.filter(
     (row) => row.progress.current >= row.progress.threshold,
@@ -175,11 +190,18 @@ export async function evaluateUnlocksImpl(
   if (eligibleRows.length > 0) {
     const achievementIds = eligibleRows.map((row) => row.family_achievement_id);
 
-    const { data: existingProgress, error: fetchError } = await readClient
+    let existingProgressQuery = readClient
       .from("family_achievement_progress")
       .select("family_achievement_id, unlocked_at")
       .eq("family_id", familyId)
       .in("family_achievement_id", achievementIds);
+
+    if (seasonId) {
+      existingProgressQuery = existingProgressQuery.eq("season_id", seasonId);
+    }
+
+    const { data: existingProgress, error: fetchError } =
+      await existingProgressQuery;
 
     if (fetchError) {
       throw new Error(`Failed to check unlock state: ${fetchError.message}`);
@@ -194,12 +216,17 @@ export async function evaluateUnlocksImpl(
     for (const achievementId of achievementIds.filter(
       (id) => !alreadyUnlocked.has(id),
     )) {
-      const { error: unlockError } = await writeClient
+      let unlockQuery = writeClient
         .from("family_achievement_progress")
         .update({ unlocked_at: new Date().toISOString() })
         .eq("family_id", familyId)
-        .eq("family_achievement_id", achievementId)
-        .is("unlocked_at", null);
+        .eq("family_achievement_id", achievementId);
+
+      if (seasonId) {
+        unlockQuery = unlockQuery.eq("season_id", seasonId);
+      }
+
+      const { error: unlockError } = await unlockQuery.is("unlocked_at", null);
 
       if (unlockError) {
         console.error(
@@ -219,11 +246,17 @@ export async function evaluateUnlocksImpl(
   );
 
   for (const row of belowThresholdRows) {
-    const { data: progressRow, error: clearError } = await writeClient
+    let clearQuery = writeClient
       .from("family_achievement_progress")
       .update({ unlocked_at: null })
       .eq("family_id", familyId)
-      .eq("family_achievement_id", row.family_achievement_id)
+      .eq("family_achievement_id", row.family_achievement_id);
+
+    if (seasonId) {
+      clearQuery = clearQuery.eq("season_id", seasonId);
+    }
+
+    const { data: progressRow, error: clearError } = await clearQuery
       .select("id")
       .maybeSingle();
 
@@ -249,52 +282,4 @@ export async function evaluateUnlocksImpl(
       }
     }
   }
-}
-
-// ─── getProgress ─────────────────────────────────────────────────────────────
-
-export async function getProgressImpl(
-  readClient: ReadClient,
-  familyId: string,
-): Promise<FamilyAchievementProgressRecord[]> {
-  const { data, error } = await readClient
-    .from("family_achievement_progress")
-    .select(
-      `
-      family_id,
-      family_achievement_id,
-      unlocked_at,
-      progress,
-      notified,
-      family_achievements (
-        id,
-        name,
-        description,
-        criteria_type,
-        criteria_config
-      )
-    `,
-    )
-    .eq("family_id", familyId);
-
-  if (error) {
-    throw new Error(`Failed to fetch family progress: ${error.message}`);
-  }
-
-  if (!data) return [];
-
-  return data.map((row) => {
-    const achievement = Array.isArray(row.family_achievements)
-      ? row.family_achievements[0]
-      : row.family_achievements;
-    return {
-      family_id: row.family_id,
-      family_achievement_id: row.family_achievement_id,
-      unlocked_at: row.unlocked_at,
-      progress: row.progress as { current: number; threshold: number } | null,
-      notified: row.notified,
-      family_achievement:
-        achievement as FamilyAchievementProgressRecord["family_achievement"],
-    };
-  });
 }

--- a/lib/family-achievement-progress/types.ts
+++ b/lib/family-achievement-progress/types.ts
@@ -21,7 +21,13 @@ export type FamilyEvaluatorFn = (
   mode: "sum" | "all",
   memberPairs: FamilyMemberPair[],
   criteriaConfig: FamilyCriteriaConfig,
+  context?: FamilyAchievementEvaluationContext,
 ) => Promise<{ current: number }>;
+
+export type FamilyAchievementEvaluationContext = {
+  seasonId: string | null;
+  seasonStartedAt: string | null;
+};
 
 export type FamilyCriteriaConfig = {
   threshold?: number;


### PR DESCRIPTION
## Summary
- Resolves active season context before recomputing family achievement progress.
- Scopes family progress reads/writes/unlocks to the active season where applicable.
- Applies `seasonStartedAt` to family stat evaluators so pre-season household activity does not backfill current-season family progress.
- Splits family context and progress reading helpers to keep the service flow focused.

Closes #154

## Test plan
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run test:unit -- --runInBand`
- `npx jest --runInBand lib/__tests__/family-achievement-season-aware.test.ts lib/__tests__/family-achievement-progress-service.integration.test.ts lib/__tests__/family-achievement-progress-service.unlock.test.ts lib/__tests__/family-achievement-progress-service.backfill.test.ts tests/unit/lib/family-achievement-update-progress.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run test:integration -- --runInBand` — expected local-environment failure for 2 Supabase-backed suites because no local Supabase was listening on `127.0.0.1:54321`; remaining 5 suites passed.

## Manual verification notes for Brian
What changed:
- Family achievement evaluation now carries active-season context through the family progress service and evaluator layer.
- Family stat evaluators ignore household activity before the active season `starts_at`.
- Family progress rows are read and updated with the current `season_id` when a season is active.

What to inspect manually:
- Review the new tests in `lib/__tests__/family-achievement-season-aware.test.ts` for the intended season cutoff behavior.
- Inspect `lib/family-achievement-progress-service.ts`, `lib/family-achievement-progress/service-helpers.ts`, and `lib/family-achievement-progress/family-evaluators-stats.ts` for season context plumbing and query scoping.
- Confirm no production Supabase credentials or writes are involved.

Exact local commands to run:
```bash
npm run lint
NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build
NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run test:unit -- --runInBand
npx jest --runInBand lib/__tests__/family-achievement-season-aware.test.ts lib/__tests__/family-achievement-progress-service.integration.test.ts lib/__tests__/family-achievement-progress-service.unlock.test.ts lib/__tests__/family-achievement-progress-service.backfill.test.ts tests/unit/lib/family-achievement-update-progress.test.ts
```

Expected results:
- Lint passes.
- Build passes with dummy Supabase env vars.
- Unit tests pass.
- Focused family achievement season-aware/progress tests pass.

Things that should not visibly change yet:
- No admin reset or reseed behavior is included here; issue #155 remains separate.
- No PR merge is performed by this task.
- GitHub issue #154 may not close until the PR reaches the default branch, so the merge gate should verify and close it manually if needed.
