### PR TITLE
fix: stabilize rewards tab smoke selector

### DIFF
--- a/tests/e2e/auth.smoke.test.ts
+++ b/tests/e2e/auth.smoke.test.ts
@@ -44,8 +44,8 @@ test.describe("Auth smoke tests", () => {
     await expect(rewardsTab).toBeVisible({ timeout: 10_000 });
     await rewardsTab.click();
 
-    await expect(
-      page.getByText(/reward store/i).or(page.getByText(/store/i)),
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("reward-store-title")).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Replace the ambiguous rewards-tab smoke assertion with the existing `reward-store-title` test id.
- Keep the click target on `tab-rewards` and assert the user-visible Reward Store header after switching tabs.

## Test Plan
- [x] `git diff --check origin/develop...HEAD`
- [x] `npx eslint tests/e2e/auth.smoke.test.ts`
- [ ] `SUPABASE_SERVICE_ROLE_KEY=... NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=... npx playwright test tests/e2e/auth.smoke.test.ts -g "authenticated user can switch to rewards tab" --reporter=line` — blocked locally because the local Supabase API on 127.0.0.1:54321 refused connections after `npx supabase start` timed out during schema initialization.

Closes #189
