### PR TITLE
docs: document safe season upgrade workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,73 @@ docker compose up -d
 - **Monitoring** – Supabase Logflare is exposed on `5552`. Pin dashboards or forward logs to your observability stack.
 - **Image updates** – Pull the latest tags listed in `supabase-docker/docker-compose.yml` and rebuild the ChoreQuest app container when Next.js dependencies change.
 
+### Safe season upgrade and start-new-season checklist
+
+> **Do not deploy season-aware achievement evaluation until the seasons migration has been applied and the target family has been started/reset for the new season.** If the app evaluates old quest history before migration + start-season/reset are complete, users may unlock a large batch of historical achievements at once.
+
+Use this checklist when promoting the season-aware achievement changes or starting a fresh achievement season:
+
+1. **Apply the database migration before deployment or admin reset work.**
+   - Local/dev Supabase CLI stack:
+     ```bash
+     npm run db:migrate:local
+     ```
+     This runs `npx supabase db push --local` and applies pending files such as `supabase/migrations/20260326000001_add_seasons.sql` without requiring a linked remote project.
+   - Production/staging: apply the same checked-in migration through your normal Supabase migration process before rebuilding or restarting the app. Do not run ad-hoc production SQL from this README, and do not paste service-role credentials into shell history.
+
+2. **Verify the admin script points at the intended Supabase target.**
+   - `scripts/admin-start-season.ts` loads `.env.local` and `.env`, then uses the service-role Supabase client. Confirm `SUPABASE_INTERNAL_URL`/`SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are for the intended environment before running any apply command.
+   - For local development, `npm run dev` runs `npm run db:preflight:local` first; that preflight applies pending local migrations and verifies the seasons schema against the same admin target.
+
+3. **Discover the family id.**
+   ```bash
+   npx tsx scripts/admin-start-season.ts --list-families
+   ```
+   Copy the desired family UUID from the dry-run discovery output.
+
+4. **Optionally discover users in that family.** Use this only when you want a targeted reset instead of the family-wide path:
+   ```bash
+   npx tsx scripts/admin-start-season.ts --family-id <family-uuid> --list-family-users
+   ```
+
+5. **Dry-run the start-season reset.** Choose exactly one reset-target mode:
+   - Family-wide reset for every character in the family; explicit user ids are not required:
+     ```bash
+     npx tsx scripts/admin-start-season.ts \
+       --family-id <family-uuid> \
+       --name "Season 2" \
+       --starts-at now \
+       --all-users \
+       --dry-run
+     ```
+   - Targeted reset for selected users only:
+     ```bash
+     npx tsx scripts/admin-start-season.ts \
+       --family-id <family-uuid> \
+       --name "Season 2" \
+       --starts-at now \
+       --reset-user <user-uuid> \
+       --reset-user <another-user-uuid> \
+       --dry-run
+     ```
+   The script rejects combining `--all-users` with `--reset-user`/`--user-id`; use either the family-wide path or the targeted path, not both.
+
+6. **Review the audit output before applying.** Confirm the family, new season name, previous active seasons, target characters, and the `gold preserved <before>-><after>` lines are what you expect. The reset clears season-derived state such as XP, level, gems, honor, active family quest, and quest streaks while preserving spendable gold.
+
+7. **Apply only after the dry run is correct.**
+   ```bash
+   npx tsx scripts/admin-start-season.ts \
+     --family-id <family-uuid> \
+     --name "Season 2" \
+     --starts-at now \
+     --all-users \
+     --apply \
+     --confirm-start-season-reset
+   ```
+   Use the targeted `--reset-user ...` form instead of `--all-users` if step 5 used selected users. `--apply` requires `--confirm-start-season-reset`; discovery helpers are dry-run only.
+
+8. **Only then deploy/restart the season-aware app.** After migration + reset are complete, rebuild or restart the app through the normal production deployment process and monitor achievement activity for unexpected unlock bursts.
+
 ## Testing & QA
 - `npm run lint` – ESLint + TypeScript checks.
 - `npm run test` – Unit/integration tests (Jest).


### PR DESCRIPTION
## Summary
- Add README operator checklist for safe season-aware achievement upgrade/start-season flow
- Document migration-first ordering, family discovery, dry-run/apply reset commands, and all-users vs targeted-user modes
- Include a prominent warning about historical achievement unlock bursts if deployment happens before migration + reset

Closes #166

## Manual verification notes for Brian
- Inspected `package.json` scripts: `db:preflight:local`, `db:migrate:local`, `db:reset:local`, `lint`
- Inspected `scripts/admin-start-season.ts` usage and dotenv loading
- Inspected `lib/admin/start-season-reset-cli.ts` for `--list-families`, `--list-family-users`, `--all-users`, `--reset-user`/`--user-id`, discovery dry-run restrictions, and mutual exclusion validation
- Inspected `lib/admin/start-season-reset.ts` for gold preservation and reset behavior
- Verified migration file exists: `supabase/migrations/20260326000001_add_seasons.sql`
- Ran `npm install` to restore dependencies in the fresh worktree after `npm run lint` initially could not find `eslint`; reverted the incidental `package-lock.json` metadata change
- Ran `npm run lint` successfully

## Test plan
- `npm run lint`

Do not merge automatically; this PR is ready for review.