### PR TITLE
docs: refresh landing page development snapshot

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@/tests/utils/test-helpers";
+import Home from "./page";
+
+const mockUseAuth = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe("Home landing page", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ user: null });
+  });
+
+  it("describes the current gameplay systems instead of an old MVP placeholder", () => {
+    render(<Home />);
+
+    expect(
+      screen.getByText(/family quest board for recurring chores, approvals, and co-op play/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/track character classes, personal achievements, family achievements, and reward redemptions/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/run boss battles, guild administration, and season resets with live family updates/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/under construction/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/foundation complete .* phase 1 mvp: in development/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls out the current stack and verification tooling from the repo", () => {
+    render(<Home />);
+
+    expect(screen.getByText(/next\.js 15 \+ react 19/i)).toBeInTheDocument();
+    expect(screen.getByText(/typescript \+ tailwind css 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/supabase auth, postgres, and realtime/i)).toBeInTheDocument();
+    expect(screen.getByText(/jest unit\/integration coverage \+ playwright e2e/i)).toBeInTheDocument();
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,30 +13,87 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
 
+const featureCards = [
+  {
+    icon: Swords,
+    iconClassName: "text-gold-400",
+    title: "Quest Board",
+    description:
+      "Run a family quest board for recurring chores, approvals, and co-op play without losing the RPG feel.",
+  },
+  {
+    icon: Zap,
+    iconClassName: "text-yellow-400",
+    title: "Progression & Rewards",
+    description:
+      "Track character classes, personal achievements, family achievements, and reward redemptions in one loop.",
+  },
+  {
+    icon: Trophy,
+    iconClassName: "text-gold-400",
+    title: "Guild Operations",
+    description:
+      "Run boss battles, guild administration, and season resets with live family updates through Supabase Realtime.",
+  },
+] as const;
+
+const stackFacts = [
+  {
+    icon: Coins,
+    accentClassName: "gold-text",
+    value: "Next.js 15 + React 19",
+    label: "App runtime",
+  },
+  {
+    icon: Zap,
+    accentClassName: "xp-text",
+    value: "TypeScript + Tailwind CSS 4",
+    label: "UI foundation",
+  },
+  {
+    icon: Gem,
+    accentClassName: "gem-text",
+    value: "Supabase Auth, Postgres, and Realtime",
+    label: "Data and live sync",
+  },
+  {
+    icon: Award,
+    accentClassName: "text-primary-400",
+    value: "Jest unit/integration coverage + Playwright E2E",
+    label: "Verification tooling",
+  },
+] as const;
+
+const developmentHighlights = [
+  "Recurring quest templates generate daily and weekly quest instances.",
+  "Reward-store and redemption approval flows are already wired into the family loop.",
+  "Character achievements and family achievements both ship as active gameplay systems.",
+  "Guild-master admin tooling covers roster management, content setup, and season reset operations.",
+] as const;
+
 export default function Home() {
   const { user } = useAuth();
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900">
-      {/* Header */}
       <header className="p-6 text-center border-b border-dark-600">
         <h1 className="text-4xl sm:text-5xl md:text-6xl font-fantasy text-transparent bg-gradient-to-r from-gold-400 to-gold-600 bg-clip-text font-bold">
           ChoreQuest
         </h1>
         <p className="text-base sm:text-lg md:text-xl text-gray-300 mt-2 font-game">
-          Transform Chores into Epic Adventures
+          Family quests, achievements, rewards, and boss battles
         </p>
       </header>
 
-      {/* Hero Section */}
       <main className="container mx-auto px-6 py-12">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-fantasy text-gray-100 mb-6">
             Welcome to Your Family&apos;s Quest Board
           </h2>
-          <p className="text-lg text-gray-400 max-w-2xl mx-auto mb-8">
-            Join the legendary guild where household tasks become heroic quests,
-            family members become mighty heroes, and every chore completed
-            brings honor to your family name.
+          <p className="text-lg text-gray-400 max-w-3xl mx-auto mb-8">
+            ChoreQuest is a cooperative family RPG built around recurring quest
+            boards, character progression, approvals, achievements, rewards,
+            and shared boss-fight goals.
           </p>
           <div className="flex gap-4 justify-center flex-wrap">
             {user ? (
@@ -71,105 +128,55 @@ export default function Home() {
           </div>
         </div>
 
-        {/* Feature Cards */}
         <div className="grid md:grid-cols-3 gap-8 mb-16">
-          <div className="fantasy-card p-6 text-center">
-            <div className="text-4xl mb-4 flex justify-center">
-              <Swords size={48} className="text-gold-400" />
+          {featureCards.map(({ icon: Icon, iconClassName, title, description }) => (
+            <div key={title} className="fantasy-card p-6 text-center">
+              <div className="text-4xl mb-4 flex justify-center">
+                <Icon size={48} className={iconClassName} />
+              </div>
+              <h3 className="text-xl font-fantasy text-gray-100 mb-3">{title}</h3>
+              <p className="text-gray-400">{description}</p>
             </div>
-            <h3 className="text-xl font-fantasy text-gray-100 mb-3">
-              Epic Quests
-            </h3>
-            <p className="text-gray-400">
-              Transform daily chores into heroic adventures. Earn XP and gold
-              for every task completed.
-            </p>
-          </div>
-          <div className="fantasy-card p-6 text-center">
-            <div className="text-4xl mb-4 flex justify-center">
-              <Zap size={48} className="text-yellow-400" />
-            </div>
-            <h3 className="text-xl font-fantasy text-gray-100 mb-3">
-              Character Classes
-            </h3>
-            <p className="text-gray-400">
-              Choose your path: Knight, Mage, Ranger, Rogue, or Healer. Each
-              class offers unique bonuses.
-            </p>
-          </div>
-          <div className="fantasy-card p-6 text-center">
-            <div className="text-4xl mb-4 flex justify-center">
-              <Trophy size={48} className="text-gold-400" />
-            </div>
-            <h3 className="text-xl font-fantasy text-gray-100 mb-3">
-              Boss Battles
-            </h3>
-            <p className="text-gray-400">
-              Unite your family against epic boss challenges. Teamwork brings
-              the greatest rewards.
-            </p>
-          </div>
+          ))}
         </div>
 
-        {/* Stats Display */}
         <div className="fantasy-card p-8 mb-16">
           <h3 className="text-2xl font-fantasy text-gray-100 mb-6 text-center">
-            Heroes&apos; Treasury
+            Current Stack
           </h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
-            <div>
-              <div className="text-3xl gold-text mb-2 flex items-center justify-center gap-2">
-                <Coins size={24} />
-                1,250
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {stackFacts.map(({ icon: Icon, accentClassName, value, label }) => (
+              <div
+                key={value}
+                className="rounded-xl border border-dark-600 bg-dark-800/70 p-5 text-center"
+              >
+                <div
+                  className={`text-xl sm:text-2xl mb-2 flex items-center justify-center gap-2 ${accentClassName}`}
+                >
+                  <Icon size={22} />
+                  <span>{value}</span>
+                </div>
+                <div className="text-sm text-gray-400">{label}</div>
               </div>
-              <div className="text-sm text-gray-400">Gold Earned</div>
-            </div>
-            <div>
-              <div className="text-3xl xp-text mb-2 flex items-center justify-center gap-2">
-                <Zap size={24} />
-                3,450
-              </div>
-              <div className="text-sm text-gray-400">Experience Points</div>
-            </div>
-            <div>
-              <div className="text-3xl gem-text mb-2 flex items-center justify-center gap-2">
-                <Gem size={24} />
-                45
-              </div>
-              <div className="text-sm text-gray-400">Gems Collected</div>
-            </div>
-            <div>
-              <div className="text-3xl text-primary-400 mb-2 flex items-center justify-center gap-2">
-                <Award size={24} />
-                128
-              </div>
-              <div className="text-sm text-gray-400">Honor Points</div>
-            </div>
+            ))}
           </div>
         </div>
 
-        {/* Development Status */}
-        <div className="fantasy-card p-6 text-center">
-          <h3 className="text-xl font-fantasy text-gray-100 mb-3 flex items-center justify-center gap-2">
+        <div className="fantasy-card p-6">
+          <h3 className="text-xl font-fantasy text-gray-100 mb-4 flex items-center justify-center gap-2 text-center">
             <AlertCircle size={24} />
-            Under Construction
+            Current Development Snapshot
             <AlertCircle size={24} />
           </h3>
-          <p className="text-gray-400 mb-4">
-            The great ChoreQuest is being forged by skilled developers. Current
-            progress:
+          <p className="text-gray-400 mb-4 text-center max-w-3xl mx-auto">
+            The landing page now reflects the working systems already present in
+            the repository rather than an old MVP placeholder.
           </p>
-          <div className="max-w-md mx-auto">
-            <div className="bg-dark-700 rounded-full h-4 mb-2">
-              <div
-                className="bg-gradient-to-r from-xp-500 to-xp-600 h-4 rounded-full"
-                style={{ width: "15%" }}
-              ></div>
-            </div>
-            <p className="text-sm text-gray-500">
-              Foundation Complete • Phase 1 MVP: In Development
-            </p>
-          </div>
+          <ul className="max-w-3xl mx-auto space-y-3 text-gray-300 list-disc list-inside">
+            {developmentHighlights.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- replace stale landing-page MVP/construction messaging with copy that reflects the current gameplay systems in the repo
- surface the current stack and verification tooling directly on the public home page
- add a focused landing-page test that guards the refreshed feature and stack copy

## Test Plan
- `npx jest app/page.test.tsx --runInBand`
- `npm run lint`
- `npm run build` (with placeholder Supabase env values supplied from `.env.production.example` because the build expects those runtime variables during static collection)

## Release implications
- no release or deploy impact; public marketing copy only

Closes #173
