### PR TITLE
refactor: colocate quest-template-manager tests

### DIFF
--- a/components/quests/quest-template-manager/delete-modal.test.tsx
+++ b/components/quests/quest-template-manager/delete-modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { DeleteModal } from '../delete-modal';
+import { DeleteModal } from './delete-modal';
 import type { QuestTemplate } from '@/lib/types/database';
 
 const mockTemplate: QuestTemplate = {

--- a/components/quests/quest-template-manager/template-form.test.tsx
+++ b/components/quests/quest-template-manager/template-form.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { TemplateForm } from '../template-form';
+import { TemplateForm } from './template-form';
 import { useAuth } from '@/lib/auth-context';
 import { userService } from '@/lib/user-service';
 import { supabase } from '@/lib/supabase';

--- a/components/quests/quest-template-manager/template-item.test.tsx
+++ b/components/quests/quest-template-manager/template-item.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { TemplateItem } from '../template-item';
+import { TemplateItem } from './template-item';
 import type { QuestTemplate } from '@/lib/types/database';
 
 // Mock framer-motion to avoid animation issues in tests

--- a/components/quests/quest-template-manager/template-list.test.tsx
+++ b/components/quests/quest-template-manager/template-list.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { TemplateList } from '../template-list';
+import { TemplateList } from './template-list';
 import type { QuestTemplate } from '@/lib/types/database';
 
 const mockIndividualTemplate: QuestTemplate = {


### PR DESCRIPTION
## Summary
- Migrates the quest-template-manager test cluster out of `components/quests/quest-template-manager/__tests__/`.
- Colocates the four component test files beside the modules they cover.
- Updates relative imports for the new colocated paths.

## Scope
- Bounded slice for issue #143: `components/quests/quest-template-manager/` only.
- Does not migrate other legacy `__tests__` clusters.

## Test Plan
- [x] Baseline focused Jest passed before relocation: `npm run test:unit -- --runTestsByPath components/quests/quest-template-manager/__tests__/delete-modal.test.tsx components/quests/quest-template-manager/__tests__/template-form.test.tsx components/quests/quest-template-manager/__tests__/template-item.test.tsx components/quests/quest-template-manager/__tests__/template-list.test.tsx`
- [x] Focused Jest passed after relocation: `npm run test:unit -- --runTestsByPath components/quests/quest-template-manager/delete-modal.test.tsx components/quests/quest-template-manager/template-form.test.tsx components/quests/quest-template-manager/template-item.test.tsx components/quests/quest-template-manager/template-list.test.tsx`
- [x] `npx eslint components/quests/quest-template-manager/delete-modal.test.tsx components/quests/quest-template-manager/template-form.test.tsx components/quests/quest-template-manager/template-item.test.tsx components/quests/quest-template-manager/template-list.test.tsx`
- [x] `git diff --check origin/develop...HEAD`
- [x] Env-seeded `npm run build` with dummy local Supabase/Cron env values

## Release implications
- Test-layout-only refactor; no runtime or deployment behavior changes expected.

Refs #143
