### PR TITLE
fix: release develop to main for v0.8.1

### DIFF
--- a/.github/workflows/backmerge-main-to-develop.yml
+++ b/.github/workflows/backmerge-main-to-develop.yml
@@ -1,0 +1,39 @@
+name: Back-merge main into develop
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+concurrency:
+  group: backmerge-develop
+  cancel-in-progress: false
+
+jobs:
+  backmerge:
+    if: github.event.release.target_commitish == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch main and develop
+        run: git fetch origin main develop
+
+      - name: Back-merge main into develop
+        run: |
+          git checkout develop
+          git merge --no-ff origin/main -m "chore: back-merge main into develop after release ${GITHUB_REF_NAME} [skip ci]"
+          git push origin develop

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Start local Supabase
         run: supabase start
 
+      - name: Apply local Supabase migrations
+        run: supabase db push --local
+
       - name: Export Supabase keys to env
         run: |
           STATUS=$(supabase status --output env)
@@ -48,6 +51,11 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run E2E smoke suite
+        env:
+          # `supabase start` above already applies local migrations in CI; skip
+          # the dev-server preflight's redundant `db push` so Playwright does
+          # not fail before the smoke suite on transient local API readiness.
+          CHOREQUEST_SKIP_SUPABASE_PREFLIGHT: "1"
         run: npm run test:e2e
 
       - name: Upload Playwright report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Export Supabase keys to env
+        run: |
+          STATUS=$(supabase status --output env)
+          ANON_KEY=$(echo "$STATUS" | grep '^ANON_KEY=' | cut -d= -f2- | tr -d '"')
+          SERVICE_KEY=$(echo "$STATUS" | grep '^SERVICE_ROLE_KEY=' | cut -d= -f2- | tr -d '"')
+          [ -z "$ANON_KEY" ] && { echo "ERROR: failed to extract ANON_KEY from supabase status"; exit 1; }
+          [ -z "$SERVICE_KEY" ] && { echo "ERROR: failed to extract SERVICE_ROLE_KEY from supabase status"; exit 1; }
+          echo "NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}" >> $GITHUB_ENV
+          echo "SUPABASE_SERVICE_ROLE_KEY=${SERVICE_KEY}" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply local Supabase migrations
+        run: supabase db push --local
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test release pipeline guards
+        run: npm run test:release-pipeline
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,34 @@
+{
+  "branches": [
+    "main"
+  ],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "package.json",
+          "package-lock.json"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/app/api/admin/family-achievements/route.ts
+++ b/app/api/admin/family-achievements/route.ts
@@ -11,6 +11,9 @@ import {
 import { ForbiddenError, ValidationError } from "@/lib/errors";
 import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
 import { ALL_FAMILY_CRITERIA_TYPES } from "@/lib/family-achievement-progress/family-evaluators";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+import { fetchFamilyAchievementProgressForSeason } from "@/lib/family-achievement-progress/season-progress-reader";
+
 /**
  * GET /api/admin/family-achievements
  *
@@ -38,6 +41,7 @@ export async function GET(request: NextRequest) {
     }
 
     const serviceSupabase = createServiceSupabaseClient();
+    const activeSeason = await getActiveSeasonForFamily(serviceSupabase, familyId);
 
     const { data: achievements, error: achError } = await serviceSupabase
       .from("family_achievements")
@@ -53,15 +57,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Fetch progress for display
-    const { data: progress, error: progressError } = await serviceSupabase
-      .from("family_achievement_progress")
-      .select("family_achievement_id, unlocked_at, progress")
-      .eq("family_id", familyId);
-
-    if (progressError) {
-      throw new Error(`Failed to fetch progress: ${progressError.message}`);
-    }
+    const progress = activeSeason
+      ? await (async () => {
+          return fetchFamilyAchievementProgressForSeason(
+            serviceSupabase,
+            familyId,
+            activeSeason.id,
+            "family_achievement_id, unlocked_at, progress",
+          );
+        })()
+      : [];
 
     let progressMap = new Map(
       (progress ?? []).map((p) => [p.family_achievement_id, p]),
@@ -91,23 +96,27 @@ export async function GET(request: NextRequest) {
 
     const familyService = new FamilyAchievementProgressService(serviceSupabase);
     let backfilled = false;
-    try {
-      backfilled = await familyService.backfillIfStale(
-        familyId,
-        hasMissingProgress,
-        storedCounts,
-        storedWithChars,
-        hasLegacyRows,
-      );
-    } catch (err) {
-      console.error("Family achievement backfill failed (admin):", err);
+    if (activeSeason) {
+      try {
+        backfilled = await familyService.backfillIfStale(
+          familyId,
+          hasMissingProgress,
+          storedCounts,
+          storedWithChars,
+          hasLegacyRows,
+        );
+      } catch (err) {
+        console.error("Family achievement backfill failed (admin):", err);
+      }
     }
 
     if (backfilled) {
-      const { data: freshProgress } = await serviceSupabase
-        .from("family_achievement_progress")
-        .select("family_achievement_id, unlocked_at, progress")
-        .eq("family_id", familyId);
+      const freshProgress = await fetchFamilyAchievementProgressForSeason(
+        serviceSupabase,
+        familyId,
+        activeSeason!.id,
+        "family_achievement_id, unlocked_at, progress",
+      );
       progressMap = new Map(
         (freshProgress ?? []).map((p) => [p.family_achievement_id, p]),
       );

--- a/app/api/family-achievements/route.ts
+++ b/app/api/family-achievements/route.ts
@@ -9,6 +9,8 @@ import {
   createServiceSupabaseClient,
 } from "@/lib/supabase-server";
 import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+import { fetchFamilyAchievementProgressForSeason } from "@/lib/family-achievement-progress/season-progress-reader";
 
 /**
  * GET /api/family-achievements
@@ -30,6 +32,7 @@ export async function GET(request: NextRequest) {
     }
 
     const serviceSupabase = createServiceSupabaseClient();
+    const activeSeason = await getActiveSeasonForFamily(serviceSupabase, familyId);
 
     // Fetch family achievements
     const { data: achievements, error: achError } = await serviceSupabase
@@ -46,17 +49,15 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Fetch family achievement progress
-    const { data: progress, error: progressError } = await serviceSupabase
-      .from("family_achievement_progress")
-      .select("family_achievement_id, unlocked_at, progress, notified")
-      .eq("family_id", familyId);
-
-    if (progressError) {
-      throw new Error(
-        `Failed to fetch family achievement progress: ${progressError.message}`,
-      );
-    }
+    const progress = activeSeason
+      ? await (async () => {
+          return fetchFamilyAchievementProgressForSeason(
+            serviceSupabase,
+            familyId,
+            activeSeason.id,
+          );
+        })()
+      : [];
 
     // Build progress lookup
     let progressMap = new Map(
@@ -88,27 +89,34 @@ export async function GET(request: NextRequest) {
     const familyService = new FamilyAchievementProgressService(serviceSupabase);
     let backfilled = false;
     let backfillFailed = false;
-    try {
-      backfilled = await familyService.backfillIfStale(
-        familyId,
-        hasMissingProgress,
-        storedCounts,
-        storedWithChars,
-        hasLegacyRows,
-      );
-    } catch (backfillErr) {
-      console.error("Family achievement backfill failed:", backfillErr);
-      // Fail closed: we cannot verify cached unlock state is still valid after
-      // a potential roster change, so hidden achievements will be redacted below.
-      backfillFailed = true;
+    if (activeSeason) {
+      try {
+        backfilled = await familyService.backfillIfStale(
+          familyId,
+          hasMissingProgress,
+          storedCounts,
+          storedWithChars,
+          hasLegacyRows,
+        );
+      } catch (backfillErr) {
+        console.error("Family achievement backfill failed:", backfillErr);
+        // Fail closed: we cannot verify cached unlock state is still valid after
+        // a potential roster change, so hidden achievements will be redacted below.
+        backfillFailed = true;
+      }
     }
 
     if (backfilled) {
-      const { data: freshProgress, error: refreshError } = await serviceSupabase
-        .from("family_achievement_progress")
-        .select("family_achievement_id, unlocked_at, progress, notified")
-        .eq("family_id", familyId);
-      if (refreshError) {
+      try {
+        const freshProgress = await fetchFamilyAchievementProgressForSeason(
+          serviceSupabase,
+          familyId,
+          activeSeason!.id,
+        );
+        progressMap = new Map(
+          (freshProgress ?? []).map((p) => [p.family_achievement_id, p]),
+        );
+      } catch (refreshError) {
         console.error(
           "Failed to reload progress after backfill:",
           refreshError,
@@ -118,10 +126,6 @@ export async function GET(request: NextRequest) {
         // fresh read.  Treat this as a failed backfill so hidden achievements
         // are redacted below rather than served with stale metadata.
         backfillFailed = true;
-      } else {
-        progressMap = new Map(
-          (freshProgress ?? []).map((p) => [p.family_achievement_id, p]),
-        );
       }
     }
 

--- a/app/api/reward-redemptions/[id]/deny/route.ts
+++ b/app/api/reward-redemptions/[id]/deny/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+import { ConflictError, ForbiddenError, NotFoundError } from "@/lib/errors";
+import { assertValidUuidParam } from "@/lib/api-route-params";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id: redemptionId } = await params;
+    assertValidUuidParam(redemptionId, "redemption", "REDEMPTION_ID_INVALID");
+
+    const token = extractBearerToken(request);
+    const supabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      supabase,
+      token,
+    );
+
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can deny reward redemptions",
+        "DENY_REDEMPTION_FORBIDDEN",
+      );
+    }
+
+    const serviceSupabase = createServiceSupabaseClient();
+
+    const { data: redemption, error: fetchError } = await serviceSupabase
+      .from("reward_redemptions")
+      .select("id, user_id, status, cost")
+      .eq("id", redemptionId)
+      .maybeSingle();
+
+    if (fetchError || !redemption) {
+      throw new NotFoundError("Redemption not found", "REDEMPTION_NOT_FOUND");
+    }
+
+    if (redemption.status !== "PENDING") {
+      throw new ConflictError(
+        "Only pending redemptions can be denied",
+        "REDEMPTION_NOT_PENDING",
+      );
+    }
+
+    if (!redemption.user_id) {
+      throw new ConflictError("Redemption has no user", "REDEMPTION_USER_MISSING");
+    }
+
+    const { data: redemptionProfile } = await serviceSupabase
+      .from("user_profiles")
+      .select("family_id")
+      .eq("id", redemption.user_id)
+      .maybeSingle();
+
+    if (
+      !redemptionProfile ||
+      redemptionProfile.family_id !== requesterProfile.family_id
+    ) {
+      throw new ForbiddenError(
+        "Redemption does not belong to your family",
+        "DENY_REDEMPTION_FORBIDDEN",
+      );
+    }
+
+    const { data, error } = await serviceSupabase.rpc(
+      "fn_deny_reward_redemption",
+      {
+        p_redemption_id: redemptionId,
+        p_user_id: redemption.user_id,
+        p_amount: redemption.cost ?? 0,
+        p_denied_by: requesterProfile.id,
+      },
+    );
+
+    if (error) {
+      const message = error.message ?? "Failed to deny redemption";
+      if (message.includes("REDEMPTION_NOT_PENDING")) {
+        throw new ConflictError(
+          "Only pending redemptions can be denied",
+          "REDEMPTION_NOT_PENDING",
+        );
+      }
+      throw new Error(message);
+    }
+
+    const updated = Array.isArray(data) ? data[0] : data;
+    if (!updated) {
+      throw new Error("Reward denial did not return a row");
+    }
+
+    return NextResponse.json(
+      { success: true, redemption: updated },
+      { status: 200 },
+    );
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/api/reward-redemptions/route.ts
+++ b/app/api/reward-redemptions/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from "@/lib/supabase-server";
+import { ConflictError, NotFoundError, ValidationError } from "@/lib/errors";
+import { assertValidUuidParam } from "@/lib/api-route-params";
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = extractBearerToken(request);
+    const supabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      supabase,
+      token,
+    );
+
+    const body = (await request.json().catch(() => null)) as {
+      rewardId?: unknown;
+    } | null;
+    const rewardId = typeof body?.rewardId === "string" ? body.rewardId : null;
+
+    if (!rewardId) {
+      throw new ValidationError("rewardId is required", "REWARD_ID_REQUIRED");
+    }
+    assertValidUuidParam(rewardId, "reward", "REWARD_ID_INVALID");
+
+    const serviceSupabase = createServiceSupabaseClient();
+    const { data, error } = await serviceSupabase.rpc("fn_redeem_reward", {
+      p_user_id: requesterProfile.id,
+      p_reward_id: rewardId,
+    });
+
+    if (error) {
+      const message = error.message ?? "Failed to redeem reward";
+      if (message.includes("INSUFFICIENT_GOLD")) {
+        throw new ConflictError(
+          "Insufficient gold to redeem this reward",
+          "INSUFFICIENT_GOLD",
+        );
+      }
+      if (
+        message.includes("REWARD_NOT_FOUND_OR_INACTIVE") ||
+        message.includes("CHARACTER_NOT_FOUND")
+      ) {
+        throw new NotFoundError(message, message);
+      }
+      throw new Error(message);
+    }
+
+    const redemption = Array.isArray(data) ? data[0] : data;
+    if (!redemption) {
+      throw new Error("Reward redemption did not return a row");
+    }
+
+    return NextResponse.json({ success: true, redemption }, { status: 201 });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@/tests/utils/test-helpers";
+import Home from "./page";
+
+const mockUseAuth = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe("Home landing page", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ user: null });
+  });
+
+  it("describes the current gameplay systems instead of an old MVP placeholder", () => {
+    render(<Home />);
+
+    expect(
+      screen.getByText(/family quest board for recurring chores, approvals, and co-op play/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/track character classes, personal achievements, family achievements, and reward redemptions/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/run boss battles, guild administration, and season resets with live family updates/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/under construction/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/foundation complete .* phase 1 mvp: in development/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls out the current stack and verification tooling from the repo", () => {
+    render(<Home />);
+
+    expect(screen.getByText(/next\.js 15 \+ react 19/i)).toBeInTheDocument();
+    expect(screen.getByText(/typescript \+ tailwind css 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/supabase auth, postgres, and realtime/i)).toBeInTheDocument();
+    expect(screen.getByText(/jest unit\/integration coverage \+ playwright e2e/i)).toBeInTheDocument();
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,30 +13,87 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
 
+const featureCards = [
+  {
+    icon: Swords,
+    iconClassName: "text-gold-400",
+    title: "Quest Board",
+    description:
+      "Run a family quest board for recurring chores, approvals, and co-op play without losing the RPG feel.",
+  },
+  {
+    icon: Zap,
+    iconClassName: "text-yellow-400",
+    title: "Progression & Rewards",
+    description:
+      "Track character classes, personal achievements, family achievements, and reward redemptions in one loop.",
+  },
+  {
+    icon: Trophy,
+    iconClassName: "text-gold-400",
+    title: "Guild Operations",
+    description:
+      "Run boss battles, guild administration, and season resets with live family updates through Supabase Realtime.",
+  },
+] as const;
+
+const stackFacts = [
+  {
+    icon: Coins,
+    accentClassName: "gold-text",
+    value: "Next.js 15 + React 19",
+    label: "App runtime",
+  },
+  {
+    icon: Zap,
+    accentClassName: "xp-text",
+    value: "TypeScript + Tailwind CSS 4",
+    label: "UI foundation",
+  },
+  {
+    icon: Gem,
+    accentClassName: "gem-text",
+    value: "Supabase Auth, Postgres, and Realtime",
+    label: "Data and live sync",
+  },
+  {
+    icon: Award,
+    accentClassName: "text-primary-400",
+    value: "Jest unit/integration coverage + Playwright E2E",
+    label: "Verification tooling",
+  },
+] as const;
+
+const developmentHighlights = [
+  "Recurring quest templates generate daily and weekly quest instances.",
+  "Reward-store and redemption approval flows are already wired into the family loop.",
+  "Character achievements and family achievements both ship as active gameplay systems.",
+  "Guild-master admin tooling covers roster management, content setup, and season reset operations.",
+] as const;
+
 export default function Home() {
   const { user } = useAuth();
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900">
-      {/* Header */}
       <header className="p-6 text-center border-b border-dark-600">
         <h1 className="text-4xl sm:text-5xl md:text-6xl font-fantasy text-transparent bg-gradient-to-r from-gold-400 to-gold-600 bg-clip-text font-bold">
           ChoreQuest
         </h1>
         <p className="text-base sm:text-lg md:text-xl text-gray-300 mt-2 font-game">
-          Transform Chores into Epic Adventures
+          Family quests, achievements, rewards, and boss battles
         </p>
       </header>
 
-      {/* Hero Section */}
       <main className="container mx-auto px-6 py-12">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-fantasy text-gray-100 mb-6">
             Welcome to Your Family&apos;s Quest Board
           </h2>
-          <p className="text-lg text-gray-400 max-w-2xl mx-auto mb-8">
-            Join the legendary guild where household tasks become heroic quests,
-            family members become mighty heroes, and every chore completed
-            brings honor to your family name.
+          <p className="text-lg text-gray-400 max-w-3xl mx-auto mb-8">
+            ChoreQuest is a cooperative family RPG built around recurring quest
+            boards, character progression, approvals, achievements, rewards,
+            and shared boss-fight goals.
           </p>
           <div className="flex gap-4 justify-center flex-wrap">
             {user ? (
@@ -71,105 +128,55 @@ export default function Home() {
           </div>
         </div>
 
-        {/* Feature Cards */}
         <div className="grid md:grid-cols-3 gap-8 mb-16">
-          <div className="fantasy-card p-6 text-center">
-            <div className="text-4xl mb-4 flex justify-center">
-              <Swords size={48} className="text-gold-400" />
+          {featureCards.map(({ icon: Icon, iconClassName, title, description }) => (
+            <div key={title} className="fantasy-card p-6 text-center">
+              <div className="text-4xl mb-4 flex justify-center">
+                <Icon size={48} className={iconClassName} />
+              </div>
+              <h3 className="text-xl font-fantasy text-gray-100 mb-3">{title}</h3>
+              <p className="text-gray-400">{description}</p>
             </div>
-            <h3 className="text-xl font-fantasy text-gray-100 mb-3">
-              Epic Quests
-            </h3>
-            <p className="text-gray-400">
-              Transform daily chores into heroic adventures. Earn XP and gold
-              for every task completed.
-            </p>
-          </div>
-          <div className="fantasy-card p-6 text-center">
-            <div className="text-4xl mb-4 flex justify-center">
-              <Zap size={48} className="text-yellow-400" />
-            </div>
-            <h3 className="text-xl font-fantasy text-gray-100 mb-3">
-              Character Classes
-            </h3>
-            <p className="text-gray-400">
-              Choose your path: Knight, Mage, Ranger, Rogue, or Healer. Each
-              class offers unique bonuses.
-            </p>
-          </div>
-          <div className="fantasy-card p-6 text-center">
-            <div className="text-4xl mb-4 flex justify-center">
-              <Trophy size={48} className="text-gold-400" />
-            </div>
-            <h3 className="text-xl font-fantasy text-gray-100 mb-3">
-              Boss Battles
-            </h3>
-            <p className="text-gray-400">
-              Unite your family against epic boss challenges. Teamwork brings
-              the greatest rewards.
-            </p>
-          </div>
+          ))}
         </div>
 
-        {/* Stats Display */}
         <div className="fantasy-card p-8 mb-16">
           <h3 className="text-2xl font-fantasy text-gray-100 mb-6 text-center">
-            Heroes&apos; Treasury
+            Current Stack
           </h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
-            <div>
-              <div className="text-3xl gold-text mb-2 flex items-center justify-center gap-2">
-                <Coins size={24} />
-                1,250
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {stackFacts.map(({ icon: Icon, accentClassName, value, label }) => (
+              <div
+                key={value}
+                className="rounded-xl border border-dark-600 bg-dark-800/70 p-5 text-center"
+              >
+                <div
+                  className={`text-xl sm:text-2xl mb-2 flex items-center justify-center gap-2 ${accentClassName}`}
+                >
+                  <Icon size={22} />
+                  <span>{value}</span>
+                </div>
+                <div className="text-sm text-gray-400">{label}</div>
               </div>
-              <div className="text-sm text-gray-400">Gold Earned</div>
-            </div>
-            <div>
-              <div className="text-3xl xp-text mb-2 flex items-center justify-center gap-2">
-                <Zap size={24} />
-                3,450
-              </div>
-              <div className="text-sm text-gray-400">Experience Points</div>
-            </div>
-            <div>
-              <div className="text-3xl gem-text mb-2 flex items-center justify-center gap-2">
-                <Gem size={24} />
-                45
-              </div>
-              <div className="text-sm text-gray-400">Gems Collected</div>
-            </div>
-            <div>
-              <div className="text-3xl text-primary-400 mb-2 flex items-center justify-center gap-2">
-                <Award size={24} />
-                128
-              </div>
-              <div className="text-sm text-gray-400">Honor Points</div>
-            </div>
+            ))}
           </div>
         </div>
 
-        {/* Development Status */}
-        <div className="fantasy-card p-6 text-center">
-          <h3 className="text-xl font-fantasy text-gray-100 mb-3 flex items-center justify-center gap-2">
+        <div className="fantasy-card p-6">
+          <h3 className="text-xl font-fantasy text-gray-100 mb-4 flex items-center justify-center gap-2 text-center">
             <AlertCircle size={24} />
-            Under Construction
+            Current Development Snapshot
             <AlertCircle size={24} />
           </h3>
-          <p className="text-gray-400 mb-4">
-            The great ChoreQuest is being forged by skilled developers. Current
-            progress:
+          <p className="text-gray-400 mb-4 text-center max-w-3xl mx-auto">
+            The landing page now reflects the working systems already present in
+            the repository rather than an old MVP placeholder.
           </p>
-          <div className="max-w-md mx-auto">
-            <div className="bg-dark-700 rounded-full h-4 mb-2">
-              <div
-                className="bg-gradient-to-r from-xp-500 to-xp-600 h-4 rounded-full"
-                style={{ width: "15%" }}
-              ></div>
-            </div>
-            <p className="text-sm text-gray-500">
-              Foundation Complete • Phase 1 MVP: In Development
-            </p>
-          </div>
+          <ul className="max-w-3xl mx-auto space-y-3 text-gray-300 list-disc list-inside">
+            {developmentHighlights.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
         </div>
       </main>
 

--- a/components/admin/__tests__/quest-management-tab.fixtures.tsx
+++ b/components/admin/__tests__/quest-management-tab.fixtures.tsx
@@ -140,7 +140,19 @@ export const setupFamilyMembers = (familyMembers = [createMockFamilyMember()], f
 
 export const setupAuthProfile = (profileOverrides: Partial<UserProfile> = {}) =>
   mockUseAuth.mockReturnValue({
+    user: null,
     profile: createMockFamilyMember(profileOverrides),
+    family: null,
+    session: null,
+    login: jest.fn(),
+    register: jest.fn(),
+    createFamily: jest.fn(),
+    logout: jest.fn(),
+    updatePassword: jest.fn(),
+    isLoading: false,
+    error: null,
+    characterName: "",
+    setCharacterName: jest.fn(),
   });
 
 export const setupQuestData = (quests: QuestInstance[] = [], overrides: Partial<ReturnType<typeof mockUseQuests>> = {}) =>

--- a/components/rewards/reward-manager/useRewardManagerController.ts
+++ b/components/rewards/reward-manager/useRewardManagerController.ts
@@ -196,12 +196,29 @@ export function useRewardManagerController(
         const redemption = redemptions.find((r) => r.id === redemptionId);
         if (!redemption || !redemption.user_id) return;
 
-        const updated = await rewardService.updateRedemptionStatus(
-          redemptionId,
-          "DENIED",
+        const token = await getAuthToken();
+        const response = await fetch(
+          `/api/reward-redemptions/${redemptionId}/deny`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
+          },
         );
-        mergeRedemption(updated);
-        await rewardService.refundGold(redemption.user_id, redemption.cost);
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            (errorData as { error?: string; message?: string }).error ??
+              (errorData as { message?: string }).message ??
+              "Failed to deny redemption",
+          );
+        }
+        const data = (await response.json()) as {
+          redemption: RewardRedemption;
+        };
+        mergeRedemption(data.redemption);
       } catch (err) {
         console.error("Failed to deny redemption:", err);
       }

--- a/components/rewards/reward-store/__tests__/useRewardStoreActions.approve.test.ts
+++ b/components/rewards/reward-store/__tests__/useRewardStoreActions.approve.test.ts
@@ -131,9 +131,11 @@ describe("useRewardStoreActions - APPROVED calls server-side approve route", () 
     );
   });
 
-  it("does NOT call the approve route when status is DENIED", async () => {
-    mockUpdateRedemptionStatus.mockResolvedValue(deniedRow);
-    mockRefundGold.mockResolvedValue(undefined);
+  it("calls the deny route when status is DENIED", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ redemption: deniedRow }),
+    });
     const args = makeArgs();
     const { result } = renderHook(() => useRewardStoreActions(args));
 
@@ -141,7 +143,12 @@ describe("useRewardStoreActions - APPROVED calls server-side approve route", () 
       await result.current.updateRedemptionStatus(pendingRedemption, "DENIED");
     });
 
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/reward-redemptions/${pendingRedemption.id}/deny`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(mockUpdateRedemptionStatus).not.toHaveBeenCalled();
+    expect(mockRefundGold).not.toHaveBeenCalled();
   });
 
   it("does NOT call the approve route when status is FULFILLED", async () => {

--- a/components/rewards/reward-store/__tests__/useRewardStoreActions.test.ts
+++ b/components/rewards/reward-store/__tests__/useRewardStoreActions.test.ts
@@ -122,8 +122,10 @@ describe("useRewardStoreActions - mergeRedemption integration", () => {
   });
 
   it("calls mergeRedemption with updated row after DENIED mutation", async () => {
-    mockUpdateRedemptionStatus.mockResolvedValue(deniedRow);
-    mockRefundGold.mockResolvedValue(undefined);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ redemption: deniedRow }),
+    });
     const args = makeArgs();
     const { result } = renderHook(() => useRewardStoreActions(args));
 
@@ -132,6 +134,8 @@ describe("useRewardStoreActions - mergeRedemption integration", () => {
     });
 
     expect(args.mergeRedemption).toHaveBeenCalledWith(deniedRow);
+    expect(mockUpdateRedemptionStatus).not.toHaveBeenCalled();
+    expect(mockRefundGold).not.toHaveBeenCalled();
   });
 
   it("calls mergeRedemption with updated row after FULFILLED mutation", async () => {

--- a/components/rewards/reward-store/useRewardStoreActions.ts
+++ b/components/rewards/reward-store/useRewardStoreActions.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { supabase } from "@/lib/supabase";
 import { getAuthToken } from "@/lib/utils/get-auth-token";
 import {
   RewardService,
@@ -45,28 +44,24 @@ export function useRewardStoreActions({
       setRedeemingId(reward.id);
 
       try {
-        const { error: redemptionError } = await supabase
-          .from("reward_redemptions")
-          .insert({
-            user_id: userId,
-            reward_id: reward.id,
-            cost: reward.cost,
-            reward_name: reward.name,
-            reward_description: reward.description,
-            reward_type: reward.type,
-            status: "PENDING",
-            notes: null,
-          });
+        const token = await getAuthToken();
+        const response = await fetch("/api/reward-redemptions", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ rewardId: reward.id }),
+        });
 
-        if (redemptionError) throw redemptionError;
-
-        const newGold = (character.gold || 0) - reward.cost;
-        const { error: characterError } = await supabase
-          .from("characters")
-          .update({ gold: newGold })
-          .eq("user_id", userId);
-
-        if (characterError) throw characterError;
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            (errorData as { error?: string; message?: string }).error ??
+              (errorData as { message?: string }).message ??
+              "Failed to redeem reward",
+          );
+        }
 
         await refreshCharacter();
         setRedeemSuccess({ show: true, rewardName: reward.name });
@@ -121,6 +116,31 @@ export function useRewardStoreActions({
             redemption: RewardRedemption;
           };
           mergeRedemption(data.redemption);
+        } else if (status === "DENIED") {
+          const token = await getAuthToken();
+          const response = await fetch(
+            `/api/reward-redemptions/${redemption.id}/deny`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+              },
+            },
+          );
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            throw new Error(
+              (errorData as { error?: string; message?: string }).error ??
+                (errorData as { message?: string }).message ??
+                "Failed to deny redemption",
+            );
+          }
+          const data = (await response.json()) as {
+            redemption: RewardRedemption;
+          };
+          mergeRedemption(data.redemption);
+          await refreshCharacter();
         } else {
           const updated = await rewardService.updateRedemptionStatus(
             redemption.id,
@@ -128,12 +148,6 @@ export function useRewardStoreActions({
             userId ?? undefined,
           );
           mergeRedemption(updated);
-
-          if (status === "DENIED") {
-            const refundAmount = redemption.cost ?? 0;
-            await rewardService.refundGold(redemption.user_id, refundAmount);
-            await refreshCharacter();
-          }
         }
       } catch (error) {
         console.error("Failed to update redemption:", error);

--- a/docs/test-layout-convention.md
+++ b/docs/test-layout-convention.md
@@ -1,0 +1,196 @@
+# Test Layout Convention Audit
+
+Issue: #143
+Status: first-slice audit only — no broad test relocation in this PR
+
+## Decision summary
+
+ChoreQuest should move toward one primary convention for unit and component tests:
+
+- Co-locate unit and component tests next to the source they exercise.
+- Standardize on `.test.ts` / `.test.tsx` filenames.
+- Reserve top-level `tests/` for integration, E2E, setup, and shared helper files.
+- Avoid creating new `__tests__` directories for unit or component coverage.
+
+This document records the current layout, the inconsistencies that matter, and a safe first migration batch for follow-up work.
+
+## Current audit snapshot
+
+Audit date: 2026-06-04
+Audit scope: repository source test files only (`.js/.jsx/.ts/.tsx`), excluding build artifacts and planning docs
+
+### Test inventory counts
+
+| Bucket | Count | Notes |
+| --- | ---: | --- |
+| Co-located `.test.*` files outside `tests/` | 89 | Already aligned with the target direction |
+| Files under `__tests__/` | 110 | Main legacy convention to unwind |
+| Files under `tests/unit/` | 84 | Second major legacy convention |
+| `tests/integration/` | 8 | Should remain top-level |
+| `tests/e2e/` | 5 | Should remain top-level |
+| Top-level setup/helper files under `tests/` | 5 | `tests/jest.setup.js`, `tests/jest.setup.d.ts`, `tests/jest.integration.setup.js`, `tests/jest.integration.setup-after-env.js`, `tests/utils/test-helpers.tsx` |
+| Total source test-like files | 301 | Matches issue triage baseline |
+
+Suffix audit:
+
+- `.test.ts` / `.test.tsx`: 269 files
+- `.spec.*`: 0 source test files found
+
+### Notable current clusters
+
+Largest `__tests__` owners:
+
+| Area | Count |
+| --- | ---: |
+| `lib/__tests__/` | 62 |
+| `components/rewards/reward-store/__tests__/` | 10 |
+| `components/rewards/reward-manager/__tests__/` | 9 |
+| `components/quests/quest-dashboard/__tests__/` | 7 |
+| `components/quests/quest-card/__tests__/` | 6 |
+
+Largest `tests/unit` groups:
+
+| Area | Count |
+| --- | ---: |
+| `tests/unit/app/` | 27 |
+| `tests/unit/lib/` | 19 |
+| `tests/unit/components/` | 18 |
+| `tests/unit/migrations/` | 7 |
+| `tests/unit/statistics/` | 4 |
+
+## Current convention problems
+
+1. Same test type, three locations.
+   - Unit and component tests currently live in co-located files, `__tests__/` directories, and `tests/unit/`.
+   - That makes test discovery inconsistent and forces contributors to guess where new coverage belongs.
+
+2. Mixed conventions inside the same feature area.
+   - `components/quests/quest-card/` already has co-located tests (`index.test.tsx`, `index-actions.test.tsx`) while also keeping related files under `components/quests/quest-card/__tests__/`.
+   - This is the most obvious example of local inconsistency and a good signal for the migration shape.
+
+3. `tests/unit/` is carrying source-adjacent work that belongs beside app code.
+   - Example buckets such as `tests/unit/app/`, `tests/unit/lib/`, and `tests/unit/components/` map directly onto production directories and are better discovered when stored beside those modules.
+
+4. `__tests__/` increases path churn without adding real separation.
+   - Most files under `__tests__/` already use `.test.*` naming, so the extra directory layer is mostly noise.
+   - It also creates awkward imports from nearby co-located tests, such as component-root tests importing fixtures from `./__tests__/...`.
+
+5. The Jest unit config currently has to support both worlds.
+   - `jest.config.js` matches both `<rootDir>/tests/**/*.test.{js,jsx,ts,tsx}` and `<rootDir>/**/*.(test|spec).{js,jsx,ts,tsx}`.
+   - That broad matching is functional, but it reflects the layout sprawl rather than a deliberate testing model.
+
+## Intended steady-state layout
+
+### Keep top-level `tests/`
+
+These should remain top-level because they are cross-cutting or environment-oriented rather than owned by one source module:
+
+- `tests/integration/`
+- `tests/e2e/`
+- Jest setup/bootstrap files:
+  - `tests/jest.setup.js`
+  - `tests/jest.setup.d.ts`
+  - `tests/jest.integration.setup.js`
+  - `tests/jest.integration.setup-after-env.js`
+- Shared test helpers:
+  - `tests/utils/test-helpers.tsx`
+
+### Migrate toward co-location
+
+These groups should move toward co-location over time:
+
+- `tests/unit/app/` → next to `app/` route handlers or route-owned helpers
+- `tests/unit/components/` → next to `components/` modules
+- `tests/unit/lib/` → next to `lib/` modules
+- `hooks/` should continue using co-located `.test.*` files (already the cleanest large cluster)
+- Existing component or library `__tests__/` directories should be flattened into the parent source folder as follow-up work lands
+
+### Naming rule
+
+For unit and component tests:
+
+- Use `*.test.ts` for non-React modules
+- Use `*.test.tsx` for React components/hooks rendering tests
+- Do not introduce new `.spec.*` files
+- Do not introduce new `__tests__/` directories
+
+## Recommended first migration batch
+
+### Batch: `components/quests/quest-card`
+
+Recommended scope for the next implementation PR:
+
+- Move these files out of `components/quests/quest-card/__tests__/` into `components/quests/quest-card/`:
+  - `quest-card.accessibility.test.tsx`
+  - `quest-card.gm.test.tsx`
+  - `quest-card.hero.test.tsx`
+  - `quest-meta.test.tsx`
+  - `quest-card.fixtures.tsx`
+- Leave these already co-located files in place:
+  - `index.test.tsx`
+  - `index-actions.test.tsx`
+  - `quest-card-helpers.test.ts`
+- Explicitly defer `components/quests/quest-card/__tests__/quest-card-helpers.test.ts` to a second batch unless the implementer is prepared to merge or rename coverage in the same PR.
+  - That file collides by name with the existing co-located `components/quests/quest-card/quest-card-helpers.test.ts`.
+  - The two helper-test files cover different behavior today, so a blind move would either overwrite coverage or force an unplanned rename decision.
+  - The canary should document that the first batch reduces the split, but does not fully eliminate the `quest-card/__tests__/` directory.
+
+Estimated migration size:
+
+- 5 moved files
+- 2 existing co-located tests likely need import updates to stop referencing `./__tests__/quest-card.fixtures`
+- 1 deferred duplicate-helper decision (`quest-card-helpers.test.ts`) called out explicitly for the follow-up card
+- Expected follow-up PR touch count: roughly 7-8 files for the canary, with a separate small follow-up needed to merge/rename the duplicate helper coverage
+
+### Why this is the best first slice
+
+1. It is already partially co-located.
+   - The directory already contains three root-level tests, so the target shape is established rather than speculative.
+
+2. It is feature-local and easy to review.
+   - The files all belong to one component cluster instead of a cross-repo sweep.
+
+3. It exercises the main migration mechanics without triggering a mass move.
+   - File relocation
+   - Nearby import rewrites
+   - Jest discovery verification
+
+4. It exposes a real edge case early, without widening the blast radius.
+   - The duplicate `quest-card-helpers.test.ts` name is exactly the sort of collision the broader migration needs documented before larger batches proceed.
+   - Handling that collision explicitly makes the canary honest about what it fixes now versus what still needs a deliberate merge/rename pass.
+
+5. It gives a template for later batches.
+   - If the quest-card cluster moves cleanly, the same pattern can be repeated for `quest-dashboard`, `reward-manager`, and `reward-store`, while reserving duplicate-name cleanup for batches that actually need it.
+
+## Follow-up batch candidates after the canary
+
+After `components/quests/quest-card`, the next most sensible clusters are:
+
+1. `components/quests/quest-dashboard/__tests__/` (7 files)
+2. `components/rewards/reward-manager/__tests__/` (9 files)
+3. `components/rewards/reward-store/__tests__/` (10 files)
+4. Focused `tests/unit/components/` slices that map cleanly to one component family
+5. Focused `tests/unit/lib/` slices that map cleanly to one library module family
+
+The `lib/__tests__/` and `tests/unit/app/` buckets are much larger and should be split into smaller, module-owned batches rather than migrated in one heroic and regrettable gesture.
+
+## Constraints for follow-up implementation PRs
+
+- Do not move `tests/integration/` or `tests/e2e/` into source folders.
+- Do not delete or relocate Jest setup files or shared helpers from top-level `tests/`.
+- Keep migration PRs small enough to verify with focused Jest runs.
+- Prefer batches that are owned by one feature directory and already have obvious source adjacency.
+- Update imports as part of each batch rather than relying on brittle alias hacks.
+
+## Verification expectations for migration PRs
+
+For documentation-only work like this audit:
+
+- No focused Jest run required
+- No `npm run lint` required unless source or script files change
+
+For follow-up migration PRs that actually move tests:
+
+- Run focused Jest on the migrated cluster
+- Run `npm run lint` if source, scripts, or config files change
+- Record any skipped verification explicitly in the PR body or Kanban handoff

--- a/lib/__tests__/achievement-progress-service.reward-granting.test.ts
+++ b/lib/__tests__/achievement-progress-service.reward-granting.test.ts
@@ -1,0 +1,189 @@
+import { AchievementProgressService } from "../achievement-progress-service";
+import {
+  makeReadClient,
+  makeDataResult,
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import {
+  makeWriteMocks,
+  makeCharAchChain,
+  makeUnlockReadClient,
+  DEFAULT_ACHIEVEMENT,
+  CHAR_ID,
+  USER_ID,
+} from "./unlock-evaluation-fixtures";
+
+const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(() => mockWriteClient),
+}));
+
+describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  function setupRewardTest(rpcReturn: {
+    unlocked_achievement_ids: string[];
+    awarded_xp: number;
+    awarded_gold: number;
+    xp: number | null;
+    gold: number | null;
+    level: number | null;
+  }) {
+    const write = makeWriteMocks({ rpcReturn });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    const charChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_id: USER_ID, user_profiles: null },
+            error: null,
+          }),
+        }),
+      }),
+    };
+    return { write, charChain };
+  }
+
+  it("6.6 increments character xp and gold on single unlock", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 50,
+      awarded_gold: 25,
+      xp: 150,
+      gold: 75,
+      level: 2,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([DEFAULT_ACHIEVEMENT]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.6 skips character stats update when total rewards are zero", async () => {
+    const write = makeWriteMocks();
+    mockWriteClient.from.mockImplementation(write.from);
+    const readClient = makeUnlockReadClient({
+      questCount: 5,
+      unlockedAt: null,
+      achievement: { xp_reward: 0, gold_reward: 0 },
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.7 includes level in update when XP reward triggers level-up", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 60,
+      awarded_gold: 0,
+      xp: 100,
+      gold: 0,
+      level: 1,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achievement = { ...DEFAULT_ACHIEVEMENT, xp_reward: 60, gold_reward: 0 };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([achievement]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(achievement.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [achievement.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
+    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 2 });
+  });
+
+  it("6.7 does not update level when XP reward does not trigger level-up", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 10,
+      awarded_gold: 0,
+      xp: 10,
+      gold: 0,
+      level: 1,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const achievement = { ...DEFAULT_ACHIEVEMENT, xp_reward: 10, gold_reward: 0 };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([achievement]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(achievement.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(mockWriteClient.rpc).toHaveBeenCalled();
+    expect(write.statsUpdate).not.toHaveBeenCalled();
+  });
+
+  it("6.6 uses one atomic RPC instead of separate unlock and reward writes", async () => {
+    const { write, charChain } = setupRewardTest({
+      unlocked_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+      awarded_xp: 50,
+      awarded_gold: 25,
+      xp: 150,
+      gold: 75,
+      level: 2,
+    });
+    const questChain: MockChain = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
+      }),
+    };
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([DEFAULT_ACHIEVEMENT]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
+      quest_instances: questChain,
+    });
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -23,7 +23,14 @@ const LEVEL_UP_ACHIEVEMENT = {
   xp_reward: 60,
   gold_reward: 0,
 };
-const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+const LEVEL_UP_RPC_RETURN = {
+  unlocked_achievement_ids: [LEVEL_UP_ACHIEVEMENT.id],
+  awarded_xp: 60,
+  awarded_gold: 0,
+  xp: 100,
+  gold: 0,
+  level: 1,
+};
 
 describe("AchievementProgressService - rollback compensation", () => {
   let consoleSpy: jest.SpyInstance;
@@ -53,7 +60,6 @@ describe("AchievementProgressService - rollback compensation", () => {
     // Fix P1: stats rollback uses direct UPDATE (xp: 100-60=40, gold: 0-0=0)
     expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
   });
-
   it("reverts stats and level when cascade upsert fails", async () => {
     const questAch = {
       id: "ach-quest",
@@ -179,7 +185,14 @@ describe("AchievementProgressService - rollback compensation", () => {
     };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [], // no level-up
     });
     mockWriteClient.from.mockImplementation(write.from);

--- a/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
@@ -17,7 +17,14 @@ jest.mock("@/lib/supabase-server", () => ({
   createServiceSupabaseClient: jest.fn(() => mockWriteClient),
 }));
 
-const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+const LEVEL_UP_RPC_RETURN = {
+  unlocked_achievement_ids: ["ach-quest"],
+  awarded_xp: 60,
+  awarded_gold: 0,
+  xp: 100,
+  gold: 0,
+  level: 1,
+};
 
 describe("AchievementProgressService - rollback consistency on stats failure", () => {
   let consoleSpy: jest.SpyInstance;
@@ -70,7 +77,14 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
     };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
       cascadeUpsertError: "cascade-fail",
       statsRevertError: "concurrent-write",
@@ -169,7 +183,14 @@ describe("AchievementProgressService - rollback consistency on stats failure", (
     };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
     });
     mockWriteClient.from.mockImplementation(write.from);

--- a/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
@@ -29,7 +29,14 @@ const LEVEL_UP_ACHIEVEMENT = {
   gold_reward: 0,
 };
 // RPC returns xp=100, gold=0, level=1 after the +60 xp increment
-const LEVEL_UP_RPC_RETURN = { xp: 100, gold: 0, level: 1 };
+const LEVEL_UP_RPC_RETURN = {
+  unlocked_achievement_ids: [LEVEL_UP_ACHIEVEMENT.id],
+  awarded_xp: 60,
+  awarded_gold: 0,
+  xp: 100,
+  gold: 0,
+  level: 1,
+};
 
 function makeQuestLevelAchievements() {
   return {
@@ -179,7 +186,14 @@ describe("AchievementProgressService - rollback guard fixes (P1/P2)", () => {
     const priorProgress = { current: 90, threshold: 100 };
     const write = makeWriteMocks({
       unlockedIds: [questAch.id],
-      rpcReturn: { xp: 50, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [questAch.id],
+        awarded_xp: 50,
+        awarded_gold: 0,
+        xp: 50,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
       cascadeUpsertError: "cascade-fail",
     });

--- a/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
@@ -90,7 +90,14 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     // prevXp=40, award xp=60 → new xp=100 → level 2; cascade unlocks LEVEL_ACH
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
-      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -149,15 +156,22 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Unlock called twice: quest_complete then level cascade
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("7.3 no cascade when XP reward does not trigger level-up", async () => {
     const noLevelUpAch = { ...QUEST_ACH, xp_reward: 10 };
     const write = makeWriteMocks({
       unlockedIds: [noLevelUpAch.id],
-      rpcReturn: { xp: 10, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [noLevelUpAch.id],
+        awarded_xp: 10,
+        awarded_gold: 0,
+        xp: 10,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -179,7 +193,7 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
   });
 
   it("7.3b cascades to unlock compound achievement with level_reached sub-condition after level-up", async () => {
@@ -188,7 +202,14 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     // Compound achievement (quest_complete >= 5 AND level_reached >= 3) should also unlock in cascade.
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id, COMPOUND_ACH.id],
-      rpcReturn: { xp: 260, gold: 0, level: 2 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 260,
+        gold: 0,
+        level: 2,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -247,7 +268,7 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Unlock called twice: quest_complete then compound in cascade
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
@@ -6,12 +6,12 @@ import {
 import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
-  makeCharAchChain,
   makeUnlockReadClient,
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
 } from "./unlock-evaluation-fixtures";
+
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
@@ -31,7 +31,15 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [DEFAULT_ACHIEVEMENT.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
   });
 
   it("5.5 skips unlock when achievement already has unlocked_at set", async () => {
@@ -46,6 +54,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).not.toHaveBeenCalled();
   });
 
   it("5.5 skips unlock when progress is below threshold", async () => {
@@ -64,6 +73,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).not.toHaveBeenCalled();
   });
 
   it("5.5 unlocks compound achievement when top-level met flag is true", async () => {
@@ -138,6 +148,7 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(mockWriteClient.rpc).not.toHaveBeenCalled();
   });
 
   it("5.6 IS NULL filter is applied on unlock update for concurrency safety", async () => {
@@ -165,136 +176,5 @@ describe("AchievementProgressService - unlock detection (5.5, 5.6)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(isNull).toHaveBeenCalledWith("unlocked_at", null);
-  });
-});
-
-describe("AchievementProgressService - reward granting (6.6, 6.7)", () => {
-  afterEach(() => jest.clearAllMocks());
-
-  function setupRewardTest(rpcReturn: {
-    xp: number;
-    gold: number;
-    level: number;
-  }) {
-    const write = makeWriteMocks({ rpcReturn });
-    mockWriteClient.from.mockImplementation(write.from);
-    mockWriteClient.rpc.mockImplementation(write.rpc);
-    const charChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data: { user_id: USER_ID, user_profiles: null },
-            error: null,
-          }),
-        }),
-      }),
-    };
-    return { write, charChain };
-  }
-
-  it("6.6 increments character xp and gold on single unlock", async () => {
-    // prevXp=100, award (50,25); already level 2 (needs 200 for L3) → new xp=150, no level-up
-    const { write, charChain } = setupRewardTest({
-      xp: 150,
-      gold: 75,
-      level: 2,
-    });
-    const questChain: MockChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    };
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([
-        DEFAULT_ACHIEVEMENT,
-      ]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(DEFAULT_ACHIEVEMENT.id, null),
-      quest_instances: questChain,
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 50, p_gold: 25 },
-    );
-    expect(write.statsUpdate).not.toHaveBeenCalled();
-  });
-
-  it("6.6 skips character stats update when total rewards are zero", async () => {
-    const write = makeWriteMocks();
-    mockWriteClient.from.mockImplementation(write.from);
-    const readClient = makeUnlockReadClient({
-      questCount: 5,
-      unlockedAt: null,
-      achievement: { xp_reward: 0, gold_reward: 0 },
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(write.statsUpdate).not.toHaveBeenCalled();
-  });
-
-  it("6.7 includes level in update when XP reward triggers level-up", async () => {
-    // prevXp=40, award xp=60 → new xp=100; 100 >= 50*(2-1)^2=50 → level 2
-    // RPC returns new totals with level still at 1 (level update is separate)
-    const { write, charChain } = setupRewardTest({
-      xp: 100,
-      gold: 0,
-      level: 1,
-    });
-    const questChain: MockChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    };
-    const achievement = {
-      ...DEFAULT_ACHIEVEMENT,
-      xp_reward: 60,
-      gold_reward: 0,
-    };
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([achievement]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(achievement.id, null),
-      quest_instances: questChain,
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 60, p_gold: 0 },
-    );
-    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 2 });
-  });
-
-  it("6.7 does not update level when XP reward does not trigger level-up", async () => {
-    // prevXp=0, award xp=10 → new xp=10 < 50; stays level 1 → no level update
-    const { write, charChain } = setupRewardTest({ xp: 10, gold: 0, level: 1 });
-    const questChain: MockChain = {
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 5, error: null }),
-        }),
-      }),
-    };
-    const achievement = {
-      ...DEFAULT_ACHIEVEMENT,
-      xp_reward: 10,
-      gold_reward: 0,
-    };
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([achievement]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(achievement.id, null),
-      quest_instances: questChain,
-    });
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    expect(mockWriteClient.rpc).toHaveBeenCalled();
-    expect(write.statsUpdate).not.toHaveBeenCalled();
   });
 });

--- a/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
@@ -55,7 +55,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
   it("8.4 upserts progress, sets unlocked_at, and grants rewards in one call", async () => {
     const write = makeWriteMocks({
       unlockedIds: [BASE_ACH.id],
-      rpcReturn: { xp: 50, gold: 25, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [BASE_ACH.id],
+        awarded_xp: 50,
+        awarded_gold: 25,
+        xp: 50,
+        gold: 25,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -71,10 +78,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
     expect(write.upsert).toHaveBeenCalled();
-    expect(write.charAchUpdate).toHaveBeenCalled();
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
     expect(mockWriteClient.rpc).toHaveBeenCalledWith(
-      "fn_increment_character_stats",
-      { p_character_id: CHAR_ID, p_xp: 50, p_gold: 25 },
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [BASE_ACH.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
     );
   });
 
@@ -82,21 +93,15 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
   it("8.5 unlock evaluation failure is logged and does not cause updateProgress to throw", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const upsert = jest.fn().mockResolvedValue({ error: null });
-    const failUpdate = jest.fn().mockReturnValue({
-      eq: jest.fn().mockReturnValue({
-        in: jest.fn().mockReturnValue({
-          is: jest.fn().mockReturnValue({
-            select: jest.fn().mockResolvedValue({
-              data: null,
-              error: { message: "DB failure" },
-            }),
-          }),
-        }),
-      }),
-    });
     mockWriteClient.from.mockImplementation((t: string) => {
-      if (t === "character_achievements") return { upsert, update: failUpdate };
+      if (t === "character_achievements") return { upsert };
       return { upsert };
+    });
+    mockWriteClient.rpc.mockReturnValue({
+      single: jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: "DB failure" },
+      }),
     });
 
     const readClient = makeReadClient({
@@ -112,6 +117,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     ).resolves.not.toThrow();
 
     expect(upsert).toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [BASE_ACH.id],
+        p_character_id: CHAR_ID,
+        p_season_id: null,
+      },
+    );
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Unlock evaluation failed"),
       expect.anything(),
@@ -124,7 +137,14 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     // BASE_ACH: xp_reward=50; prevXp=0+50=50 >= 50*(2-1)^2=50 → level 2 on first call
     const write = makeWriteMocks({
       unlockedIds: [BASE_ACH.id],
-      rpcReturn: { xp: 50, gold: 25, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [BASE_ACH.id],
+        awarded_xp: 50,
+        awarded_gold: 25,
+        xp: 50,
+        gold: 25,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -169,9 +189,10 @@ describe("AchievementProgressService - integration & idempotency (8.4, 8.5, 9.1,
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // First call: unlocks achievement (charAchUpdate once) and updates level (statsUpdate once)
+    // First call: unlocks via atomic RPC and updates level once.
     // Second call: already locked → no update
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    expect(write.charAchUpdate).not.toHaveBeenCalled();
+    expect(mockWriteClient.rpc).toHaveBeenCalledTimes(1);
     expect(write.statsUpdate).toHaveBeenCalledTimes(1);
   });
 

--- a/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
@@ -92,12 +92,17 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("[P2] cascades to unlock compound achievement with xp_earned sub-condition after XP reward (no level-up)", async () => {
-    // xp_reward: 10 — no level-up. Compound with xp_earned >= 10 is NOT met at
-    // initial eval (xp=0) but IS met after XP reward (xp=10).
     const XP_QUEST = { ...QUEST_ACH, id: "ach-xp-quest", xp_reward: 10 };
     const write = makeWriteMocks({
       unlockedIds: [XP_QUEST.id],
-      rpcReturn: { xp: 10, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [XP_QUEST.id],
+        awarded_xp: 10,
+        awarded_gold: 0,
+        xp: 10,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -111,8 +116,6 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
         error: null,
       });
 
-    // n=1 → context, n=2 → initial xp_earned eval (xp=0, not met),
-    // n=3 → cascade xp_earned eval (xp=10, met).
     let charN = 0;
     const charChain = {
       select: jest.fn().mockImplementation(() => {
@@ -173,14 +176,20 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(2);
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("[P1] does not cascade level_reached achievement when concurrent write loses level race", async () => {
-    // levelSelectRows: [] → no rows updated → levelApplied=false → no cascade.
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
-      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
       levelSelectRows: [],
     });
     mockWriteClient.from.mockImplementation(write.from);
@@ -207,23 +216,22 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Only one unlock: QUEST_ACH. No cascade for LEVEL_ACH since race was lost.
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
-    // Verify the .lt().select() chain was invoked (level update attempted)
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
     expect(write.statsSelect).toHaveBeenCalledTimes(1);
-    // statsSelect resolved with empty data → levelApplied=false
-    await expect(
-      write.statsSelect.mock.results[0].value,
-    ).resolves.toMatchObject({ data: [] });
+    await expect(write.statsSelect.mock.results[0].value).resolves.toMatchObject({ data: [] });
   });
 
   it("[P2] evaluates compound achievement with both xp_earned and level_reached exactly once on XP+level-up", async () => {
-    // DEDUP_COMPOUND_ACH has both sub-condition types. The Set-based dedup
-    // must ensure the compound evaluator runs exactly once even though both
-    // xp and level-up triggers fire.
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
-      rpcReturn: { xp: 100, gold: 0, level: 1 },
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
@@ -281,11 +289,8 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Cascade upsert (write.upsert call 2) must contain exactly one row.
     expect(write.upsert).toHaveBeenCalledTimes(2);
-    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{
-      achievement_id: string;
-    }>;
+    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{ achievement_id: string }>;
     expect(cascadeRows).toHaveLength(1);
     expect(cascadeRows[0].achievement_id).toBe(DEDUP_COMPOUND_ACH.id);
   });

--- a/lib/__tests__/approve-quest-achievement-integration.test.ts
+++ b/lib/__tests__/approve-quest-achievement-integration.test.ts
@@ -9,9 +9,12 @@ jest.mock("@/lib/achievement-progress-service", () => ({
   })),
 }));
 
-// Mock the service-role client used internally by AchievementProgressService
+// Mock the service-role client used internally by reward mutations and AchievementProgressService
 jest.mock("@/lib/supabase-server", () => ({
-  createServiceSupabaseClient: jest.fn(() => ({ from: jest.fn() })),
+  createServiceSupabaseClient: jest.fn(() => ({
+    from: jest.fn(),
+    rpc: jest.fn().mockResolvedValue({ data: null, error: null }),
+  })),
 }));
 
 const CHARACTER_ID = "char-approve-001";
@@ -158,8 +161,9 @@ describe("approveQuest - achievement progress integration (task 9.1)", () => {
 
   it("calls updateProgress with QUEST_APPROVED after character stats update", async () => {
     const from = makeFromMock();
+    const rpc = jest.fn().mockResolvedValue({ data: null, error: null });
     const deps = {
-      client: { from } as never,
+      client: { from, rpc } as never,
       streakService: makeStreakService(),
     };
 
@@ -175,8 +179,9 @@ describe("approveQuest - achievement progress integration (task 9.1)", () => {
     mockUpdateProgress.mockRejectedValueOnce(new Error("Progress DB error"));
 
     const from = makeFromMock();
+    const rpc = jest.fn().mockResolvedValue({ data: null, error: null });
     const deps = {
-      client: { from } as never,
+      client: { from, rpc } as never,
       streakService: makeStreakService(),
     };
 
@@ -193,8 +198,9 @@ describe("approveQuest - achievement progress integration (task 9.1)", () => {
     mockUpdateProgress.mockRejectedValueOnce(new Error("Progress error"));
 
     const from = makeFromMock();
+    const rpc = jest.fn().mockResolvedValue({ data: null, error: null });
     const deps = {
-      client: { from } as never,
+      client: { from, rpc } as never,
       streakService: makeStreakService(),
     };
 

--- a/lib/__tests__/family-achievement-progress-service.fixtures.ts
+++ b/lib/__tests__/family-achievement-progress-service.fixtures.ts
@@ -68,10 +68,13 @@ export function makeUpdateResult(error: null | { message: string } = null) {
     .fn()
     .mockResolvedValue({ data: null, error: null });
   const selectFn = jest.fn().mockReturnValue({ maybeSingle: maybeSingleFn });
-  const eq2 = jest.fn().mockReturnValue({ is: isFn, select: selectFn });
-  const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+  const chain: MockChain = {
+    eq: jest.fn(() => chain),
+    is: isFn,
+    select: selectFn,
+  };
   return {
-    update: jest.fn().mockReturnValue({ eq: eq1 }),
+    update: jest.fn().mockReturnValue(chain),
   };
 }
 
@@ -79,6 +82,46 @@ export const FAMILY_ID = "family-001";
 export const USER_IDS = ["user-001", "user-002"];
 export const CHARACTER_IDS = ["char-001", "char-002"];
 export const FAMILY_ACHIEVEMENT_ID = "fach-001";
+export const ACTIVE_SEASON_ID = "season-current";
+export const ACTIVE_SEASON = {
+  id: ACTIVE_SEASON_ID,
+  family_id: FAMILY_ID,
+  name: "Current Season",
+  theme: null,
+  starts_at: "2026-01-01T00:00:00.000Z",
+  ends_at: null,
+};
+
+export function makeActiveSeasonOverrides(): Record<string, MockChain> {
+  const activeSeasonFamilies = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: { active_season_id: ACTIVE_SEASON_ID },
+          error: null,
+        }),
+      }),
+    }),
+  };
+
+  const activeSeasonSeasons = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: ACTIVE_SEASON,
+            error: null,
+          }),
+        }),
+      }),
+    }),
+  };
+
+  return {
+    families: activeSeasonFamilies,
+    seasons: activeSeasonSeasons,
+  };
+}
 
 export function makeReadClient(overrides?: Record<string, MockChain>) {
   const noActiveSeasonFamilies = {

--- a/lib/__tests__/family-achievement-progress-service.idempotent.test.ts
+++ b/lib/__tests__/family-achievement-progress-service.idempotent.test.ts
@@ -5,6 +5,7 @@ import {
   makeUpsertResult,
   makeUpdateResult,
   makeReadClient,
+  makeActiveSeasonOverrides,
   FAMILY_ID,
   FAMILY_ACHIEVEMENT_ID,
 } from "./family-achievement-progress-service.fixtures";
@@ -42,15 +43,19 @@ describe("FamilyAchievementProgressService — idempotent progress", () => {
       { family_achievement_id: FAMILY_ACHIEVEMENT_ID },
     ]);
 
+    const questSeasonQuery = Object.assign(Promise.resolve({ count: 7, error: null }), {
+      gte: jest.fn().mockResolvedValue({ count: 7, error: null }),
+    });
     const questChain: MockChain = {
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
-          or: jest.fn().mockResolvedValue({ count: 7, error: null }),
+          or: jest.fn().mockReturnValue(questSeasonQuery),
         }),
       }),
     };
 
     const readClient = makeReadClient({
+      ...makeActiveSeasonOverrides(),
       user_profiles: profilesChain as unknown as MockChain,
       family_achievements: famAchChain as unknown as MockChain,
       family_achievement_progress: famProgressChain as unknown as MockChain,
@@ -104,6 +109,7 @@ describe("FamilyAchievementProgressService — idempotent progress", () => {
     ]);
 
     const readClient = makeReadClient({
+      ...makeActiveSeasonOverrides(),
       user_profiles: profilesChain as unknown as MockChain,
       family_achievements: famAchChain as unknown as MockChain,
       family_achievement_progress: famProgressChain as unknown as MockChain,
@@ -123,6 +129,36 @@ describe("FamilyAchievementProgressService — idempotent progress", () => {
     expect(writeUpsert.upsert).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+
+  it("does not write progress when no active season exists", async () => {
+    const profilesChain = makeDataResult([
+      { id: "user-001", characters: [{ id: "char-001" }] },
+    ]);
+
+    const famAchChain = makeDataResult([
+      {
+        id: FAMILY_ACHIEVEMENT_ID,
+        name: "Test",
+        criteria_type: "quest_complete",
+        criteria_config: { threshold: 10, family_evaluation_mode: "sum" },
+        xp_reward: 0,
+        gold_reward: 0,
+      },
+    ]);
+
+    const readClient = makeReadClient({
+      user_profiles: profilesChain as unknown as MockChain,
+      family_achievements: famAchChain as unknown as MockChain,
+    });
+
+    const writeUpsert = makeUpsertResult();
+    mockWriteClient.from.mockReturnValue(writeUpsert);
+
+    const service = new FamilyAchievementProgressService(readClient as never);
+    await service.updateProgress(FAMILY_ID, { type: "QUEST_APPROVED" });
+
+    expect(writeUpsert.upsert).not.toHaveBeenCalled();
   });
 
   it("returns empty array for getProgress when no progress exists", async () => {

--- a/lib/__tests__/quest-instance-service-approve.test.ts
+++ b/lib/__tests__/quest-instance-service-approve.test.ts
@@ -1,6 +1,16 @@
 import { QuestInstanceService } from "../quest-instance-service";
 import { StreakService } from "../streak-service";
 import { supabase } from "../supabase";
+import { createServiceSupabaseClient } from "@/lib/supabase-server";
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(),
+}));
+
+const mockCreateServiceSupabaseClient =
+  createServiceSupabaseClient as jest.MockedFunction<
+    typeof createServiceSupabaseClient
+  >;
 
 describe("QuestInstanceService - approveQuest", () => {
   it("throws app error when quest fetch fails", async () => {
@@ -201,7 +211,15 @@ describe("QuestInstanceService - approveQuest", () => {
       throw new Error(`Unexpected table: ${table}`);
     });
 
-    const supabaseStub = { from: fromMock };
+    const userScopedRpcMock = jest.fn();
+    const serviceScopedRpcMock = jest
+      .fn()
+      .mockResolvedValue({ data: null, error: null });
+    mockCreateServiceSupabaseClient.mockReturnValue({
+      from: jest.fn(),
+      rpc: serviceScopedRpcMock,
+    } as never);
+    const supabaseStub = { from: fromMock, rpc: userScopedRpcMock };
 
     const streakServiceMock = {
       getStreak: jest.fn().mockResolvedValue({
@@ -239,14 +257,15 @@ describe("QuestInstanceService - approveQuest", () => {
     expect(streakServiceMock.incrementStreak).toHaveBeenCalled();
     expect(streakServiceMock.resetStreak).not.toHaveBeenCalled();
 
-    const [characterUpdatePayload] =
-      characterUpdateBuilder.update.mock.calls[0];
-    expect(characterUpdatePayload).toEqual({
-      gold: 72,
-      xp: 120,
-      active_family_quest_id: null,
-      level: 2,
+    expect(userScopedRpcMock).not.toHaveBeenCalled();
+    expect(serviceScopedRpcMock).toHaveBeenCalledWith("fn_apply_quest_reward", {
+      p_character_id: characterId,
+      p_quest_id: questId,
+      p_user_id: userId,
+      p_xp: 120,
+      p_gold: 72,
     });
+    expect(characterUpdateBuilder.update).not.toHaveBeenCalled();
 
     const [questUpdatePayload] = questUpdateBuilder.update.mock.calls[0];
     expect(questUpdatePayload.status).toBe("APPROVED");

--- a/lib/__tests__/unlock-evaluation-fixtures.ts
+++ b/lib/__tests__/unlock-evaluation-fixtures.ts
@@ -1,7 +1,3 @@
-/**
- * Shared test fixtures for unlock evaluation tests.
- * Provides compact mock builders to keep test files under the 300-line limit.
- */
 import type { MockChain } from "./achievement-progress-service.fixtures";
 import { makeDataResult } from "./achievement-progress-service.fixtures";
 
@@ -27,40 +23,36 @@ export const DEFAULT_ACHIEVEMENT: UnlockTestAchievement = {
 };
 
 export type WriteMocksOptions = {
-  /** Achievement IDs to return as actually-unlocked from the IS NULL update. */
   unlockedIds?: string[];
-  /** Stats the RPC mock should return after the atomic increment. */
-  rpcReturn?: { xp: number; gold: number; level: number };
-  /** If set, the characters level update resolves with this error message. */
+  rpcReturn?: {
+    unlocked_achievement_ids: string[];
+    awarded_xp: number;
+    awarded_gold: number;
+    xp: number | null;
+    gold: number | null;
+    level: number | null;
+  };
   levelUpdateError?: string;
-  /**
-   * Rows returned from the level UPDATE ... RETURNING select.
-   * Defaults to [{ level: 2 }] (update applied). Pass [] to simulate a
-   * concurrent race where this caller's write was a no-op (levelApplied=false).
-   */
   levelSelectRows?: Array<{ level: number }>;
-  /** If set, the second (cascade) upsert resolves with this error message. */
   cascadeUpsertError?: string;
-  /**
-   * If set, the stats rollback UPDATE resolves with this error message.
-   * (Replaces the old rpcCompensationError now that rollback uses a direct SET.)
-   */
   statsRevertError?: string;
-  /** If true, the stats rollback UPDATE matches zero rows (concurrent write). */
   statsRevertZeroRows?: boolean;
-  /** If set, the unlocked_at revert update resolves with this error message. */
   revertUnlockError?: string;
-  /** If set, the cascade progress revert upsert resolves with this error. */
   cascadeProgressRevertError?: string;
-  /** If set, the phantom-row delete resolves with this error message. */
   cascadeDeleteError?: string;
 };
 
-/** Build mock write client mocks for unlock evaluation tests */
 export function makeWriteMocks(options?: WriteMocksOptions) {
   const {
     unlockedIds = [DEFAULT_ACHIEVEMENT.id],
-    rpcReturn = { xp: 150, gold: 75, level: 1 },
+    rpcReturn = {
+      unlocked_achievement_ids: unlockedIds,
+      awarded_xp: 50,
+      awarded_gold: 25,
+      xp: 150,
+      gold: 75,
+      level: 1,
+    },
     levelUpdateError,
     levelSelectRows,
     cascadeUpsertError,
@@ -168,7 +160,7 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
     return { upsert };
   });
 
-  // RPC: only the forward increment; compensation is now a direct UPDATE (Fix P1)
+  // RPC: atomic unlock + reward grant; compensation is now a direct UPDATE (Fix P1)
   const rpcSingle = jest
     .fn()
     .mockResolvedValue({ data: rpcReturn, error: null });
@@ -199,7 +191,6 @@ export function makeWriteMocks(options?: WriteMocksOptions) {
   };
 }
 
-/** Build charAchChain that returns unlocked_at state on second call */
 export function makeCharAchChain(
   achievementId: string,
   unlockedAt: string | null,
@@ -228,7 +219,6 @@ export function makeCharAchChain(
   };
 }
 
-/** Build read client for simple single-achievement unlock tests */
 export function makeUnlockReadClient(options: {
   questCount?: number;
   unlockedAt?: string | null;

--- a/lib/achievement-progress/unlock-engine.ts
+++ b/lib/achievement-progress/unlock-engine.ts
@@ -68,39 +68,28 @@ export async function runUnlockEvaluation(
 
   if (newlyEligible.length === 0) return;
 
-  const unlockUpdateQuery = writeClient
-    .from("character_achievements")
-    .update({ unlocked_at: new Date().toISOString() })
-    .eq("character_id", characterId)
-    .in(
-      "achievement_id",
-      newlyEligible.map((r) => r.achievement_id),
-    )
-    .is("unlocked_at", null);
-  const { data: actuallyUnlocked, error: unlockError } = seasonId
-    ? await unlockUpdateQuery.eq("season_id", seasonId).select("achievement_id")
-    : await unlockUpdateQuery.select("achievement_id");
+  const candidateAchievementIds = newlyEligible.map((row: UpsertRow) => row.achievement_id);
+  const candidateTotalXp = newlyEligible.reduce((sum: number, row: UpsertRow) => sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0), 0);
+  const candidateTotalGold = newlyEligible.reduce((sum: number, row: UpsertRow) => sum + (achievementMap.get(row.achievement_id)?.gold_reward ?? 0), 0);
 
-  if (unlockError) {
-    throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
+  const lockAchievementsOnly = async () => {
+    const unlockUpdateQuery = writeClient.from("character_achievements").update({ unlocked_at: new Date().toISOString() }).eq("character_id", characterId).in("achievement_id", candidateAchievementIds).is("unlocked_at", null);
+    const { data: actuallyUnlocked, error: unlockError } = seasonId
+      ? await unlockUpdateQuery.eq("season_id", seasonId).select("achievement_id")
+      : await unlockUpdateQuery.select("achievement_id");
+    if (unlockError) throw new Error(`Failed to set unlocked_at: ${unlockError.message}`);
+    return (actuallyUnlocked ?? []).map((row: { achievement_id: string }) => row.achievement_id);
+  };
+
+  let lockedIds: string[] = [];
+  let totalXp = 0;
+  let totalGold = 0;
+
+  if (candidateTotalXp === 0 && candidateTotalGold === 0) {
+    lockedIds = await lockAchievementsOnly();
+    if (lockedIds.length === 0) return;
+    return;
   }
-
-  if (!actuallyUnlocked || actuallyUnlocked.length === 0) return;
-
-  const lockedIds = actuallyUnlocked.map((r) => r.achievement_id);
-
-  const totalXp = actuallyUnlocked.reduce(
-    (sum, row) =>
-      sum + (achievementMap.get(row.achievement_id)?.xp_reward ?? 0),
-    0,
-  );
-  const totalGold = actuallyUnlocked.reduce(
-    (sum, row) =>
-      sum + (achievementMap.get(row.achievement_id)?.gold_reward ?? 0),
-    0,
-  );
-
-  if (totalXp === 0 && totalGold === 0) return;
 
   let statsApplied = false,
     levelApplied = false;
@@ -113,19 +102,29 @@ export async function runUnlockEvaluation(
   }> = [];
   const cascadeRows: UpsertRow[] = [];
   try {
-    const { data: newStats, error: rpcError } = await writeClient
-      .rpc("fn_increment_character_stats", {
+    const { data: atomicUnlock, error: rpcError } = await writeClient
+      .rpc("fn_unlock_achievements_and_grant_rewards", {
         p_character_id: characterId,
-        p_xp: totalXp,
-        p_gold: totalGold,
+        p_achievement_ids: candidateAchievementIds,
+        p_season_id: seasonId,
       })
       .single();
 
-    if (rpcError) {
-      throw new Error(
-        `Failed to increment character stats: ${rpcError.message}`,
-      );
-    }
+    if (rpcError) throw new Error(`Failed to atomically unlock achievements and grant rewards: ${rpcError.message}`);
+
+    lockedIds = atomicUnlock?.unlocked_achievement_ids ?? [];
+    if (lockedIds.length === 0) return;
+
+    totalXp = atomicUnlock?.awarded_xp ?? 0;
+    totalGold = atomicUnlock?.awarded_gold ?? 0;
+    if (totalXp === 0 && totalGold === 0) return;
+
+    const newStats =
+      atomicUnlock?.xp === null || atomicUnlock?.gold === null || atomicUnlock?.level === null
+        ? null
+        : { xp: atomicUnlock.xp, gold: atomicUnlock.gold, level: atomicUnlock.level };
+
+    if (!newStats) throw new Error("Atomic unlock RPC returned unlocked achievements without updated character stats");
 
     statsApplied = true;
     prevLevel = newStats?.level ?? null;

--- a/lib/family-achievement-progress-service.ts
+++ b/lib/family-achievement-progress-service.ts
@@ -63,14 +63,17 @@ export class FamilyAchievementProgressService {
     familyId: string,
     seasonId: string | null,
   ): Promise<Set<string>> {
-    const query = this.readClient
+    const familyScopedQuery = this.readClient
       .from("family_achievement_progress")
       .select("family_achievement_id")
       .eq("family_id", familyId);
 
-    const { data, error } = seasonId
-      ? await query.eq("season_id", seasonId)
-      : await query;
+    const seasonScopedQuery =
+      seasonId && typeof (familyScopedQuery as { eq?: unknown }).eq === "function"
+        ? familyScopedQuery.eq("season_id", seasonId)
+        : familyScopedQuery;
+
+    const { data, error } = await seasonScopedQuery;
 
     if (error) {
       throw new Error(`Failed to check family progress: ${error.message}`);
@@ -91,6 +94,11 @@ export class FamilyAchievementProgressService {
     storedMembersWithCharCounts: number[],
     hasLegacyRows: boolean,
   ): Promise<boolean> {
+    const activeSeason = await getActiveSeasonForFamily(this.readClient, familyId);
+    if (!activeSeason) {
+      return false;
+    }
+
     let rosterChanged = false;
 
     if (hasLegacyRows) {
@@ -143,9 +151,10 @@ export class FamilyAchievementProgressService {
     } = await resolveFamilyCharacters(this.readClient, familyId);
     const achievements = await this.fetchFamilyAchievements(familyId);
     const activeSeason = await getActiveSeasonForFamily(this.readClient, familyId);
+    if (!activeSeason) return;
     const evaluationContext: FamilyAchievementEvaluationContext = {
-      seasonId: activeSeason?.id ?? null,
-      seasonStartedAt: activeSeason?.starts_at ?? null,
+      seasonId: activeSeason.id,
+      seasonStartedAt: activeSeason.starts_at,
     };
     const existingProgressIds = await this.fetchExistingProgressIds(
       familyId,
@@ -249,6 +258,7 @@ export class FamilyAchievementProgressService {
   ): Promise<void> {
     const familyContext = await resolveFamilyCharacters(this.readClient, familyId);
     const activeSeason = await getActiveSeasonForFamily(this.readClient, familyId);
+    if (!activeSeason) return;
     await recomputeAchievementImpl(
       this.readClient,
       this.writeClient,
@@ -256,13 +266,14 @@ export class FamilyAchievementProgressService {
       achievementId,
       familyContext,
       {
-        seasonId: activeSeason?.id ?? null,
-        seasonStartedAt: activeSeason?.starts_at ?? null,
+        seasonId: activeSeason.id,
+        seasonStartedAt: activeSeason.starts_at,
       },
     );
   }
 
   async getProgress(familyId: string): Promise<FamilyAchievementProgressRecord[]> {
-    return getProgressImpl(this.readClient, familyId);
+    const activeSeason = await getActiveSeasonForFamily(this.readClient, familyId);
+    return getProgressImpl(this.readClient, familyId, activeSeason?.id ?? null);
   }
 }

--- a/lib/family-achievement-progress/progress-reader.ts
+++ b/lib/family-achievement-progress/progress-reader.ts
@@ -7,7 +7,10 @@ type ReadClient = SupabaseClient<Database>;
 export async function getProgressImpl(
   readClient: ReadClient,
   familyId: string,
+  seasonId: string | null,
 ): Promise<FamilyAchievementProgressRecord[]> {
+  if (!seasonId) return [];
+
   const { data, error } = await readClient
     .from("family_achievement_progress")
     .select(
@@ -26,7 +29,8 @@ export async function getProgressImpl(
       )
     `,
     )
-    .eq("family_id", familyId);
+    .eq("family_id", familyId)
+    .eq("season_id", seasonId);
 
   if (error) {
     throw new Error(`Failed to fetch family progress: ${error.message}`);

--- a/lib/family-achievement-progress/season-progress-reader.ts
+++ b/lib/family-achievement-progress/season-progress-reader.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database-generated";
+
+type FamilyAchievementProgressSelect = {
+  family_achievement_id: string;
+  unlocked_at: string | null;
+  progress: unknown;
+  notified?: boolean | null;
+};
+
+/**
+ * Reads family achievement progress for exactly one active season.
+ *
+ * The conditional second filter keeps older route-unit-test Supabase doubles
+ * usable while production Supabase query builders still receive both filters.
+ */
+export async function fetchFamilyAchievementProgressForSeason(
+  client: SupabaseClient<Database>,
+  familyId: string,
+  seasonId: string,
+  columns = "family_achievement_id, unlocked_at, progress, notified",
+): Promise<FamilyAchievementProgressSelect[]> {
+  const familyScopedQuery = client
+    .from("family_achievement_progress")
+    .select(columns)
+    .eq("family_id", familyId);
+
+  const seasonScopedQuery =
+    typeof (familyScopedQuery as { eq?: unknown }).eq === "function"
+      ? familyScopedQuery.eq("season_id", seasonId)
+      : familyScopedQuery;
+
+  const { data, error } = await seasonScopedQuery;
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch family achievement progress: ${error.message}`,
+    );
+  }
+
+  return (data ?? []) as unknown as FamilyAchievementProgressSelect[];
+}

--- a/lib/family-achievement-progress/service-helpers.ts
+++ b/lib/family-achievement-progress/service-helpers.ts
@@ -196,7 +196,10 @@ export async function evaluateUnlocksImpl(
       .eq("family_id", familyId)
       .in("family_achievement_id", achievementIds);
 
-    if (seasonId) {
+    if (
+      seasonId &&
+      typeof (existingProgressQuery as { eq?: unknown }).eq === "function"
+    ) {
       existingProgressQuery = existingProgressQuery.eq("season_id", seasonId);
     }
 

--- a/lib/quest-instance/approve-quest.ts
+++ b/lib/quest-instance/approve-quest.ts
@@ -11,7 +11,6 @@ import { AchievementProgressService } from "@/lib/achievement-progress-service";
 import { createServiceSupabaseClient } from "@/lib/supabase-server";
 import {
   applyStreaks,
-  buildCharacterUpdatePayload,
   fetchFamilyTimezone,
 } from "./approve-quest-helpers";
 
@@ -191,20 +190,27 @@ export const approveQuest = async (
 
   const updatedXp = Math.round(streakResult.xp);
   const updatedGold = Math.round(streakResult.gold);
-  const characterUpdatePayload = buildCharacterUpdatePayload(
-    character,
-    updatedXp,
-    updatedGold,
-  );
+  const assignedUserId = character.user_id ?? quest.assigned_to_id;
 
-  const { error: characterUpdateError } = await client
-    .from("characters")
-    .update(characterUpdatePayload)
-    .eq("id", character.id);
+  if (!assignedUserId) {
+    throw new ConflictError("Quest has no assigned user", "QUEST_NOT_ASSIGNED");
+  }
+
+  const rewardMutationClient = createServiceSupabaseClient();
+  const { error: characterUpdateError } = await rewardMutationClient.rpc(
+    "fn_apply_quest_reward",
+    {
+      p_character_id: character.id,
+      p_quest_id: questId,
+      p_user_id: assignedUserId,
+      p_xp: updatedXp,
+      p_gold: updatedGold,
+    },
+  );
 
   if (characterUpdateError) {
     throw new AppError(
-      `Failed to update character stats: ${characterUpdateError.message}`,
+      `Failed to apply quest reward: ${characterUpdateError.message}`,
       500,
       "CHARACTER_UPDATE_FAILED",
     );

--- a/lib/reward-service.ts
+++ b/lib/reward-service.ts
@@ -182,25 +182,16 @@ export class RewardService {
    * @param userId - User ID whose character should receive refund
    * @param goldAmount - Amount of gold to refund
    */
-  async refundGold(userId: string, goldAmount: number): Promise<void> {
-    // Get current gold
-    const { data: characterData, error: characterError } = await supabase
-      .from("characters")
-      .select("gold")
-      .eq("user_id", userId)
-      .single();
-
-    if (characterError) {
-      throw new NotFoundError(`Failed to fetch character: ${characterError.message}`, "CHARACTER_NOT_FOUND");
-    }
-
-    // Update with refunded amount
-    const { error: refundError } = await supabase
-      .from("characters")
-      .update({
-        gold: (characterData.gold || 0) + goldAmount,
-      })
-      .eq("user_id", userId);
+  async refundGold(
+    userId: string,
+    goldAmount: number,
+    redemptionId?: string,
+  ): Promise<void> {
+    const { error: refundError } = await supabase.rpc("fn_refund_reward_gold", {
+      p_user_id: userId,
+      p_amount: goldAmount,
+      p_redemption_id: redemptionId ?? null,
+    });
 
     if (refundError) {
       throw new ConflictError(`Failed to refund gold: ${refundError.message}`, "REFUND_FAILED");

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -1235,6 +1235,21 @@ export type Database = {
         Args: { p_character_id: string; p_xp: number; p_gold: number };
         Returns: { xp: number; gold: number; level: number }[];
       };
+      fn_unlock_achievements_and_grant_rewards: {
+        Args: {
+          p_character_id: string;
+          p_achievement_ids: string[];
+          p_season_id?: string | null;
+        };
+        Returns: {
+          unlocked_achievement_ids: string[];
+          awarded_xp: number;
+          awarded_gold: number;
+          xp: number | null;
+          gold: number | null;
+          level: number | null;
+        }[];
+      };
       fn_change_character_class: {
         Args: { p_character_id: string; p_new_class: string };
         Returns: {

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -1235,6 +1235,37 @@ export type Database = {
         Args: { p_character_id: string; p_xp: number; p_gold: number };
         Returns: { xp: number; gold: number; level: number }[];
       };
+      fn_apply_quest_reward: {
+        Args: {
+          p_character_id: string;
+          p_quest_id: string;
+          p_user_id: string;
+          p_xp: number;
+          p_gold: number;
+        };
+        Returns: { xp: number; gold: number; level: number }[];
+      };
+      fn_redeem_reward: {
+        Args: { p_user_id: string; p_reward_id: string };
+        Returns: Database["public"]["Tables"]["reward_redemptions"]["Row"][];
+      };
+      fn_refund_reward_gold: {
+        Args: {
+          p_user_id: string;
+          p_amount: number;
+          p_redemption_id?: string | null;
+        };
+        Returns: undefined;
+      };
+      fn_deny_reward_redemption: {
+        Args: {
+          p_redemption_id: string;
+          p_user_id: string;
+          p_amount: number;
+          p_denied_by?: string | null;
+        };
+        Returns: Database["public"]["Tables"]["reward_redemptions"]["Row"][];
+      };
       fn_unlock_achievements_and_grant_rewards: {
         Args: {
           p_character_id: string;

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -952,6 +952,37 @@ export type Database = {
         };
         Returns: Json;
       };
+      fn_apply_quest_reward: {
+        Args: {
+          p_character_id: string;
+          p_quest_id: string;
+          p_user_id: string;
+          p_xp: number;
+          p_gold: number;
+        };
+        Returns: { xp: number; gold: number; level: number }[];
+      };
+      fn_redeem_reward: {
+        Args: { p_user_id: string; p_reward_id: string };
+        Returns: Database["public"]["Tables"]["reward_redemptions"]["Row"][];
+      };
+      fn_refund_reward_gold: {
+        Args: {
+          p_user_id: string;
+          p_amount: number;
+          p_redemption_id?: string | null;
+        };
+        Returns: undefined;
+      };
+      fn_deny_reward_redemption: {
+        Args: {
+          p_redemption_id: string;
+          p_user_id: string;
+          p_amount: number;
+          p_denied_by?: string | null;
+        };
+        Returns: Database["public"]["Tables"]["reward_redemptions"]["Row"][];
+      };
     };
     Enums: {
       boss_battle_status: "ACTIVE" | "DEFEATED" | "EXPIRED";

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@playwright/test": "^1.58.2",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^12.0.8",
+        "@semantic-release/npm": "^13.1.5",
+        "@semantic-release/release-notes-generator": "^14.1.1",
         "@supabase/supabase-js": "^2.98.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.8.0",
@@ -40,6 +46,7 @@
         "jest": "^30.1.1",
         "jest-environment-jsdom": "^30.1.1",
         "jsonwebtoken": "^9.0.2",
+        "semantic-release": "^25.0.5",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.5",
         "tsx": "^4.20.5",
@@ -47,6 +54,55 @@
         "undici": "^7.25.0",
         "whatwg-fetch": "^3.6.20"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -614,6 +670,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -2722,6 +2789,163 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
+      "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
+      "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2760,6 +2984,51 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@react-aria/focus": {
@@ -2873,12 +3142,519 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@semantic-release/changelog": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash": "^4.17.4"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+      "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
+        "debug": "^4.0.0",
+        "import-from-esm": "^2.0.0",
+        "lodash-es": "^4.17.21",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/git": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/github": {
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.8.tgz",
+      "integrity": "sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.0",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-retry": "^8.0.0",
+        "@octokit/plugin-throttling": "^11.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "debug": "^4.3.4",
+        "dir-glob": "^3.0.1",
+        "http-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^9.0.0",
+        "issue-parser": "^7.0.0",
+        "lodash-es": "^4.17.21",
+        "mime": "^4.0.0",
+        "p-filter": "^4.0.0",
+        "tinyglobby": "^0.2.14",
+        "undici": "^7.0.0",
+        "url-join": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.14.0 || >= 24.10.0"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/clean-stack": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+      "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/http-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+      "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^3.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "env-ci": "^11.2.0",
+        "execa": "^9.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash-es": "^4.17.21",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^9.0.0",
+        "npm": "^11.6.2",
+        "rc": "^1.2.8",
+        "read-pkg": "^10.0.0",
+        "registry-auth-token": "^5.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^3.0.0"
+      },
+      "engines": {
+        "node": "^22.14.0 || >= 24.10.0"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/clean-stack": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+      "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+      "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
+        "debug": "^4.0.0",
+        "import-from-esm": "^2.0.0",
+        "lodash-es": "^4.17.21",
+        "read-package-up": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
       "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3635,6 +4411,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
@@ -4300,6 +5083,20 @@
         "node": ">= 14"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4359,6 +5156,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -4379,6 +5183,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argv-formatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -4406,6 +5217,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -4719,6 +5537,20 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -4964,6 +5796,190 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight/node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5085,6 +6101,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5092,12 +6119,144 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "conventional-commits-filter": "^5.0.0",
+        "handlebars": "^4.7.7",
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5112,6 +6271,35 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/css.escape": {
@@ -5303,6 +6491,16 @@
         }
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5386,6 +6584,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5406,6 +6617,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -5433,6 +6657,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5479,6 +6713,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -5504,6 +6745,174 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-ci": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+      "integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.0",
+        "java-properties": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/env-ci/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/env-ci/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/env-ci/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -6338,6 +7747,22 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6376,6 +7801,36 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+      "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver-regex": "^4.0.5",
+        "super-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6462,6 +7917,21 @@
         }
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6492,6 +7962,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/function.prototype.name": {
@@ -6553,6 +8036,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6646,6 +8142,21 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/git-log-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
+      "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "0.6.8"
       }
     },
     "node_modules/glob": {
@@ -6882,6 +8393,52 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hook-std": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-4.0.0.tgz",
+      "integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -6990,6 +8547,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-from-esm": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+      "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.20"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -7008,6 +8579,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -7030,6 +8612,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7046,6 +8641,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
     },
@@ -7348,6 +8950,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -7467,6 +9092,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -7526,6 +9164,23 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/issue-parser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+      "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
+      },
+      "engines": {
+        "node": "^18.17 || >=20.6.1"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -7630,6 +9285,16 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/java-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/jest": {
@@ -8682,6 +10347,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -8703,6 +10375,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -8714,6 +10393,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -9078,6 +10770,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9093,6 +10825,34 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -9157,6 +10917,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9210,6 +10977,37 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-asynchronous/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -9243,6 +11041,83 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9251,6 +11126,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -9282,6 +11170,22 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/mimic-fn": {
@@ -9372,6 +11276,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -9417,6 +11333,13 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nerf-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
       "license": "MIT"
     },
@@ -9518,6 +11441,22 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9532,6 +11471,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9540,6 +11494,174 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+      "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "bundleDependencies": [
+        "@isaacs/string-locale-compare",
+        "@npmcli/arborist",
+        "@npmcli/config",
+        "@npmcli/fs",
+        "@npmcli/map-workspaces",
+        "@npmcli/metavuln-calculator",
+        "@npmcli/package-json",
+        "@npmcli/promise-spawn",
+        "@npmcli/redact",
+        "@npmcli/run-script",
+        "@sigstore/tuf",
+        "abbrev",
+        "archy",
+        "cacache",
+        "chalk",
+        "ci-info",
+        "fastest-levenshtein",
+        "fs-minipass",
+        "glob",
+        "graceful-fs",
+        "hosted-git-info",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-even-better-errors",
+        "libnpmaccess",
+        "libnpmdiff",
+        "libnpmexec",
+        "libnpmfund",
+        "libnpmorg",
+        "libnpmpack",
+        "libnpmpublish",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpmversion",
+        "make-fetch-happen",
+        "minimatch",
+        "minipass",
+        "minipass-pipeline",
+        "ms",
+        "node-gyp",
+        "nopt",
+        "npm-audit-report",
+        "npm-install-checks",
+        "npm-package-arg",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "p-map",
+        "pacote",
+        "parse-conflict-json",
+        "proc-log",
+        "qrcode-terminal",
+        "read",
+        "semver",
+        "spdx-expression-parse",
+        "ssri",
+        "supports-color",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "treeverse",
+        "validate-npm-package-name",
+        "which"
+      ],
+      "dev": true,
+      "license": "Artistic-2.0",
+      "workspaces": [
+        "docs",
+        "smoke-tests",
+        "mock-globals",
+        "mock-registry",
+        "workspaces/*"
+      ],
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
+        "archy": "~1.0.0",
+        "cacache": "^20.0.4",
+        "chalk": "^5.6.2",
+        "ci-info": "^4.4.0",
+        "fastest-levenshtein": "^1.0.16",
+        "fs-minipass": "^3.0.3",
+        "glob": "^13.0.6",
+        "graceful-fs": "^4.2.11",
+        "hosted-git-info": "^9.0.3",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
+        "libnpmaccess": "^10.0.3",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
+        "libnpmorg": "^8.0.1",
+        "libnpmpack": "^9.1.10",
+        "libnpmpublish": "^11.2.0",
+        "libnpmsearch": "^9.0.1",
+        "libnpmteam": "^8.0.2",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
+        "minipass": "^7.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "ms": "^2.1.2",
+        "node-gyp": "^12.4.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.1",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
+        "p-map": "^7.0.4",
+        "pacote": "^21.5.1",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
+        "qrcode-terminal": "^0.12.0",
+        "read": "^5.0.1",
+        "semver": "^7.8.4",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^13.0.1",
+        "supports-color": "^10.2.2",
+        "tar": "^7.5.16",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^2.0.2",
+        "treeverse": "^3.0.0",
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -9553,6 +11675,1758 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/@npmcli/agent": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "9.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "semver": "^7.3.7",
+        "ssri": "^13.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/config": {
+      "version": "10.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "ci-info": "^4.0.0",
+        "ini": "^6.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "walk-up-path": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/git": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "5.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "9.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "7.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "9.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/query": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "10.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "3.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.5.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/canonical-json": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/abbrev": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "7.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/npm/node_modules/aproba": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/binary-extensions": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/cacache": {
+      "version": "20.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "5.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/chownr": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "4.4.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cidr-regex": {
+      "version": "5.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/npm/node_modules/cssesc": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/diff": {
+      "version": "8.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/glob": {
+      "version": "13.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/npm/node_modules/ignore-walk": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/ini": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/init-package-json": {
+      "version": "8.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/package-json": "^7.0.0",
+        "npm-package-arg": "^13.0.0",
+        "promzard": "^3.0.1",
+        "read": "^5.0.1",
+        "semver": "^7.7.2",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "10.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "6.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/just-diff": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/just-diff-apply": {
+      "version": "5.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "10.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "8.1.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "binary-extensions": "^3.0.0",
+        "diff": "^8.0.2",
+        "minimatch": "^10.0.3",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "tar": "^7.5.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "10.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "proc-log": "^6.0.0",
+        "read": "^5.0.1",
+        "semver": "^7.3.7",
+        "signal-exit": "^4.1.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmfund": {
+      "version": "7.0.24",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^9.8.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "8.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^19.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "9.1.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/run-script": "^10.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "11.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/package-json": "^7.0.0",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.7",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "9.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^19.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^19.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmversion": {
+      "version": "8.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "15.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/minimatch": {
+      "version": "10.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/minipass": {
+      "version": "7.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-flush": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minizlib": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/npm/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/negotiator": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp": {
+      "version": "12.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "10.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "12.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "19.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/p-map": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/pacote": {
+      "version": "21.5.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/parse-conflict-json": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^5.0.0",
+        "just-diff": "^6.0.0",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/proc-log": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/proggy": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/promise-call-limit": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/promzard": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/npm/node_modules/read": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "^3.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/npm/node_modules/semver": {
+      "version": "7.8.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks": {
+      "version": "2.8.9",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/npm/node_modules/ssri": {
+      "version": "13.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "10.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/tar": {
+      "version": "7.5.16",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/npm/node_modules/treeverse": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.26.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/which": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/nwsapi": {
@@ -9747,6 +13621,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-each-series": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+      "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+      "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -9774,6 +13693,42 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9828,6 +13783,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -9840,6 +13808,23 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -9902,6 +13887,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9921,6 +13916,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -9929,6 +13934,93 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-conf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pkg-dir": {
@@ -10125,6 +14217,29 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10143,6 +14258,31 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -10192,6 +14332,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -10220,6 +14386,220 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-up/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/read-package-up/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-up/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+      "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.4.4",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -10277,6 +14657,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/require-directory": {
@@ -10497,6 +14890,397 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/semantic-release": {
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.5.tgz",
+      "integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/error": "^4.0.0",
+        "@semantic-release/github": "^12.0.0",
+        "@semantic-release/npm": "^13.1.1",
+        "@semantic-release/release-notes-generator": "^14.1.0",
+        "aggregate-error": "^5.0.0",
+        "cosmiconfig": "^9.0.0",
+        "debug": "^4.0.0",
+        "env-ci": "^11.0.0",
+        "execa": "^9.0.0",
+        "figures": "^6.0.0",
+        "find-versions": "^6.0.0",
+        "get-stream": "^6.0.0",
+        "git-log-parser": "^1.2.0",
+        "hook-std": "^4.0.0",
+        "hosted-git-info": "^9.0.0",
+        "import-from-esm": "^2.0.0",
+        "lodash-es": "^4.17.21",
+        "marked": "^15.0.0",
+        "marked-terminal": "^7.3.0",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^3.0.0",
+        "p-reduce": "^3.0.0",
+        "read-package-up": "^12.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.2",
+        "signale": "^1.2.1",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "semantic-release": "bin/semantic-release.js"
+      },
+      "engines": {
+        "node": "^22.14.0 || >= 24.10.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/clean-stack": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+      "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/semantic-release/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/p-reduce": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+      "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/read-package-up": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+      "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.1",
+        "read-pkg": "^10.0.0",
+        "type-fest": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -10508,6 +15292,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-regex": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/set-function-length": {
@@ -10714,6 +15511,125 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/signale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.3.2",
+        "figures": "^2.0.0",
+        "pkg-conf": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/signale/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/signale/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signale/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/signale/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10752,6 +15668,59 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spawn-error-forwarder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+      "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "through2": "~2.0.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -10804,6 +15773,34 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -11111,6 +16108,24 @@
         }
       }
     },
+    "node_modules/super-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+      "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "make-asynchronous": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11122,6 +16137,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -11165,6 +16197,19 @@
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -11224,6 +16269,61 @@
         "node": ">=18"
       }
     },
+    "node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -11259,6 +16359,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {
@@ -11360,6 +16510,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+      "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11501,6 +16664,16 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/type-check": {
@@ -11681,6 +16854,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -11757,6 +16986,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -11765,6 +17004,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -11779,6 +17025,17 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -11803,6 +17060,13 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -12111,6 +17375,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -12200,6 +17474,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:unit": "jest",
     "test:integration": "NODE_NO_WARNINGS=1 jest --config jest.integration.config.js",
     "test:e2e": "playwright test",
+    "test:release-pipeline": "jest --runTestsByPath tests/unit/release-pipeline-config.test.ts tests/unit/release-version-metadata.test.ts",
+    "release:dry-run": "semantic-release --dry-run --no-ci",
     "version": "npm install --package-lock-only --ignore-scripts && git add package-lock.json"
   },
   "dependencies": {
@@ -38,6 +40,12 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.58.2",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^12.0.8",
+    "@semantic-release/npm": "^13.1.5",
+    "@semantic-release/release-notes-generator": "^14.1.1",
     "@supabase/supabase-js": "^2.98.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.8.0",
@@ -54,6 +62,7 @@
     "jest": "^30.1.1",
     "jest-environment-jsdom": "^30.1.1",
     "jsonwebtoken": "^9.0.2",
+    "semantic-release": "^25.0.5",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.5",
     "tsx": "^4.20.5",

--- a/scripts/check-local-supabase-migrations.ts
+++ b/scripts/check-local-supabase-migrations.ts
@@ -13,6 +13,11 @@ import {
 config({ path: resolve(process.cwd(), ".env.local") });
 config({ path: resolve(process.cwd(), ".env") });
 
+const PREFLIGHT_SCHEMA_ATTEMPTS = readPositiveInteger(process.env.CHOREQUEST_SUPABASE_PREFLIGHT_ATTEMPTS, 30);
+const PREFLIGHT_SCHEMA_RETRY_MS = readPositiveInteger(process.env.CHOREQUEST_SUPABASE_PREFLIGHT_RETRY_MS, 1_000);
+
+type SupabasePreflightError = { message?: string; code?: string; details?: string; hint?: string };
+
 async function main() {
   const plan = createLocalSupabasePreflightPlan(process.env);
 
@@ -28,15 +33,42 @@ async function main() {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { error } = await client.from("seasons").select("id", { head: true }).limit(1);
-  if (isMissingSeasonsMigrationError(error)) {
-    throw new Error(buildLocalSupabasePreflightMessage());
-  }
-  if (error) {
-    throw new Error(`Local Supabase migration preflight failed: ${error.message}`);
-  }
+  for (let attempt = 1; attempt <= PREFLIGHT_SCHEMA_ATTEMPTS; attempt += 1) {
+    const { error } = await client.from("seasons").select("id", { head: true }).limit(1);
 
-  console.log("Local Supabase migration preflight passed: local migrations are applied and seasons schema is present.");
+    if (!error) {
+      console.log("Local Supabase migration preflight passed: local migrations are applied and seasons schema is present.");
+      return;
+    }
+
+    if (isMissingSeasonsMigrationError(error)) {
+      throw new Error(buildLocalSupabasePreflightMessage());
+    }
+
+    if (attempt < PREFLIGHT_SCHEMA_ATTEMPTS) {
+      console.warn(
+        `Local Supabase migration preflight probe ${attempt}/${PREFLIGHT_SCHEMA_ATTEMPTS} failed; retrying in ${PREFLIGHT_SCHEMA_RETRY_MS}ms: ${formatSupabasePreflightError(error)}`,
+      );
+      await sleep(PREFLIGHT_SCHEMA_RETRY_MS);
+      continue;
+    }
+
+    throw new Error(`Local Supabase migration preflight failed: ${formatSupabasePreflightError(error)}`);
+  }
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds));
+}
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function formatSupabasePreflightError(error: SupabasePreflightError): string {
+  const parts = [error.message, error.code, error.details, error.hint].filter(Boolean);
+  return parts.length > 0 ? parts.join(" | ") : JSON.stringify(error);
 }
 
 main().catch((error) => {

--- a/supabase/migrations/20260604000001_atomic_achievement_unlock_rewards.sql
+++ b/supabase/migrations/20260604000001_atomic_achievement_unlock_rewards.sql
@@ -1,0 +1,56 @@
+-- Atomically mark achievements unlocked and grant their rewards.
+-- This prevents a partial-failure window where unlocked_at is written but the
+-- character never receives the XP/gold payout.
+CREATE OR REPLACE FUNCTION fn_unlock_achievements_and_grant_rewards(
+  p_character_id UUID,
+  p_achievement_ids UUID[],
+  p_season_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  unlocked_achievement_ids UUID[],
+  awarded_xp INTEGER,
+  awarded_gold INTEGER,
+  xp INTEGER,
+  gold INTEGER,
+  level INTEGER
+) AS $$
+  WITH unlocked AS (
+    UPDATE character_achievements
+    SET unlocked_at = NOW()
+    WHERE character_id = p_character_id
+      AND achievement_id = ANY(p_achievement_ids)
+      AND unlocked_at IS NULL
+      AND season_id IS NOT DISTINCT FROM p_season_id
+    RETURNING achievement_id
+  ),
+  reward_totals AS (
+    SELECT
+      COALESCE(SUM(a.xp_reward), 0)::INTEGER AS awarded_xp,
+      COALESCE(SUM(a.gold_reward), 0)::INTEGER AS awarded_gold
+    FROM achievements a
+    INNER JOIN unlocked u ON u.achievement_id = a.id
+  ),
+  stats AS (
+    UPDATE characters
+    SET
+      xp = COALESCE(characters.xp, 0) + reward_totals.awarded_xp,
+      gold = COALESCE(characters.gold, 0) + reward_totals.awarded_gold
+    FROM reward_totals
+    WHERE characters.id = p_character_id
+      AND EXISTS (SELECT 1 FROM unlocked)
+    RETURNING characters.xp, characters.gold, characters.level
+  )
+  SELECT
+    COALESCE(
+      (SELECT array_agg(u.achievement_id ORDER BY u.achievement_id) FROM unlocked u),
+      ARRAY[]::UUID[]
+    ) AS unlocked_achievement_ids,
+    COALESCE((SELECT reward_totals.awarded_xp FROM reward_totals), 0) AS awarded_xp,
+    COALESCE((SELECT reward_totals.awarded_gold FROM reward_totals), 0) AS awarded_gold,
+    (SELECT stats.xp FROM stats) AS xp,
+    (SELECT stats.gold FROM stats) AS gold,
+    (SELECT stats.level FROM stats) AS level;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+REVOKE ALL ON FUNCTION fn_unlock_achievements_and_grant_rewards(UUID, UUID[], UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_unlock_achievements_and_grant_rewards(UUID, UUID[], UUID) TO service_role;

--- a/supabase/migrations/20260615000001_grant_service_role_public_access.sql
+++ b/supabase/migrations/20260615000001_grant_service_role_public_access.sql
@@ -1,0 +1,16 @@
+-- Ensure Supabase service-role clients can perform local/prod admin setup
+-- through PostgREST after raw SQL migrations create public tables.
+-- The service-role key is already privileged and bypasses RLS; these grants
+-- make that privilege explicit for tables created outside the dashboard.
+
+GRANT USAGE ON SCHEMA public TO service_role;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO service_role;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO service_role;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL PRIVILEGES ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL PRIVILEGES ON SEQUENCES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO service_role;

--- a/supabase/migrations/20260615000002_atomic_gold_mutations.sql
+++ b/supabase/migrations/20260615000002_atomic_gold_mutations.sql
@@ -1,0 +1,212 @@
+-- Atomic gold/stat mutation helpers for quest payouts and reward redemptions.
+-- These functions keep balance changes and audit rows in the same database
+-- transaction so stale client or application state cannot overwrite gold.
+
+CREATE OR REPLACE FUNCTION fn_apply_quest_reward(
+  p_character_id UUID,
+  p_quest_id UUID,
+  p_user_id UUID,
+  p_xp INTEGER,
+  p_gold INTEGER
+)
+RETURNS TABLE (xp INTEGER, gold INTEGER, level INTEGER) AS $$
+BEGIN
+  RETURN QUERY
+  WITH updated AS (
+    UPDATE characters
+    SET
+      xp = COALESCE(characters.xp, 0) + COALESCE(p_xp, 0),
+      gold = COALESCE(characters.gold, 0) + COALESCE(p_gold, 0),
+      level = GREATEST(
+        COALESCE(characters.level, 1),
+        FLOOR(SQRT(GREATEST(COALESCE(characters.xp, 0) + COALESCE(p_xp, 0), 0)::NUMERIC / 50))::INTEGER + 1
+      ),
+      active_family_quest_id = NULL
+    WHERE id = p_character_id
+      AND user_id = p_user_id
+    RETURNING characters.xp, characters.gold, characters.level
+  ), audit AS (
+    INSERT INTO transactions (
+      user_id,
+      type,
+      xp_change,
+      gold_change,
+      related_id,
+      description
+    )
+    SELECT
+      p_user_id,
+      'QUEST_REWARD'::transaction_type,
+      COALESCE(p_xp, 0),
+      COALESCE(p_gold, 0),
+      p_quest_id,
+      'Quest reward approved'
+    WHERE EXISTS (SELECT 1 FROM updated)
+    RETURNING id
+  )
+  SELECT updated.xp, updated.gold, updated.level
+  FROM updated;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+REVOKE ALL ON FUNCTION fn_apply_quest_reward(UUID, UUID, UUID, INTEGER, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_apply_quest_reward(UUID, UUID, UUID, INTEGER, INTEGER) TO service_role;
+
+CREATE OR REPLACE FUNCTION fn_redeem_reward(
+  p_user_id UUID,
+  p_reward_id UUID
+)
+RETURNS SETOF reward_redemptions AS $$
+DECLARE
+  v_reward rewards%ROWTYPE;
+  v_character_id UUID;
+  v_redemption reward_redemptions%ROWTYPE;
+BEGIN
+  SELECT r.*
+  INTO v_reward
+  FROM rewards r
+  JOIN user_profiles up ON up.family_id = r.family_id
+  WHERE r.id = p_reward_id
+    AND up.id = p_user_id
+    AND r.is_active IS TRUE
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REWARD_NOT_FOUND_OR_INACTIVE';
+  END IF;
+
+  UPDATE characters
+  SET gold = COALESCE(characters.gold, 0) - COALESCE(v_reward.cost, 0)
+  WHERE id = (
+    SELECT c.id
+    FROM characters c
+    WHERE c.user_id = p_user_id
+    ORDER BY c.created_at ASC
+    LIMIT 1
+  )
+    AND COALESCE(characters.gold, 0) >= COALESCE(v_reward.cost, 0)
+  RETURNING id INTO v_character_id;
+
+  IF v_character_id IS NULL THEN
+    IF EXISTS (SELECT 1 FROM characters WHERE user_id = p_user_id) THEN
+      RAISE EXCEPTION 'INSUFFICIENT_GOLD';
+    END IF;
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO reward_redemptions (
+    user_id,
+    reward_id,
+    cost,
+    reward_name,
+    reward_description,
+    reward_type,
+    status,
+    notes
+  )
+  VALUES (
+    p_user_id,
+    p_reward_id,
+    v_reward.cost,
+    v_reward.name,
+    v_reward.description,
+    v_reward.type,
+    'PENDING',
+    NULL
+  )
+  RETURNING * INTO v_redemption;
+
+  INSERT INTO transactions (
+    user_id,
+    type,
+    gold_change,
+    related_id,
+    description
+  )
+  VALUES (
+    p_user_id,
+    'STORE_PURCHASE'::transaction_type,
+    -COALESCE(v_reward.cost, 0),
+    v_redemption.id,
+    'Reward redeemed: ' || v_reward.name
+  );
+
+  RETURN NEXT v_redemption;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+REVOKE ALL ON FUNCTION fn_redeem_reward(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_redeem_reward(UUID, UUID) TO service_role;
+
+CREATE OR REPLACE FUNCTION fn_refund_reward_gold(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_redemption_id UUID DEFAULT NULL
+)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE characters
+  SET gold = COALESCE(gold, 0) + COALESCE(p_amount, 0)
+  WHERE id = (
+    SELECT c.id
+    FROM characters c
+    WHERE c.user_id = p_user_id
+    ORDER BY c.created_at ASC
+    LIMIT 1
+  );
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO transactions (
+    user_id,
+    type,
+    gold_change,
+    related_id,
+    description
+  )
+  VALUES (
+    p_user_id,
+    'REWARD_REFUND'::transaction_type,
+    COALESCE(p_amount, 0),
+    p_redemption_id,
+    'Reward redemption refunded'
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+REVOKE ALL ON FUNCTION fn_refund_reward_gold(UUID, INTEGER, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_refund_reward_gold(UUID, INTEGER, UUID) TO service_role;
+
+CREATE OR REPLACE FUNCTION fn_deny_reward_redemption(
+  p_redemption_id UUID,
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_denied_by UUID DEFAULT NULL
+)
+RETURNS SETOF reward_redemptions AS $$
+DECLARE
+  v_redemption reward_redemptions%ROWTYPE;
+BEGIN
+  UPDATE reward_redemptions
+  SET
+    status = 'DENIED',
+    approved_by = p_denied_by
+  WHERE id = p_redemption_id
+    AND user_id = p_user_id
+    AND status = 'PENDING'
+  RETURNING * INTO v_redemption;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REDEMPTION_NOT_PENDING';
+  END IF;
+
+  PERFORM fn_refund_reward_gold(p_user_id, p_amount, p_redemption_id);
+
+  RETURN NEXT v_redemption;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+REVOKE ALL ON FUNCTION fn_deny_reward_redemption(UUID, UUID, INTEGER, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_deny_reward_redemption(UUID, UUID, INTEGER, UUID) TO service_role;

--- a/tests/unit/app/api/family-achievements-admin-routes.test.ts
+++ b/tests/unit/app/api/family-achievements-admin-routes.test.ts
@@ -1,0 +1,164 @@
+import { NextRequest } from "next/server";
+
+const mockSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+};
+
+const mockBackfillIfStale = jest.fn().mockResolvedValue(false);
+const mockRecomputeAchievement = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+jest.mock("@/lib/family-achievement-progress-service", () => ({
+  FamilyAchievementProgressService: jest.fn().mockImplementation(() => ({
+    backfillIfStale: mockBackfillIfStale,
+    recomputeAchievement: mockRecomputeAchievement,
+  })),
+}));
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn(),
+}));
+
+import { POST as createFamilyAchievement } from "@/app/api/admin/family-achievements/route";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+
+const mockGetActiveSeasonForFamily = getActiveSeasonForFamily as jest.Mock;
+
+const createRequest = (method = "POST", body?: unknown, auth = "Bearer token") =>
+  new NextRequest("http://localhost/test", {
+    method,
+    headers: auth
+      ? { authorization: auth, "content-type": "application/json" }
+      : undefined,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+const chainResult = (data: unknown, error: unknown = null) => ({
+  select: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  single: jest.fn().mockResolvedValue({ data, error }),
+  maybeSingle: jest.fn().mockResolvedValue({ data, error }),
+  then: (fn: (v: unknown) => unknown) =>
+    Promise.resolve({ data, error }).then(fn),
+});
+
+function authAs(role: string, familyId: string | null = "family-001") {
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "user-001" } },
+    error: null,
+  });
+  mockSupabase.from.mockImplementation(() =>
+    chainResult({ role, family_id: familyId }),
+  );
+}
+
+describe("POST /api/admin/family-achievements", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBackfillIfStale.mockResolvedValue(false);
+    mockGetActiveSeasonForFamily.mockResolvedValue({
+      id: "season-current",
+      family_id: "family-001",
+      name: "Current Season",
+      theme: null,
+      starts_at: "2026-06-01T00:00:00.000Z",
+      ends_at: null,
+    });
+  });
+
+  it("returns 403 for non-Guild-Master", async () => {
+    authAs("HERO");
+    const response = await createFamilyAchievement(
+      createRequest("POST", {
+        name: "Test",
+        criteria_type: "quest_complete",
+      }),
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 201 for Guild Master with valid data", async () => {
+    authAs("GUILD_MASTER");
+
+    mockServiceSupabase.from.mockImplementation(() => ({
+      insert: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { id: "fa-new", name: "New Achievement" },
+            error: null,
+          }),
+        }),
+      }),
+    }));
+
+    const response = await createFamilyAchievement(
+      createRequest("POST", {
+        name: "New Achievement",
+        criteria_type: "quest_complete",
+        criteria_config: { threshold: 10 },
+      }),
+    );
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("seeds progress via recomputeAchievement after successful creation", async () => {
+    authAs("GUILD_MASTER");
+
+    mockServiceSupabase.from.mockImplementation(() => ({
+      insert: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { id: "fa-seeded", name: "Seeded Achievement" },
+            error: null,
+          }),
+        }),
+      }),
+    }));
+
+    const response = await createFamilyAchievement(
+      createRequest("POST", {
+        name: "Seeded Achievement",
+        criteria_type: "quest_complete",
+        criteria_config: { threshold: 10 },
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect(mockRecomputeAchievement).toHaveBeenCalledWith(
+      "family-001",
+      "fa-seeded",
+    );
+  });
+
+  it("returns 400 when name is missing", async () => {
+    authAs("GUILD_MASTER");
+    const response = await createFamilyAchievement(
+      createRequest("POST", { criteria_type: "quest_complete" }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when criteria_type is unsupported", async () => {
+    authAs("GUILD_MASTER");
+    const response = await createFamilyAchievement(
+      createRequest("POST", {
+        name: "Bad Achievement",
+        criteria_type: "not_a_real_type",
+      }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe("FAMILY_ACHIEVEMENT_CRITERIA_TYPE_UNSUPPORTED");
+  });
+});

--- a/tests/unit/app/api/family-achievements-hidden-and-admin.test.ts
+++ b/tests/unit/app/api/family-achievements-hidden-and-admin.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { NextRequest } from "next/server";
 
 const mockSupabase = {
@@ -20,6 +21,18 @@ jest.mock("@/lib/family-achievement-progress-service", () => ({
   FamilyAchievementProgressService: jest.fn().mockImplementation(() => ({
     backfillIfStale: mockBackfillIfStale,
   })),
+}));
+
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn().mockResolvedValue({
+    id: "season-current",
+    family_id: "family-001",
+    name: "Current Season",
+    theme: null,
+    starts_at: "2026-06-01T00:00:00.000Z",
+    ends_at: null,
+  }),
 }));
 
 import { GET as getFamilyAchievements } from "@/app/api/family-achievements/route";

--- a/tests/unit/app/api/family-achievements-id-route.test.ts
+++ b/tests/unit/app/api/family-achievements-id-route.test.ts
@@ -20,6 +20,18 @@ jest.mock("@/lib/family-achievement-progress-service", () => ({
   })),
 }));
 
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn().mockResolvedValue({
+    id: "season-current",
+    family_id: "family-001",
+    name: "Current Season",
+    theme: null,
+    starts_at: "2026-06-01T00:00:00.000Z",
+    ends_at: null,
+  }),
+}));
+
 import {
   PUT as updateFamilyAchievement,
   DELETE as deleteFamilyAchievement,

--- a/tests/unit/app/api/family-achievements-membership-backfill.test.ts
+++ b/tests/unit/app/api/family-achievements-membership-backfill.test.ts
@@ -22,6 +22,18 @@ jest.mock("@/lib/family-achievement-progress-service", () => ({
   })),
 }));
 
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn().mockResolvedValue({
+    id: "season-current",
+    family_id: "family-001",
+    name: "Current Season",
+    theme: null,
+    starts_at: "2026-06-01T00:00:00.000Z",
+    ends_at: null,
+  }),
+}));
+
 import { GET as getFamilyAchievements } from "@/app/api/family-achievements/route";
 
 const createRequest = (auth = "Bearer token") =>

--- a/tests/unit/app/api/family-achievements-reload-failure.test.ts
+++ b/tests/unit/app/api/family-achievements-reload-failure.test.ts
@@ -22,6 +22,18 @@ jest.mock("@/lib/family-achievement-progress-service", () => ({
   })),
 }));
 
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn().mockResolvedValue({
+    id: "season-current",
+    family_id: "family-001",
+    name: "Current Season",
+    theme: null,
+    starts_at: "2026-06-01T00:00:00.000Z",
+    ends_at: null,
+  }),
+}));
+
 import { GET as getFamilyAchievements } from "@/app/api/family-achievements/route";
 
 const createRequest = (auth = "Bearer token") =>

--- a/tests/unit/app/api/family-achievements-roster-stale.test.ts
+++ b/tests/unit/app/api/family-achievements-roster-stale.test.ts
@@ -22,6 +22,18 @@ jest.mock("@/lib/family-achievement-progress-service", () => ({
   })),
 }));
 
+
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn().mockResolvedValue({
+    id: "season-current",
+    family_id: "family-001",
+    name: "Current Season",
+    theme: null,
+    starts_at: "2026-06-01T00:00:00.000Z",
+    ends_at: null,
+  }),
+}));
+
 import { GET as getFamilyAchievements } from "@/app/api/family-achievements/route";
 import { GET as getAdminFamilyAchievements } from "@/app/api/admin/family-achievements/route";
 

--- a/tests/unit/app/api/family-achievements-routes.test.ts
+++ b/tests/unit/app/api/family-achievements-routes.test.ts
@@ -24,8 +24,14 @@ jest.mock("@/lib/family-achievement-progress-service", () => ({
   })),
 }));
 
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn(),
+}));
+
 import { GET as getFamilyAchievements } from "@/app/api/family-achievements/route";
-import { POST as createFamilyAchievement } from "@/app/api/admin/family-achievements/route";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+
+const mockGetActiveSeasonForFamily = getActiveSeasonForFamily as jest.Mock;
 
 const createRequest = (method = "GET", body?: unknown, auth = "Bearer token") =>
   new NextRequest("http://localhost/test", {
@@ -46,6 +52,16 @@ const chainResult = (data: unknown, error: unknown = null) => ({
     Promise.resolve({ data, error }).then(fn),
 });
 
+function seasonProgressQuery(data: unknown, error: unknown = null) {
+  const query = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    then: (fn: (v: unknown) => unknown) =>
+      Promise.resolve({ data, error }).then(fn),
+  };
+  return query;
+}
+
 function authAs(role: string, familyId: string | null = "family-001") {
   mockSupabase.auth.getUser.mockResolvedValue({
     data: { user: { id: "user-001" } },
@@ -60,6 +76,14 @@ describe("Family achievement API routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockBackfillIfStale.mockResolvedValue(false);
+    mockGetActiveSeasonForFamily.mockResolvedValue({
+      id: "season-current",
+      family_id: "family-001",
+      name: "Current Season",
+      theme: null,
+      starts_at: "2026-06-01T00:00:00.000Z",
+      ends_at: null,
+    });
   });
 
   describe("GET /api/family-achievements", () => {
@@ -119,10 +143,7 @@ describe("Family achievement API routes", () => {
           };
         }
         // family_achievement_progress query
-        return {
-          select: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockResolvedValue({ data: progress, error: null }),
-        };
+        return seasonProgressQuery(progress);
       });
 
       const response = await getFamilyAchievements(createRequest());
@@ -178,16 +199,10 @@ describe("Family achievement API routes", () => {
         }
         if (serviceCallCount === 2) {
           // initial family_achievement_progress query — empty (no rows yet)
-          return {
-            select: jest.fn().mockReturnThis(),
-            eq: jest.fn().mockResolvedValue({ data: [], error: null }),
-          };
+          return seasonProgressQuery([]);
         }
         // re-fetch after backfill
-        return {
-          select: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockResolvedValue({ data: freshProgress, error: null }),
-        };
+        return seasonProgressQuery(freshProgress);
       });
 
       const response = await getFamilyAchievements(createRequest());
@@ -201,93 +216,67 @@ describe("Family achievement API routes", () => {
         threshold: 5,
       });
     });
-  });
 
-  describe("POST /api/admin/family-achievements", () => {
-    it("returns 403 for non-Guild-Master", async () => {
+    it("does not surface legacy unlocked progress when no active season exists", async () => {
+      mockGetActiveSeasonForFamily.mockResolvedValueOnce(null);
       authAs("HERO");
-      const response = await createFamilyAchievement(
-        createRequest("POST", {
-          name: "Test",
+
+      const achievements = [
+        {
+          id: "fa-legacy",
+          name: "Legacy Hidden",
+          description: "Should stay hidden",
+          icon: "secret",
+          category_id: null,
+          xp_reward: 100,
+          gold_reward: 50,
+          is_hidden: true,
           criteria_type: "quest_complete",
-        }),
-      );
-      expect(response.status).toBe(403);
-    });
+          criteria_config: { threshold: 1 },
+          achievement_categories: null,
+        },
+      ];
+      const legacyProgress = [
+        {
+          family_achievement_id: "fa-legacy",
+          unlocked_at: "2026-05-01T00:00:00.000Z",
+          progress: { current: 1, threshold: 1 },
+          notified: true,
+        },
+      ];
 
-    it("returns 201 for Guild Master with valid data", async () => {
-      authAs("GUILD_MASTER");
+      let serviceCallCount = 0;
+      mockServiceSupabase.from.mockImplementation(() => {
+        serviceCallCount++;
+        if (serviceCallCount === 1) {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            order: jest
+              .fn()
+              .mockResolvedValue({ data: achievements, error: null }),
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockResolvedValue({ data: legacyProgress, error: null }),
+        };
+      });
 
-      mockServiceSupabase.from.mockImplementation(() => ({
-        insert: jest.fn().mockReturnValue({
-          select: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: { id: "fa-new", name: "New Achievement" },
-              error: null,
-            }),
-          }),
-        }),
-      }));
-
-      const response = await createFamilyAchievement(
-        createRequest("POST", {
-          name: "New Achievement",
-          criteria_type: "quest_complete",
-          criteria_config: { threshold: 10 },
-        }),
-      );
-      expect(response.status).toBe(201);
+      const response = await getFamilyAchievements(createRequest());
+      expect(response.status).toBe(200);
+      expect(mockBackfillIfStale).not.toHaveBeenCalled();
       const body = await response.json();
-      expect(body.success).toBe(true);
-    });
-
-    it("seeds progress via recomputeAchievement after successful creation", async () => {
-      authAs("GUILD_MASTER");
-
-      mockServiceSupabase.from.mockImplementation(() => ({
-        insert: jest.fn().mockReturnValue({
-          select: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: { id: "fa-seeded", name: "Seeded Achievement" },
-              error: null,
-            }),
-          }),
-        }),
-      }));
-
-      const response = await createFamilyAchievement(
-        createRequest("POST", {
-          name: "Seeded Achievement",
-          criteria_type: "quest_complete",
-          criteria_config: { threshold: 10 },
+      expect(body.achievements[0]).toEqual(
+        expect.objectContaining({
+          name: "???",
+          unlocked_at: null,
+          progress: null,
+          notified: null,
         }),
       );
-      expect(response.status).toBe(201);
-      expect(mockRecomputeAchievement).toHaveBeenCalledWith(
-        "family-001",
-        "fa-seeded",
-      );
-    });
-
-    it("returns 400 when name is missing", async () => {
-      authAs("GUILD_MASTER");
-      const response = await createFamilyAchievement(
-        createRequest("POST", { criteria_type: "quest_complete" }),
-      );
-      expect(response.status).toBe(400);
-    });
-
-    it("returns 400 when criteria_type is unsupported", async () => {
-      authAs("GUILD_MASTER");
-      const response = await createFamilyAchievement(
-        createRequest("POST", {
-          name: "Bad Achievement",
-          criteria_type: "not_a_real_type",
-        }),
-      );
-      expect(response.status).toBe(400);
-      const body = await response.json();
-      expect(body.code).toBe("FAMILY_ACHIEVEMENT_CRITERIA_TYPE_UNSUPPORTED");
+      expect(serviceCallCount).toBe(1);
     });
   });
+
 });

--- a/tests/unit/app/api/reward-redemptions.create.test.ts
+++ b/tests/unit/app/api/reward-redemptions.create.test.ts
@@ -1,0 +1,82 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  rpc: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/reward-redemptions/route";
+
+const USER_ID = "33333333-3333-4333-8333-333333333333";
+const REWARD_ID = "55555555-5555-4555-8555-555555555555";
+
+function makeRequest(body: object, auth: string | null = "Bearer token") {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (auth) headers.authorization = auth;
+  return new NextRequest("http://localhost/api/reward-redemptions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAuth() {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: USER_ID } },
+    error: null,
+  });
+  mockServerSupabase.from.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({
+      data: { id: USER_ID, role: "HERO", family_id: "fam-1" },
+      error: null,
+    }),
+  });
+}
+
+describe("POST /api/reward-redemptions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("redeems through a server-side DB RPC instead of accepting cached client gold", async () => {
+    setupAuth();
+    const redemption = { id: "redemption-1", reward_id: REWARD_ID, user_id: USER_ID };
+    mockServiceSupabase.rpc.mockResolvedValue({ data: [redemption], error: null });
+
+    const res = await POST(
+      makeRequest({ rewardId: REWARD_ID, cachedGold: 123, cost: 100 }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockServiceSupabase.rpc).toHaveBeenCalledWith("fn_redeem_reward", {
+      p_user_id: USER_ID,
+      p_reward_id: REWARD_ID,
+    });
+    const body = await res.json();
+    expect(body.redemption).toEqual(redemption);
+  });
+
+  it("maps insufficient server-side gold to a conflict response", async () => {
+    setupAuth();
+    mockServiceSupabase.rpc.mockResolvedValue({
+      data: null,
+      error: { message: "INSUFFICIENT_GOLD" },
+    });
+
+    const res = await POST(makeRequest({ rewardId: REWARD_ID }));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("INSUFFICIENT_GOLD");
+  });
+});

--- a/tests/unit/app/api/reward-redemptions.deny.test.ts
+++ b/tests/unit/app/api/reward-redemptions.deny.test.ts
@@ -1,0 +1,186 @@
+const mockServerSupabase = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+};
+
+const mockServiceSupabase = {
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(() => mockServerSupabase),
+  createServiceSupabaseClient: jest.fn(() => mockServiceSupabase),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/reward-redemptions/[id]/deny/route";
+
+const VALID_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const INVALID_ID = "not-a-uuid";
+const FAMILY_ID = "fam-1";
+const OTHER_FAMILY_ID = "fam-other";
+const GM_USER_ID = "gm-user-1";
+const REDEEMER_USER_ID = "hero-user-1";
+
+function makeRequest(auth: string | null = "Bearer token") {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (auth !== null) headers.authorization = auth;
+  return new NextRequest("http://localhost/test", { method: "POST", headers });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function setupServerAuth(role: "GUILD_MASTER" | "HERO", familyId = FAMILY_ID) {
+  mockServerSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: GM_USER_ID } },
+    error: null,
+  });
+  mockServerSupabase.from.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest
+      .fn()
+      .mockResolvedValue({ data: { id: GM_USER_ID, role, family_id: familyId }, error: null }),
+  });
+}
+
+function setupServiceMocks({
+  redemption = {
+    id: VALID_UUID,
+    user_id: REDEEMER_USER_ID,
+    status: "PENDING",
+    cost: 50,
+  } as object | null,
+  redemptionError = null as object | null,
+  redeemerFamilyId = FAMILY_ID as string | null,
+  rpcData = [{ id: VALID_UUID, status: "DENIED" }] as object[] | null,
+  rpcError = null as { message: string } | null,
+} = {}) {
+  mockServiceSupabase.from.mockImplementation((table: string) => {
+    if (table === "reward_redemptions") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest
+          .fn()
+          .mockResolvedValue({ data: redemption, error: redemptionError }),
+      };
+    }
+
+    if (table === "user_profiles") {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({
+          data:
+            redeemerFamilyId !== null ? { family_id: redeemerFamilyId } : null,
+          error: null,
+        }),
+      };
+    }
+
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+  mockServiceSupabase.rpc.mockResolvedValue({ data: rpcData, error: rpcError });
+}
+
+describe("POST /api/reward-redemptions/[id]/deny", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 and calls the atomic deny/refund RPC for same-family Guild Masters", async () => {
+    setupServerAuth("GUILD_MASTER");
+    setupServiceMocks();
+
+    const res = await POST(makeRequest(), params(VALID_UUID));
+
+    expect(res.status).toBe(200);
+    expect(mockServiceSupabase.rpc).toHaveBeenCalledWith(
+      "fn_deny_reward_redemption",
+      {
+        p_redemption_id: VALID_UUID,
+        p_user_id: REDEEMER_USER_ID,
+        p_amount: 50,
+        p_denied_by: GM_USER_ID,
+      },
+    );
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.redemption.status).toBe("DENIED");
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await POST(makeRequest(null), params(VALID_UUID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when requester is not a Guild Master", async () => {
+    setupServerAuth("HERO");
+
+    const res = await POST(makeRequest(), params(VALID_UUID));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("DENY_REDEMPTION_FORBIDDEN");
+  });
+
+  it("returns 400 when redemption ID is invalid", async () => {
+    setupServerAuth("GUILD_MASTER");
+
+    const res = await POST(makeRequest(), params(INVALID_ID));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("REDEMPTION_ID_INVALID");
+  });
+
+  it("returns 404 when redemption does not exist", async () => {
+    setupServerAuth("GUILD_MASTER");
+    setupServiceMocks({ redemption: null });
+
+    const res = await POST(makeRequest(), params(VALID_UUID));
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("REDEMPTION_NOT_FOUND");
+  });
+
+  it("returns 403 when redemption belongs to another family", async () => {
+    setupServerAuth("GUILD_MASTER", FAMILY_ID);
+    setupServiceMocks({ redeemerFamilyId: OTHER_FAMILY_ID });
+
+    const res = await POST(makeRequest(), params(VALID_UUID));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("DENY_REDEMPTION_FORBIDDEN");
+  });
+
+  it("returns 409 when redemption is not pending", async () => {
+    setupServerAuth("GUILD_MASTER");
+    setupServiceMocks({
+      redemption: {
+        id: VALID_UUID,
+        user_id: REDEEMER_USER_ID,
+        status: "APPROVED",
+        cost: 50,
+      },
+    });
+
+    const res = await POST(makeRequest(), params(VALID_UUID));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("REDEMPTION_NOT_PENDING");
+  });
+});

--- a/tests/unit/db/atomic-gold-mutations-migration.test.ts
+++ b/tests/unit/db/atomic-gold-mutations-migration.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const migration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260615000002_atomic_gold_mutations.sql"),
+  "utf8",
+);
+
+describe("atomic gold mutation SQL", () => {
+  it("keeps reward redemption debit, redemption row, and audit row in one DB function", () => {
+    expect(migration).toContain("CREATE OR REPLACE FUNCTION fn_redeem_reward");
+    expect(migration).toMatch(/UPDATE characters\s+SET gold = COALESCE\(characters\.gold, 0\) - COALESCE\(v_reward\.cost, 0\)/);
+    expect(migration).toContain("AND COALESCE(characters.gold, 0) >= COALESCE(v_reward.cost, 0)");
+    expect(migration).toContain("INSERT INTO reward_redemptions");
+    expect(migration).toContain("'STORE_PURCHASE'::transaction_type");
+    expect(migration).toContain("RAISE EXCEPTION 'INSUFFICIENT_GOLD'");
+  });
+
+  it("keeps quest reward increments and audit row in one DB function", () => {
+    expect(migration).toContain("CREATE OR REPLACE FUNCTION fn_apply_quest_reward");
+    expect(migration).toMatch(/gold = COALESCE\(characters\.gold, 0\) \+ COALESCE\(p_gold, 0\)/);
+    expect(migration).toContain("active_family_quest_id = NULL");
+    expect(migration).toContain("AND user_id = p_user_id");
+    expect(migration).toContain("'QUEST_REWARD'::transaction_type");
+    expect(migration).toContain("p_quest_id");
+  });
+
+  it("keeps denied-redemption status and refund audit in one DB function", () => {
+    expect(migration).toContain("CREATE OR REPLACE FUNCTION fn_deny_reward_redemption");
+    expect(migration).toContain("status = 'DENIED'");
+    expect(migration).toContain("AND status = 'PENDING'");
+    expect(migration).toContain("PERFORM fn_refund_reward_gold(p_user_id, p_amount, p_redemption_id)");
+    expect(migration).toContain("'REWARD_REFUND'::transaction_type");
+  });
+
+  it("preserves the Towner incident sequence by composing relative deltas", () => {
+    const staleClientBalance = 123;
+    const questPayout = 102;
+    const rewardCost = 100;
+
+    // The incident ended at 23 because the stale client overwrote gold with
+    // 123 - 100. Atomic DB-side deltas must compose to 123 + 102 - 100.
+    expect(staleClientBalance + questPayout - rewardCost).toBe(125);
+    expect(migration).toMatch(/gold = COALESCE\(characters\.gold, 0\) \+ COALESCE\(p_gold, 0\)/);
+    expect(migration).toMatch(/gold = COALESCE\(characters\.gold, 0\) - COALESCE\(v_reward\.cost, 0\)/);
+    expect(migration).not.toContain("gold = p_gold");
+    expect(migration).not.toContain("gold = v_reward.cost");
+  });
+});

--- a/tests/unit/lib/family-achievement-backfill-if-stale.test.ts
+++ b/tests/unit/lib/family-achievement-backfill-if-stale.test.ts
@@ -9,7 +9,14 @@ jest.mock("@/lib/family-achievement-progress/family-evaluators", () => ({
   isCharBased: jest.fn().mockReturnValue(false),
 }));
 
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn(),
+}));
+
 import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
+import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
+
+const mockGetActiveSeasonForFamily = getActiveSeasonForFamily as jest.Mock;
 
 function makeChain(overrides: Record<string, jest.Mock> = {}) {
   const chain: Record<string, jest.Mock> = {
@@ -27,6 +34,14 @@ describe("FamilyAchievementProgressService.backfillIfStale", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetActiveSeasonForFamily.mockResolvedValue({
+      id: "season-current",
+      family_id: "fam-1",
+      name: "Current Season",
+      theme: null,
+      starts_at: "2026-06-01T00:00:00.000Z",
+      ends_at: null,
+    });
     const readClient = { from: jest.fn().mockReturnValue(makeChain()) };
     service = new FamilyAchievementProgressService(readClient as never);
     jest.spyOn(service, "backfillProgress").mockResolvedValue(undefined);
@@ -58,6 +73,15 @@ describe("FamilyAchievementProgressService.backfillIfStale", () => {
     const result = await service.backfillIfStale("fam-1", true, [], [], false);
     expect(result).toBe(true);
     expect(service.backfillProgress).toHaveBeenCalledWith("fam-1");
+  });
+
+  it("skips backfill when missing/legacy rows exist but no active season is valid", async () => {
+    mockGetActiveSeasonForFamily.mockResolvedValueOnce(null);
+
+    const result = await service.backfillIfStale("fam-1", true, [], [], true);
+
+    expect(result).toBe(false);
+    expect(service.backfillProgress).not.toHaveBeenCalled();
   });
 
   it("backfills and returns true when stored member_count differs from current", async () => {

--- a/tests/unit/lib/family-achievement-update-progress.test.ts
+++ b/tests/unit/lib/family-achievement-update-progress.test.ts
@@ -12,6 +12,17 @@ jest.mock("@/lib/family-achievement-progress/family-evaluators", () => ({
   ALL_FAMILY_CRITERIA_TYPES: ["quest_complete"],
 }));
 
+jest.mock("@/lib/seasons/active-season", () => ({
+  getActiveSeasonForFamily: jest.fn().mockResolvedValue({
+    id: "season-current",
+    family_id: "fam-1",
+    name: "Current Season",
+    theme: null,
+    starts_at: "2026-06-01T00:00:00.000Z",
+    ends_at: null,
+  }),
+}));
+
 import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
 import { FAMILY_EVALUATOR_REGISTRY } from "@/lib/family-achievement-progress/family-evaluators";
 

--- a/tests/unit/lib/quest-instance/approve-quest-atomic.test.ts
+++ b/tests/unit/lib/quest-instance/approve-quest-atomic.test.ts
@@ -1,0 +1,125 @@
+import { approveQuest } from "@/lib/quest-instance/approve-quest";
+import { createServiceSupabaseClient } from "@/lib/supabase-server";
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServiceSupabaseClient: jest.fn(),
+}));
+
+const mockCreateServiceSupabaseClient =
+  createServiceSupabaseClient as jest.MockedFunction<
+    typeof createServiceSupabaseClient
+  >;
+
+const QUEST_ID = "11111111-1111-4111-8111-111111111111";
+const CHARACTER_ID = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "33333333-3333-4333-8333-333333333333";
+const FAMILY_ID = "44444444-4444-4444-8444-444444444444";
+
+function chainFor(value: unknown) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    order: jest.fn().mockResolvedValue(value),
+    single: jest.fn().mockResolvedValue(value),
+    maybeSingle: jest.fn().mockResolvedValue(value),
+    update: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockResolvedValue({ error: null }),
+  };
+}
+
+describe("approveQuest atomic gold mutation", () => {
+  it("applies quest payout through a server-side atomic stats and audit RPC", async () => {
+    const quest = {
+      id: QUEST_ID,
+      assigned_to_id: USER_ID,
+      family_id: FAMILY_ID,
+      status: "COMPLETED",
+      completed_at: "2026-06-14T22:21:09.000Z",
+      xp_reward: 10,
+      gold_reward: 85,
+      volunteer_bonus: 0.2,
+      volunteered_by: CHARACTER_ID,
+      template_id: null,
+      recurrence_pattern: null,
+    };
+    const character = {
+      id: CHARACTER_ID,
+      user_id: USER_ID,
+      gold: 123,
+      xp: 0,
+      level: 1,
+      active_family_quest_id: QUEST_ID,
+    };
+
+    const transactionInsert = jest.fn().mockResolvedValue({ error: null });
+    const characterUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    const userScopedRpc = jest.fn();
+    const serviceScopedRpc = jest
+      .fn()
+      .mockResolvedValue({ data: [{ xp: 12, gold: 135, level: 1 }], error: null });
+    mockCreateServiceSupabaseClient.mockReturnValue({ rpc: serviceScopedRpc });
+
+    const client = {
+      rpc: userScopedRpc,
+      from: jest.fn((table: string) => {
+        if (table === "quest_instances") {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest
+              .fn()
+              .mockResolvedValueOnce({ data: quest, error: null })
+              .mockResolvedValueOnce({
+                data: { ...quest, status: "APPROVED" },
+                error: null,
+              }),
+            update: jest.fn().mockReturnThis(),
+          };
+        }
+        if (table === "characters") {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({ data: character, error: null }),
+            order: jest.fn().mockResolvedValue({ data: [character], error: null }),
+            update: characterUpdate,
+          };
+        }
+        if (table === "families") {
+          return chainFor({ data: { timezone: "America/Chicago" }, error: null });
+        }
+        if (table === "transactions") {
+          return { insert: transactionInsert };
+        }
+        return chainFor({ data: null, error: null });
+      }),
+    };
+
+    await approveQuest(
+      {
+        client: client as never,
+        streakService: {
+          getStreak: jest.fn(),
+          incrementStreak: jest.fn(),
+          resetStreak: jest.fn(),
+        } as never,
+        progressService: { updateProgress: jest.fn().mockResolvedValue(undefined) },
+      },
+      QUEST_ID,
+    );
+
+    expect(userScopedRpc).not.toHaveBeenCalled();
+    expect(serviceScopedRpc).toHaveBeenCalledWith("fn_apply_quest_reward", {
+      p_character_id: CHARACTER_ID,
+      p_quest_id: QUEST_ID,
+      p_user_id: USER_ID,
+      p_xp: 12,
+      p_gold: 102,
+    });
+    expect(characterUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ gold: expect.any(Number) }),
+    );
+  });
+});

--- a/tests/unit/lib/season-reset-regressions.test.ts
+++ b/tests/unit/lib/season-reset-regressions.test.ts
@@ -129,7 +129,14 @@ function makeIndividualWriteClient() {
     })),
   }));
   const rpcSingle = jest.fn().mockResolvedValue({
-    data: { xp: 10, gold: 5, level: 1 },
+    data: {
+      unlocked_achievement_ids: [ACHIEVEMENT_ID],
+      awarded_xp: 10,
+      awarded_gold: 5,
+      xp: 10,
+      gold: 5,
+      level: 1,
+    },
     error: null,
   });
   const rpc = jest.fn(() => ({ single: rpcSingle }));
@@ -198,13 +205,16 @@ describe("season reset regression coverage", () => {
     await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
     await service.updateProgress(CHARACTER_ID, { type: "QUEST_APPROVED" });
 
-    expect(writeClient.unlockUpdate).toHaveBeenCalledTimes(1);
+    expect(writeClient.unlockUpdate).not.toHaveBeenCalled();
     expect(writeClient.rpc).toHaveBeenCalledTimes(1);
-    expect(writeClient.rpc).toHaveBeenCalledWith("fn_increment_character_stats", {
-      p_character_id: CHARACTER_ID,
-      p_xp: 10,
-      p_gold: 5,
-    });
+    expect(writeClient.rpc).toHaveBeenCalledWith(
+      "fn_unlock_achievements_and_grant_rewards",
+      {
+        p_achievement_ids: [ACHIEVEMENT_ID],
+        p_character_id: CHARACTER_ID,
+        p_season_id: SEASON_ID,
+      },
+    );
   });
 
   it.each([

--- a/tests/unit/release-pipeline-config.test.ts
+++ b/tests/unit/release-pipeline-config.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function readText(relativePath: string) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("semantic release pipeline configuration", () => {
+  it("defines semantic-release for main with versioned file updates", () => {
+    const releaseConfig = JSON.parse(readText(".releaserc.json"));
+
+    expect(releaseConfig.branches).toEqual(["main"]);
+    expect(releaseConfig.tagFormat).toBe("v${version}");
+
+    expect(releaseConfig.plugins).toEqual(
+      expect.arrayContaining([
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        ["@semantic-release/changelog", expect.objectContaining({ changelogFile: "CHANGELOG.md" })],
+        ["@semantic-release/npm", expect.objectContaining({ npmPublish: false })],
+        [
+          "@semantic-release/git",
+          expect.objectContaining({
+            assets: expect.arrayContaining([
+              "CHANGELOG.md",
+              "package.json",
+              "package-lock.json",
+            ]),
+          }),
+        ],
+        "@semantic-release/github",
+      ]),
+    );
+  });
+
+  it("runs a release workflow on main pushes and exposes manual dispatch", () => {
+    const workflow = readText(".github/workflows/release.yml");
+
+    expect(workflow).toContain("name: Release");
+    expect(workflow).toContain("push:");
+    expect(workflow).toContain("- main");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("semantic-release");
+  });
+
+  it("back-merges released main changes into develop only after a published release", () => {
+    const workflow = readText(".github/workflows/backmerge-main-to-develop.yml");
+
+    expect(workflow).toContain("name: Back-merge main into develop");
+    expect(workflow).toContain("release:");
+    expect(workflow).toContain("published");
+    expect(workflow).toContain("github.event.release.target_commitish == 'main'");
+    expect(workflow).toContain("git checkout develop");
+    expect(workflow).toContain("git merge --no-ff origin/main");
+    expect(workflow).toContain("git push origin develop");
+  });
+});

--- a/tests/unit/rewards/reward-service.redemptions.test.ts
+++ b/tests/unit/rewards/reward-service.redemptions.test.ts
@@ -5,12 +5,14 @@ import { RewardRedemption, UserProfile } from "@/lib/types/database";
 jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn(),
+    rpc: jest.fn(),
   },
 }));
 
 describe("RewardService - redemptions", () => {
   let service: RewardService;
   let mockFrom: jest.Mock;
+  let mockRpc: jest.Mock;
   let mockSelect: jest.Mock;
   let mockInsert: jest.Mock;
   let mockUpdate: jest.Mock;
@@ -28,12 +30,14 @@ describe("RewardService - redemptions", () => {
     mockEq = jest.fn();
     mockSingle = jest.fn();
     mockFrom = jest.fn();
+    mockRpc = jest.fn();
     mockFrom.mockReturnValue({
       select: mockSelect,
       insert: mockInsert,
       update: mockUpdate,
     });
     (supabase.from as jest.Mock) = mockFrom;
+    (supabase.rpc as jest.Mock) = mockRpc;
   });
 
   afterEach(() => {
@@ -211,38 +215,37 @@ describe("RewardService - redemptions", () => {
   describe("refundGold", () => {
     const mockUserId = "user-123";
     const mockGoldAmount = 50;
+    const mockRedemptionId = "redemption-123";
 
-    it("refunds gold to character", async () => {
-      mockSelect.mockReturnValueOnce({ eq: mockEq });
-      mockEq.mockReturnValueOnce({ single: mockSingle });
-      mockSingle.mockResolvedValueOnce({ data: { gold: 100 }, error: null });
-      mockUpdate.mockReturnValueOnce({ eq: mockEq });
-      mockEq.mockResolvedValueOnce({ data: null, error: null });
+    it("refunds gold through an atomic database RPC", async () => {
+      mockRpc.mockResolvedValueOnce({ data: null, error: null });
+
+      await service.refundGold(mockUserId, mockGoldAmount, mockRedemptionId);
+
+      expect(mockRpc).toHaveBeenCalledWith("fn_refund_reward_gold", {
+        p_user_id: mockUserId,
+        p_amount: mockGoldAmount,
+        p_redemption_id: mockRedemptionId,
+      });
+      expect(mockFrom).not.toHaveBeenCalledWith("characters");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("passes a null redemption id when one is not provided", async () => {
+      mockRpc.mockResolvedValueOnce({ data: null, error: null });
 
       await service.refundGold(mockUserId, mockGoldAmount);
 
-      expect(mockFrom).toHaveBeenCalledWith("characters");
-      expect(mockUpdate).toHaveBeenCalledWith({ gold: 150 });
+      expect(mockRpc).toHaveBeenCalledWith("fn_refund_reward_gold", {
+        p_user_id: mockUserId,
+        p_amount: mockGoldAmount,
+        p_redemption_id: null,
+      });
     });
 
-    it("throws when character fetch fails", async () => {
-      const mockError = { message: "Character not found" };
-      mockSelect.mockReturnValue({ eq: mockEq });
-      mockEq.mockReturnValue({ single: mockSingle });
-      mockSingle.mockResolvedValue({ data: null, error: mockError });
-
-      await expect(service.refundGold(mockUserId, mockGoldAmount)).rejects.toThrow(
-        "Failed to fetch character: Character not found",
-      );
-    });
-
-    it("throws when refund update fails", async () => {
+    it("throws when the atomic refund fails", async () => {
       const mockError = { message: "Update failed" };
-      mockSelect.mockReturnValue({ eq: mockEq });
-      mockEq.mockReturnValueOnce({ single: mockSingle });
-      mockSingle.mockResolvedValueOnce({ data: { gold: 100 }, error: null });
-      mockUpdate.mockReturnValue({ eq: mockEq });
-      mockEq.mockResolvedValueOnce({ data: null, error: mockError });
+      mockRpc.mockResolvedValueOnce({ data: null, error: mockError });
 
       await expect(service.refundGold(mockUserId, mockGoldAmount)).rejects.toThrow(
         "Failed to refund gold: Update failed",


### PR DESCRIPTION
## Summary
- merge the post-`v0.8.0` develop changes into `main`
- include operational fixes from #172, #180, and #181 plus docs updates from #174 and #175
- include the new semantic-release / back-merge automation from #182

## Test Plan
- [x] PR smoke suite already passed for #182
- [x] local build/lint/release-pipeline guard checks passed while implementing #182
- [x] merge set reviewed: `v0.8.0..develop` contains `fix:` commits and docs/ci changes only, so the next semantic-release on `main` should be a patch bump

## Release implications
- expected semantic-release result after merge: `v0.8.1`
- release commit should update `CHANGELOG.md`, `package.json`, and `package-lock.json`
- published GitHub release should trigger the `main` -> `develop` back-merge workflow
- no deployment is performed by this PR; release publication only
