### PR TITLE
refactor: colocate quest create modal tests

### DIFF
--- a/components/quests/quest-create-modal/adhoc-quest-form.test.tsx
+++ b/components/quests/quest-create-modal/adhoc-quest-form.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import AdhocQuestForm from "../adhoc-quest-form";
+import AdhocQuestForm from "./adhoc-quest-form";
 import { QuestDifficulty, QuestCategory } from "@/lib/types/database";
 
 describe("AdhocQuestForm", () => {

--- a/components/quests/quest-create-modal/recurring-quest-form.test.tsx
+++ b/components/quests/quest-create-modal/recurring-quest-form.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import RecurringQuestForm from "../recurring-quest-form";
+import RecurringQuestForm from "./recurring-quest-form";
 import type { TemplateFormData } from "@/lib/types/quest-templates";
 
 describe("RecurringQuestForm", () => {

--- a/components/quests/quest-create-modal/template-quest-form.test.tsx
+++ b/components/quests/quest-create-modal/template-quest-form.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import TemplateQuestForm from "../template-quest-form";
+import TemplateQuestForm from "./template-quest-form";
 import { QuestTemplate } from "@/lib/types/database";
 
 describe("TemplateQuestForm", () => {


### PR DESCRIPTION
## Summary
- Moves the quest-create-modal test cluster out of `__tests__` and into colocated `.test.tsx` files beside the forms they cover.
- Updates the relative imports in the moved tests to match the new colocated layout.
- Keeps issue #143 open for the remaining legacy test clusters.

Refs #143

## Test Plan
- [x] `git diff --check origin/develop...HEAD`
- [x] `npm run test:unit -- --runTestsByPath components/quests/quest-create-modal/adhoc-quest-form.test.tsx components/quests/quest-create-modal/recurring-quest-form.test.tsx components/quests/quest-create-modal/template-quest-form.test.tsx --runInBand`
- [x] `npm run lint -- components/quests/quest-create-modal/adhoc-quest-form.test.tsx components/quests/quest-create-modal/recurring-quest-form.test.tsx components/quests/quest-create-modal/template-quest-form.test.tsx`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_SERVICE_ROLE_KEY=test-service-role-key SUPABASE_URL=http://127.0.0.1:54321 npm run build`

## Documentation impact
None. Test-layout-only refactor.

## Release implications
None. No runtime behavior or release pipeline changes.
