### PR TITLE
fix: atomically grant achievement rewards

### DIFF
--- a/lib/__tests__/achievement-progress-service.reward-granting.test.ts
+++ b/lib/__tests__/achievement-progress-service.reward-granting.test.ts
@@ -1,0 +1,189 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeCharAchChain,
+  makeUnlockReadClient,
+  DEFAULT_ACHIEVEMENT,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  function setupRewardTest(rpcReturn: {
+    unlocked_achievement_ids: string[];
+    awarded_xp: number;
+    awarded_gold: number;
+    xp: number | null;
+    gold: number | null;
+    level: number | null;
+  }) {
+    const write = makeWriteMocks({ rpcReturn });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const charChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_id: USER_ID, user_profiles: null },
+            error: null,
+          }),
+        }),
+      }),
+    };
+    return { write, charChain };
+  }
+
+  it("6.6 increments character xp and gold on single unlock", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 50,
+      awarded_gold: 25,
+      xp: 150,
+      gold: 75,
+      level: 2,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([DEFAULT_ACHIEVEMENT]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.6 skips character stats update when total rewards are zero", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: { xp_reward: 0, gold_reward: 0 },
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.7 includes level in update when XP reward triggers level-up", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 60,
+      awarded_gold: 0,
+      xp: 100,
+      gold: 0,
+      level: 1,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achievement = { ...DEFAULT_ACHIEVEMENT, xp_reward: 60, gold_reward: 0 };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([achievement]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(achievement.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [achievement.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
+    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 2 });
+  });
+
+  it("6.7 does not update level when XP reward does not trigger level-up", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 10,
+      awarded_gold: 0,
+      xp: 10,
+      gold: 0,
+      level: 1,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achievement = { ...DEFAULT_ACHIEVEMENT, xp_reward: 10, gold_reward: 0 };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([achievement]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(achievement.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenCalled();
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.6 uses one atomic RPC instead of separate unlock and reward writes", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 50,
+      awarded_gold: 25,
+      xp: 150,
+      gold: 75,
+      level: 2,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([DEFAULT_ACHIEVEMENT]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -23,7 +23,14 @@ const LEVEL_UP_ACHIEVEMENT = {
   xp_reward: 60,
   gold_reward: 0,
 };
-const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+const LEVEL_UP_RPC_RETURN = {
+  unlocked_achievement_ids: [LEVEL_UP_ACHIEVEMENT.id],
+  awarded_xp: 60,
+  awarded_gold: 0,
+  xp: 100,
+  gold: 0,
+  level: 1,
+};
 
 describe("AchievementProgressService - rollback compensation", () => {
   let consoleSpy: jest.SpyInstance;
@@ -53,7 +60,6 @@ describe("AchievementProgressService - rollback compensation", () => {
     // Fix P1: stats rollback uses direct UPDATE (xp: 100-60=40, gold: 0-0=0)
     expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
   });
-
   it("reverts stats and level when cascade upsert fails", async () => {
     const questAch = {
       id: "ach-quest",
@@ -179,7 +185,14 @@ describe("AchievementProgressService - rollback compensation", () => {
     };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [], // no level-up
     });
     mockWriteClient.from.mockImplementation(write.from);

--- a/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
@@ -17,7 +17,14 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
-const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+const LEVEL_UP_RPC_RETURN = {
+  unlocked_achievement_ids: ["ach-quest"],
+  awarded_xp: 60,
+  awarded_gold: 0,
+  xp: 100,
+  gold: 0,
+  level: 1,
+};
 
 describe("AchievementProgressService - rollback consistency on stats failure", () => {
   let consoleSpy: jest.SpyInstance;
@@ -70,7 +77,14 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
     };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
       cascadeUpsertError: "cascade-fail",
       statsRevertError: "concurrent-write",
@@ -169,7 +183,14 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
     };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
     });
     mockWriteClient.from.mockImplementation(write.from);

--- a/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
@@ -29,7 +29,14 @@ const LEVEL_UP_ACHIEVEMENT = {
   gold_reward: 0,
 };
 // RPC returns xp=100, gold=0, level=1 after the +60 xp increment
-const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+const LEVEL_UP_RPC_RETURN = {
+  unlocked_achievement_ids: [LEVEL_UP_ACHIEVEMENT.id],
+  awarded_xp: 60,
+  awarded_gold: 0,
+  xp: 100,
+  gold: 0,
+  level: 1,
+};
 
 function makeQuestLevelAchievements() {
   return {
@@ -179,7 +186,14 @@ describe("AchievementProgressService - rollback guard fixes (P1/P2)", () => {
     const priorProgress = { current: 90, threshold: 100 };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
       cascadeUpsertError: "cascade-fail",
     });

--- a/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
@@ -90,7 +90,14 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     // prevXp=40, award xp=60 → new xp=100 → level 2; cascade unlocks LEVEL_ACH
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
-      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -149,15 +156,22 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Unlock called twice: quest_complete then level cascade
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("7.3 no cascade when XP reward does not trigger level-up", async () => {
     const noLevelUpAch = { ...QUEST_ACH, xp_reward: 10 };
     const write = makeWriteMocks({
       unlockedIds: [noLevelUpAch.id],
-      rpcReturn: { xp: 10, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [noLevelUpAch.id],
+        awarded_xp: 10,
+        awarded_gold: 0,
+        xp: 10,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -179,7 +193,7 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
   });
 
   it("7.3b cascades to unlock compound achievement with level_reached sub-condition after level-up", async () => {
@@ -188,7 +202,14 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     // Compound achievement (quest_complete >= 5 AND level_reached >= 3) should also unlock in cascade.
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id, COMPOUND_ACH.id],
-      rpcReturn: { xp: 260, gold: 0, level: 2 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 260,
+        gold: 0,
+        level: 2,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -247,7 +268,7 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Unlock called twice: quest_complete then compound in cascade
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
@@ -6,12 +6,12 @@ import {
 import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
-  makeCharAchChain,
   makeUnlockReadClient,
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
 } from "./unlock-evaluation-fixtures";
+
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
@@ -31,7 +31,15 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
   });
 
   it("5.5 skips unlock when achievement already has unlocked_at set", async () => {
@@ -46,6 +54,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).not.toHaveBeenCalled();
   });
 
   it("5.5 skips unlock when progress is below threshold", async () => {
@@ -64,6 +73,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).not.toHaveBeenCalled();
   });
 
   it("5.5 unlocks compound achievement when top-level met flag is true", async () => {
@@ -138,6 +148,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(mockWriteClient.rpc).not.toHaveBeenCalled();
   });
 
   it("5.6 IS NULL filter is applied on unlock update for concurrency safety", async () => {
@@ -165,136 +176,5 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(isNull).toHaveBeenCalledWith("unlocked_at", null);
-  });
-});
-
-describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
-  afterEach(() => jest.clearAllMocks());
-
-  function setupRewardTest(rpcReturn: {
-    xp: number;
-    gold: number;
-    level: number;
-  }) {
-    const write = makeWriteMocks({ rpcReturn });
-    mockWriteClient.from.mockImplementation(write.from);
-    mockWriteClient.rpc.mockImplementation(write.rpc);
-    const charChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data: { user_id: USER_ID, user_profiles: null },
-            error: null,
-          }),
-        }),
-      }),
-    };
-    return { write, charChain };
-  }
-
-  it("6.6 increments character xp and gold on single unlock", async () => {
-    // prevXp=100, award (50,25); already level 2 (needs 200 for L3) → new xp=150, no level-up
-    const { write, charChain } = setupRewardTest({
-      xp: 150,
-      gold: 75,
-      level: 2,
-    });
-    const questChain: MockChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    };
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([
-        DEFAULT_ACHIEVEMENT,
-      ]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
-      quest_instances: questChain,
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 50, p_gold: 25 },
-    );
-    expect(write.statsUpdate).not.toHaveBeenCalled();
-  });
-
-  it("6.6 skips character stats update when total rewards are zero", async () => {
-    const write = makeWriteMocks();
-    mockWriteClient.from.mockImplementation(write.from);
-    const readClient = makeUnlockReadClient({
-      questCount: 5,
-      unlockedAt: null,
-      achievement: { xp_reward: 0, gold_reward: 0 },
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.statsUpdate).not.toHaveBeenCalled();
-  });
-
-  it("6.7 includes level in update when XP reward triggers level-up", async () => {
-    // prevXp=40, award xp=60 → new xp=100; 100 >= 50*(2-1)^2=50 → level 2
-    // RPC returns new totals with level still at 1 (level update is separate)
-    const { write, charChain } = setupRewardTest({
-      xp: 100,
-      gold: 0,
-      level: 1,
-    });
-    const questChain: MockChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    };
-    const achievement = {
-      ...DEFAULT_ACHIEVEMENT,
-      xp_reward: 60,
-      gold_reward: 0,
-    };
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([achievement]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(achievement.id, null),
-      quest_instances: questChain,
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 60, p_gold: 0 },
-    );
-    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 2 });
-  });
-
-  it("6.7 does not update level when XP reward does not trigger level-up", async () => {
-    // prevXp=0, award xp=10 → new xp=10 < 50; stays level 1 → no level update
-    const { write, charChain } = setupRewardTest({ xp: 10, gold: 0, level: 1 });
-    const questChain: MockChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    };
-    const achievement = {
-      ...DEFAULT_ACHIEVEMENT,
-      xp_reward: 10,
-      gold_reward: 0,
-    };
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([achievement]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(achievement.id, null),
-      quest_instances: questChain,
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenCalled();
-    expect(write.statsUpdate).not.toHaveBeenCalled();
   });
 });

--- a/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
@@ -55,7 +55,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
   it("8.4 upserts progress, sets unlocked_at, and grants rewards in one call", async () => {
     const write = makeWriteMocks({
       unlockedIds: [BASE_ACH.id],
-      rpcReturn: { xp: 50, gold: 25, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [BASE_ACH.id],
+        awarded_xp: 50,
+        awarded_gold: 25,
+        xp: 50,
+        gold: 25,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -71,10 +78,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
     expect(write.upsert).toHaveBeenCalled();
-    expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
     expect(mockWriteClient.rpc).toHaveBeenCalledWith(
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 50, p_gold: 25 },
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [BASE_ACH.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
     );
   });
 
@@ -82,21 +93,15 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
   it("8.5 unlock evaluation failure is logged and does not cause updateProgress to throw", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const upsert = jest.fn().mockResolvedValue({ error: null });
-    const failUpdate = jest.fn().mockReturnValue({
-      eq: jest.fn().mockReturnValue({
-        in: jest.fn().mockReturnValue({
-          is: jest.fn().mockReturnValue({
-            select: jest.fn().mockResolvedValue({
-              data: null,
-              error: { message: "DB failure" },
-            }),
-          }),
-        }),
-      }),
-    });
     mockWriteClient.from.mockImplementation((t: string) => {
-      if (t === "character_achievements") return { upsert, update: failUpdate };
+      if (t === "character_achievements") return { upsert };
       return { upsert };
+    });
+    mockWriteClient.rpc.mockReturnValue({
+      single: jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: "DB failure" },
+      }),
     });
 
     const readClient = makeReadClient({
@@ -112,6 +117,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     ).resolves.not.toThrow();
 
     expect(upsert).toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [BASE_ACH.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Unlock evaluation failed"),
       expect.anything(),
@@ -124,7 +137,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     // BASE_ACH: xp_reward=50; prevXp=0+50=50 >= 50*(2-1)^2=50 → level 2 on first call
     const write = makeWriteMocks({
       unlockedIds: [BASE_ACH.id],
-      rpcReturn: { xp: 50, gold: 25, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [BASE_ACH.id],
+        awarded_xp: 50,
+        awarded_gold: 25,
+        xp: 50,
+        gold: 25,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -169,9 +189,10 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // First call: unlocks achievement (charAchUpdate once) and updates level (statsUpdate once)
+    // First call: unlocks via atomic RPC and updates level once.
     // Second call: already locked → no update
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledTimes(1);
     expect(write.statsUpdate).toHaveBeenCalledTimes(1);
   });
 

--- a/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
@@ -92,12 +92,17 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("[P2] cascades to unlock compound achievement with xp_earned sub-condition after XP reward (no level-up)", async () => {
-    // xp_reward: 10 — no level-up. Compound with xp_earned >= 10 is NOT met at
-    // initial eval (xp=0) but IS met after XP reward (xp=10).
     const XP_QUEST = { ...QUEST_ACH, id: "ach-xp-quest", xp_reward: 10 };
     const write = makeWriteMocks({
       unlockedIds: [XP_QUEST.id],
-      rpcReturn: { xp: 10, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [XP_QUEST.id],
+        awarded_xp: 10,
+        awarded_gold: 0,
+        xp: 10,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -111,8 +116,6 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
         error: null,
       });
 
-    // n=1 → context, n=2 → initial xp_earned eval (xp=0, not met),
-    // n=3 → cascade xp_earned eval (xp=10, met).
     let charN = 0;
     const charChain = {
       select: jest.fn().mockImplementation(() => {
@@ -173,14 +176,20 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("[P1] does not cascade level_reached achievement when concurrent write loses level race", async () => {
-    // levelSelectRows: [] → no rows updated → levelApplied=false → no cascade.
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
-      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
     });
     mockWriteClient.from.mockImplementation(write.from);
@@ -207,23 +216,22 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Only one unlock: QUEST_ACH. No cascade for LEVEL_ACH since race was lost.
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
-    // Verify the .lt().select() chain was invoked (level update attempted)
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
     expect(write.statsSelect).toHaveBeenCalledTimes(1);
-    // statsSelect resolved with empty data → levelApplied=false
-    await expect(
-      write.statsSelect.mock.results[0].value,
-    ).resolves.toMatchObject({ data: [] });
+    await expect(write.statsSelect.mock.results[0].value).resolves.toMatchObject({ data: [] });
   });
 
   it("[P2] evaluates compound achievement with both xp_earned and level_reached exactly once on XP+level-up", async () => {
-    // DEDUP_COMPOUND_ACH has both sub-condition types. The Set-based dedup
-    // must ensure the compound evaluator runs exactly once even though both
-    // xp and level-up triggers fire.
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
-      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -281,11 +289,8 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Cascade upsert (write.upsert call 2) must contain exactly one row.
     expect(write.upsert).toHaveBeenCalledTimes(2);
-    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{
-      achievement_id: string;
-    }>;
+    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{ achievement_id: string }>;
     expect(cascadeRows).toHaveLength(1);
     expect(cascadeRows[0].achievement_id).toBe(DEDUP_COMPOUND_ACH.id);
   });

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -1,7 +1,3 @@
-/**
- * Shared test fixtures for unlock evaluation tests.
- * Provides compact mock builders to keep test files under the 300-line limit.
- */
 import type { MockChain } from "./achievement-progress-service.fixtures";
 import { makeDataResult } from "./achievement-progress-service.fixtures";
 
@@ -27,40 +23,36 @@ export const DEFAULT_ACHIEVEMENT: UnlockTestAchievement = {
 };
 
 export type WriteMocksOptions = {
-  /** Achievement IDs to return as actually-unlocked from the IS NULL update. */
   unlockedIds?: string[];
-  /** Stats the RPC mock should return after the atomic increment. */
-  rpcReturn?: { xp: number; gold: number; level: number };
-  /** If set, the characters level update resolves with this error message. */
+  rpcReturn?: {
+    unlocked_achievement_ids: string[];
+    awarded_xp: number;
+    awarded_gold: number;
+    xp: number | null;
+    gold: number | null;
+    level: number | null;
+  };
   levelUpdateError?: string;
-  /**
-   * Rows returned from the level UPDATE ... RETURNING select.
-   * Defaults to [{ level: 2 }] (update applied). Pass [] to simulate a
-   * concurrent race where this caller's write was a no-op (levelApplied=false).
-   */
   levelSelectRows?: Array<{ level: number }>;
-  /** If set, the second (cascade) upsert resolves with this error message. */
   cascadeUpsertError?: string;
-  /**
-   * If set, the stats rollback UPDATE resolves with this error message.
-   * (Replaces the old rpcCompensationError now that rollback uses a direct SET.)
-   */
   statsRevertError?: string;
-  /** If true, the stats rollback UPDATE matches zero rows (concurrent write). */
   statsRevertZeroRows?: boolean;
-  /** If set, the unlocked_at revert update resolves with this error message. */
   revertUnlockError?: string;
-  /** If set, the cascade progress revert upsert resolves with this error. */
   cascadeProgressRevertError?: string;
-  /** If set, the phantom-row delete resolves with this error message. */
   cascadeDeleteError?: string;
 };
 
-/** Build mock write client mocks for unlock evaluation tests */
 export function makeWriteMocks(options?: WriteMocksOptions) {
   const {
     unlockedIds = [DEFAULT_ACHIEVEMENT.id],
-    rpcReturn = { xp: 150, gold: 75, level: 1 },
+    rpcReturn = {
+      unlocked_achievement_ids: unlockedIds,
+      awarded_xp: 50,
+      awarded_gold: 25,
+      xp: 150,
+      gold: 75,
+      level: 1,
+    },
     levelUpdateError,
     levelSelectRows,
     cascadeUpsertError,
@@ -168,7 +160,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     return { upsert };
   });
 
-  // RPC: only the forward increment; compensation is now a direct UPDATE (Fix P1)
+  // RPC: atomic unlock + reward grant; compensation is now a direct UPDATE (Fix P1)
   const rpcSingle = jest
     .fn()
     .mockResolvedValue({ data: rpcReturn, error: null });
@@ -199,7 +191,6 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
   };
 }
 
-/** Build charAchChain that returns unlocked_at state on second call */
 export function makeCharAchChain(
   achievementId: string,
   unlockedAt: string | null,
@@ -228,7 +219,6 @@ export function makeCharAchChain(
   };
 }
 
-/** Build read client for simple single-achievement unlock tests */
 export function makeUnlockReadClient(options: {
   questCount?: number;
   unlockedAt?: string | null;

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -68,39 +68,28 @@ export async function runUnlockEvaluation(
 
   if (newlyEligible.length === 0) return;
 
-  const unlockUpdateQuery = writeClient
-    .from("character_achievements")
-    .update({ unlocked_at: new Date().toISOString() })
-    .eq("character_id", characterId)
-    .in(
-      "achievement_id",
-      newlyEligible.map((r) => r.achievement_id),
-    )
-    .is("unlocked_at", null);
-  const { data: actuallyUnlocked, error: unlockError } = seasonId
-    ? await unlockUpdateQuery.eq("season_id", seasonId).select("achievement_id")
-    : await unlockUpdateQuery.select("achievement_id");
+  const candidateAchievementIds = newlyEligible.map((row: UpsertRow) => row.achievement_id);
+  const candidateTotalXp = newlyEligible.reduce((sum: number, row: UpsertRow) => sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0), 0);
+  const candidateTotalGold = newlyEligible.reduce((sum: number, row: UpsertRow) => sum + (achievementMap.get(row.achievement_id)?.gold_reward ?? 0), 0);
 
-  if (unlockError) {
-    throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
+  const lockAchievementsOnly = async () => {
+    const unlockUpdateQuery = writeClient.from("character_achievements").update({ unlocked_at: new Date().toISOString() }).eq("character_id", characterId).in("achievement_id", candidateAchievementIds).is("unlocked_at", null);
+    const { data: actuallyUnlocked, error: unlockError } = seasonId
+      ? await unlockUpdateQuery.eq("season_id", seasonId).select("achievement_id")
+      : await unlockUpdateQuery.select("achievement_id");
+    if (unlockError) throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
+    return (actuallyUnlocked ?? []).map((row: { achievement_id: string }) => row.achievement_id);
+  };
+
+  let lockedIds: string[] = [];
+  let totalXp = 0;
+  let totalGold = 0;
+
+  if (candidateTotalXp === 0 && candidateTotalGold === 0) {
+    lockedIds = await lockAchievementsOnly();
+    if (lockedIds.length === 0) return;
+    return;
   }
-
-  if (!actuallyUnlocked || actuallyUnlocked.length === 0) return;
-
-  const lockedIds = actuallyUnlocked.map((r) => r.achievement_id);
-
-  const totalXp = actuallyUnlocked.reduce(
-    (sum, row) =>
-      sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0),
-    0,
-  );
-  const totalGold = actuallyUnlocked.reduce(
-    (sum, row) =>
-      sum + (achievementMap.get(row.achievement_id)?.gold_reward ?? 0),
-    0,
-  );
-
-  if (totalXp === 0 && totalGold === 0) return;
 
   let statsApplied = false,
     levelApplied = false;
@@ -113,19 +102,29 @@ export async function runUnlockEvaluation(
   }> = [];
   const cascadeRows: UpsertRow[] = [];
   try {
-    const { data: newStats, error: rpcError } = await writeClient
-      .rpc("fn_increment_character_stats", {
+    const { data: atomicUnlock, error: rpcError } = await writeClient
+      .rpc("fn_unlock_achievements_and_grant_rewards", {
         p_character_id: characterId,
-        p_xp: totalXp,
-        p_gold: totalGold,
+        p_achievement_ids: candidateAchievementIds,
+        p_season_id: seasonId,
       })
       .single();
 
-    if (rpcError) {
-      throw new Error(
-        `Failed to increment character stats: ${rpcError.message}`,
-      );
-    }
+    if (rpcError) throw new Error(`Failed to atomically unlock achievements and grant rewards: ${rpcError.message}`);
+
+    lockedIds = atomicUnlock?.unlocked_achievement_ids ?? [];
+    if (lockedIds.length === 0) return;
+
+    totalXp = atomicUnlock?.awarded_xp ?? 0;
+    totalGold = atomicUnlock?.awarded_gold ?? 0;
+    if (totalXp === 0 && totalGold === 0) return;
+
+    const newStats =
+      atomicUnlock?.xp === null || atomicUnlock?.gold === null || atomicUnlock?.level === null
+        ? null
+        : { xp: atomicUnlock.xp, gold: atomicUnlock.gold, level: atomicUnlock.level };
+
+    if (!newStats) throw new Error("Atomic unlock RPC returned unlocked achievements without updated character stats");
 
     statsApplied = true;
     prevLevel = newStats?.level ?? null;

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -1235,6 +1235,21 @@ export type Database = {
         Args: { p_character_id: string; p_xp: number; p_gold: number };
         Returns: { xp: number; gold: number; level: number }[];
       };
+      fn_unlock_achievements_and_grant_rewards: {
+        Args: {
+          p_character_id: string;
+          p_achievement_ids: string[];
+          p_season_id?: string | null;
+        };
+        Returns: {
+          unlocked_achievement_ids: string[];
+          awarded_xp: number;
+          awarded_gold: number;
+          xp: number | null;
+          gold: number | null;
+          level: number | null;
+        }[];
+      };
       fn_change_character_class: {
         Args: { p_character_id: string; p_new_class: string };
         Returns: {

--- a/supabase/migrations/20260604000001_atomic_achievement_unlock_rewards.sql
+++ b/supabase/migrations/20260604000001_atomic_achievement_unlock_rewards.sql
@@ -1,0 +1,56 @@
+-- Atomically mark achievements unlocked and grant their rewards.
+-- This prevents a partial-failure window where unlocked_at is written but the
+-- character never receives the XP/gold payout.
+CREATE OR REPLACE FUNCTION fn_unlock_achievements_and_grant_rewards(
+  p_character_id UUID,
+  p_achievement_ids UUID[],
+  p_season_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  unlocked_achievement_ids UUID[],
+  awarded_xp INTEGER,
+  awarded_gold INTEGER,
+  xp INTEGER,
+  gold INTEGER,
+  level INTEGER
+) AS $$
+  WITH unlocked AS (
+    UPDATE character_achievements
+    SET unlocked_at = NOW()
+    WHERE character_id = p_character_id
+      AND achievement_id = ANY(p_achievement_ids)
+      AND unlocked_at IS NULL
+      AND season_id IS NOT DISTINCT FROM p_season_id
+    RETURNING achievement_id
+  ),
+  reward_totals AS (
+    SELECT
+      COALESCE(SUM(a.xp_reward), 0)::INTEGER AS awarded_xp,
+      COALESCE(SUM(a.gold_reward), 0)::INTEGER AS awarded_gold
+    FROM achievements a
+    INNER JOIN unlocked u ON u.achievement_id = a.id
+  ),
+  stats AS (
+    UPDATE characters
+    SET
+      xp = COALESCE(characters.xp, 0) + reward_totals.awarded_xp,
+      gold = COALESCE(characters.gold, 0) + reward_totals.awarded_gold
+    FROM reward_totals
+    WHERE characters.id = p_character_id
+      AND EXISTS (SELECT 1 FROM unlocked)
+    RETURNING characters.xp, characters.gold, characters.level
+  )
+  SELECT
+    COALESCE(
+      (SELECT array_agg(u.achievement_id ORDER BY u.achievement_id) FROM unlocked u),
+      ARRAY[]::UUID[]
+    ) AS unlocked_achievement_ids,
+    COALESCE((SELECT reward_totals.awarded_xp FROM reward_totals), 0) AS awarded_xp,
+    COALESCE((SELECT reward_totals.awarded_gold FROM reward_totals), 0) AS awarded_gold,
+    (SELECT stats.xp FROM stats) AS xp,
+    (SELECT stats.gold FROM stats) AS gold,
+    (SELECT stats.level FROM stats) AS level;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+REVOKE ALL ON FUNCTION fn_unlock_achievements_and_grant_rewards(UUID, UUID[], UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_unlock_achievements_and_grant_rewards(UUID, UUID[], UUID) TO service_role;

--- a/tests/unit/lib/season-reset-regressions.test.ts
+++ b/tests/unit/lib/season-reset-regressions.test.ts
@@ -129,7 +129,14 @@ function makeIndividualWriteClient() {
     })),
   }));
   const rpcSingle = jest.fn().mockResolvedValue({
-    data: { xp: 10, gold: 5, level: 1 },
+    data: {
+      unlocked_achievement_ids: [ACHIEVEMENT_ID],
+      awarded_xp: 10,
+      awarded_gold: 5,
+      xp: 10,
+      gold: 5,
+      level: 1,
+    },
     error: null,
   });
   const rpc = jest.fn(() => ({ single: rpcSingle }));
@@ -198,13 +205,16 @@ describe("season reset regression coverage", () => {
     await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
     await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
 
-    expect(writeClient.unlockUpdate).toHaveBeenCalledTimes(1);
+    expect(writeClient.unlockUpdate).not.toHaveBeenCalled();
     expect(writeClient.rpc).toHaveBeenCalledTimes(1);
-    expect(writeClient.rpc).toHaveBeenCalledWith("fn_increment_character_stats", {
-      p_character_id: CHARACTER_ID,
-      p_xp: 10,
-      p_gold: 5,
-    });
+    expect(writeClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [ACHIEVEMENT_ID],
+        p_character_id: CHARACTER_ID,
+        p_season_id: SEASON_ID,
+      },
+    );
   });
 
   it.each([


### PR DESCRIPTION
## Summary

Fixes #144 by moving reward-bearing achievement unlocks onto a database RPC so `unlocked_at` and XP/gold rewards are applied atomically instead of as two application-layer writes.

## Changes

- Add Supabase migration `fn_unlock_achievements_and_grant_rewards`.
- Update unlock flow to use the atomic RPC for reward-bearing achievements.
- Preserve direct `unlocked_at` path for zero-reward achievements.
- Update generated database types for the new RPC.
- Split/refresh achievement reward, cascade, integration, and season-reset regression tests.

## Verification

Passed:

```text
git diff --check
npm exec -- eslint lib/achievement-progress/unlock-engine.ts lib/types/database-generated.ts lib/__tests__/unlock-evaluation-fixtures.ts lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts lib/__tests__/achievement-progress-service.reward-granting.test.ts lib/__tests__/achievement-progress-service.unlock-integration.test.ts lib/__tests__/achievement-progress-service.unlock-cascade.test.ts lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts tests/unit/lib/season-reset-regressions.test.ts
npm exec -- jest --runInBand lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts lib/__tests__/achievement-progress-service.reward-granting.test.ts lib/__tests__/achievement-progress-service.unlock-integration.test.ts lib/__tests__/achievement-progress-service.unlock-cascade.test.ts lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts tests/unit/lib/season-reset-regressions.test.ts
```

Focused Jest result: 6 suites / 28 tests passed.

Known unrelated check failure:

```text
npm exec -- tsc --noEmit
components/admin/__tests__/quest-management-tab.fixtures.tsx(142,31): AuthContextType mismatch
```

That failure is outside this PR's touched files and appears pre-existing.

## Documentation / migration impact

- Database migration added; deployment must apply Supabase migrations before relying on the new RPC path.
- No user-facing docs changes.
- No live deployment or service action performed by this card.
