### PR TITLE
ci: trigger backmerge after release workflow

### DIFF
--- a/.github/workflows/backmerge-main-to-develop.yml
+++ b/.github/workflows/backmerge-main-to-develop.yml
@@ -1,9 +1,11 @@
 name: Back-merge main into develop
 
 on:
-  release:
+  workflow_run:
+    workflows:
+      - Release
     types:
-      - published
+      - completed
 
 permissions:
   contents: write
@@ -14,7 +16,7 @@ concurrency:
 
 jobs:
   backmerge:
-    if: github.event.release.target_commitish == 'main'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
 
     steps:
@@ -35,5 +37,5 @@ jobs:
       - name: Back-merge main into develop
         run: |
           git checkout develop
-          git merge --no-ff origin/main -m "chore: back-merge main into develop after release ${GITHUB_REF_NAME} [skip ci]"
+          git merge --no-ff origin/main -m "chore: back-merge main into develop after release workflow [skip ci]"
           git push origin develop

--- a/tests/unit/release-pipeline-config.test.ts
+++ b/tests/unit/release-pipeline-config.test.ts
@@ -50,9 +50,10 @@ describe("semantic release pipeline configuration", () => {
     const workflow = readText(".github/workflows/backmerge-main-to-develop.yml");
 
     expect(workflow).toContain("name: Back-merge main into develop");
-    expect(workflow).toContain("release:");
-    expect(workflow).toContain("published");
-    expect(workflow).toContain("github.event.release.target_commitish == 'main'");
+    expect(workflow).toContain("workflow_run:");
+    expect(workflow).toContain("- Release");
+    expect(workflow).toContain("completed");
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'");
     expect(workflow).toContain("git checkout develop");
     expect(workflow).toContain("git merge --no-ff origin/main");
     expect(workflow).toContain("git push origin develop");


### PR DESCRIPTION
## Summary
- trigger the back-merge automation from the successful `Release` workflow instead of the `release.published` event
- keep test coverage aligned with the new workflow trigger

## Why
The `v0.8.1` release published successfully, but GitHub did not fire the back-merge workflow from the release event created by `GITHUB_TOKEN`. Triggering from `workflow_run` of `Release` is more reliable for this repo.

## Test Plan
- [x] `npm run test:release-pipeline`
- [x] parse `.releaserc.json` and workflow YAML files with Python
