### PR TITLE
refactor: colocate realtime tests

### DIFF
--- a/lib/realtime/achievement-unlock-listener.test.ts
+++ b/lib/realtime/achievement-unlock-listener.test.ts
@@ -1,5 +1,5 @@
-import { createListenerRegistry } from "../listener-registry";
-import type { RealtimeEvent } from "../types";
+import { createListenerRegistry } from "./listener-registry";
+import type { RealtimeEvent } from "./types";
 
 const makeUnlockEvent = (
   overrides: Partial<RealtimeEvent> = {},

--- a/lib/realtime/channel-subscriptions.test.ts
+++ b/lib/realtime/channel-subscriptions.test.ts
@@ -1,5 +1,5 @@
-import { createFamilyRealtimeChannels } from "../channel-subscriptions";
-import { createListenerRegistry } from "../listener-registry";
+import { createFamilyRealtimeChannels } from "./channel-subscriptions";
+import { createListenerRegistry } from "./listener-registry";
 
 const mockOn = jest.fn().mockReturnThis();
 const mockChannel = jest.fn(() => ({ on: mockOn }));


### PR DESCRIPTION
## Summary
- Migrate the bounded `lib/realtime/__tests__/` cluster into colocated test files under `lib/realtime/`.
- Update relative imports in the moved realtime tests to use same-directory module paths.

Refs #143

## Verification
- `git diff --check origin/develop...HEAD`
- `npm run test:unit -- --runTestsByPath lib/realtime/achievement-unlock-listener.test.ts lib/realtime/channel-subscriptions.test.ts`
- `npx eslint lib/realtime/achievement-unlock-listener.test.ts lib/realtime/channel-subscriptions.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_SERVICE_ROLE_KEY=test-service-role-key npm run build`

## Release implications
- None expected. Test-layout-only refactor; no runtime code changes.

## Documentation impact
- None.
