### PR TITLE
chore: prepare v0.8.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.8.0] - 2026-05-24
+
+### Added
+- Achievement system milestone:
+  - Achievement schema, progress tracking, unlock evaluation, notifications, badge display, categories, hidden achievements, and family achievements.
+  - Family-achievement realtime updates and RLS fixes for multi-user households.
+- Seasons foundation for achievement progression:
+  - Seasons data model with active family season support.
+  - Season-aware individual and family achievement evaluation so historical completions do not leak into a new season.
+  - Admin start-season/reset tooling that backfills or starts seasons while preserving existing gold balances.
+- Operator safety documentation for season upgrades and new-season starts, including family/user discovery, migration checks, dry-run usage, and all-users versus selected-user reset guidance.
+- Regression coverage for season backfill, duplicate reward prevention, and season reset behavior.
+
+### Changed
+- Rebalanced seeded achievement progression and rewards around the current family economy: typical daily chores at roughly 10 gold, 100 gold at roughly $10, and harder chores up to roughly 100 gold.
+- Release/version reporting now reads package metadata so the app reports the shipped version consistently.
+- Local development startup now runs a Supabase migration preflight before `next dev`, with explicit local migration/reset scripts for season schema changes.
+- Hardened the v0.8.0 dependency set and reduced npm audit exposure to remaining moderate advisories.
+
+### Verification
+- Unit, lint, build, npm install/lockfile, audit, and GitHub Playwright smoke checks were run across the v0.8.0 preparation PRs.
+- Brian reported local integration tests pass before the v0.8.0 release/version PR.
+
+### Notes
+- This release includes database migrations for achievements and seasons. Follow the safe season upgrade workflow before starting a new family season.
+- Gold balances are intentionally preserved during season resets; achievement progress/rewards are the seasonal reset target.
+
 ## [0.5.0] - 2026-03-07
 
 ### Added

--- a/TASKS.md
+++ b/TASKS.md
@@ -93,15 +93,20 @@ transforms household tasks into epic adventures.
 - [ ] Boss categories (mini-boss, major boss, raid boss)
 - [ ] Loot system with exclusive rewards
 
-### Achievement System
+### Achievement System - COMPLETED for v0.8.0 2026-05-24
 
-- [ ] Achievement definition system
-- [ ] Progress tracking
-- [ ] Achievement notifications
-- [ ] Badge display system
-- [ ] Achievement categories
-- [ ] Hidden achievements
-- [ ] Family achievements
+- [x] Achievement definition system
+- [x] Progress tracking
+- [x] Achievement notifications
+- [x] Badge display system
+- [x] Achievement categories
+- [x] Hidden achievements
+- [x] Family achievements
+- [x] Seasons baseline and active family season support
+- [x] Season-aware individual and family achievement evaluation
+- [x] Admin start-season/reset tooling that preserves existing gold balances
+- [x] Safe season upgrade and start-season operator documentation
+- [x] Season reset regression coverage and seeded achievement economy rebalance
 
 ## Phase 3: Social Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chorequest",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chorequest",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chorequest",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "predev": "npm run db:preflight:local",


### PR DESCRIPTION
## Summary
- Bumps package metadata and lockfile from 0.7.0 to 0.8.0 using the repo npm version workflow.
- Adds v0.8.0 changelog notes covering achievements, seasons, season-aware evaluation, admin start-season/reset, safe-season docs, regression coverage, economy rebalance, and dependency hardening.
- Marks the Phase 2 achievement milestone complete in TASKS.md with the new season/reset release items.

## Verification
- npm ci
- npm run lint
- env-backed npm run build
- env-backed npm run test:unit -- --runInBand (259 suites / 2215 tests passed)

## Notes
- Brian reported local integration tests pass before this release/version PR.
- This PR is release preparation only; do not merge without human review.