### PR TITLE
ci: run semantic-release on node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install Supabase CLI

--- a/tests/unit/release-pipeline-config.test.ts
+++ b/tests/unit/release-pipeline-config.test.ts
@@ -42,6 +42,7 @@ describe("semantic release pipeline configuration", () => {
     expect(workflow).toContain("push:");
     expect(workflow).toContain("- main");
     expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("node-version: 24");
     expect(workflow).toContain("semantic-release");
   });
 


### PR DESCRIPTION
## Summary
- fix the release workflow to install Node 24 before running semantic-release
- add a unit assertion that the release workflow stays on Node 24+

## Why
The first `main` release run after #183 failed because `semantic-release@25` requires Node `^22.14.0 || >=24.10.0`, while the workflow was still installing Node 20.

## Test Plan
- [x] `npm run test:release-pipeline`
- [x] parse `.releaserc.json` and workflow YAML files with Python
