### PR TITLE
refactor: colocate root quest dashboard tests

### DIFF
--- a/components/quests/quest-dashboard/index.realtime-delete-deduplicate.test.tsx
+++ b/components/quests/quest-dashboard/index.realtime-delete-deduplicate.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, waitFor, screen, act } from "@testing-library/react";
-import QuestDashboard from "../quests/quest-dashboard";
+import QuestDashboard from "./index";
 import { useAuth } from "@/lib/auth-context";
 import { useRealtime } from "@/lib/realtime-context";
 import { supabase } from "@/lib/supabase";

--- a/components/quests/quest-dashboard/index.realtime-delete.test.tsx
+++ b/components/quests/quest-dashboard/index.realtime-delete.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, waitFor, screen, act } from "@testing-library/react";
-import QuestDashboard from "../quests/quest-dashboard";
+import QuestDashboard from "./index";
 import { useAuth } from "@/lib/auth-context";
 import { useRealtime } from "@/lib/realtime-context";
 import { supabase } from "@/lib/supabase";


### PR DESCRIPTION
## Summary
- Moves the remaining root `components/__tests__` quest-dashboard DELETE-event tests beside `components/quests/quest-dashboard/index.tsx`.
- Renames the moved files to colocated `index.realtime-delete*.test.tsx` names.
- Updates the QuestDashboard imports for the new colocated paths.

Refs #143

## Test Plan
- [x] `npm run test:unit -- --runTestsByPath components/__tests__/quest-dashboard.test.tsx components/__tests__/quest-dashboard.deduplicate.test.tsx --runInBand` (baseline before move)
- [x] `npm run test:unit -- --runTestsByPath components/quests/quest-dashboard/index.realtime-delete.test.tsx components/quests/quest-dashboard/index.realtime-delete-deduplicate.test.tsx --runInBand`
- [x] `git diff --check origin/develop...HEAD`
- [x] `npx eslint components/quests/quest-dashboard/index.realtime-delete.test.tsx components/quests/quest-dashboard/index.realtime-delete-deduplicate.test.tsx`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`

## Notes
- Build and Jest emitted the existing Next.js workspace-root warning because this Kanban workspace lives under the Hermes Agent checkout, which also has a lockfile. The commands completed successfully.
- This slice is intentionally limited to the two root `components/__tests__` files named in the card.

## Release implications
- None expected; test-layout-only refactor.
