### PR TITLE
refactor: colocate admin statistics tests

### DIFF
--- a/components/admin/statistics/QuestStatisticsCards.test.tsx
+++ b/components/admin/statistics/QuestStatisticsCards.test.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { render, screen } from "@testing-library/react";
-import { QuestStatisticsCards } from "../QuestStatisticsCards";
+import { QuestStatisticsCards } from "./QuestStatisticsCards";
 import type { FamilyStatistics } from "@/lib/statistics-service";
 
 const baseStatistics: FamilyStatistics = {


### PR DESCRIPTION
## Summary
- Colocates the admin statistics QuestStatisticsCards test beside the component it covers.
- Removes the `components/admin/statistics/__tests__/` subdirectory for this bounded slice.
- Updates the relocated test import to use the sibling component path.

## Test Plan
- `npm run test:unit -- --runTestsByPath components/admin/statistics/__tests__/quest-statistics-cards.test.tsx` (baseline before move)
- `npm run test:unit -- --runTestsByPath components/admin/statistics/QuestStatisticsCards.test.tsx` (red after move with old import, then green after import update)
- `git diff --check origin/develop...HEAD`
- `npm run lint -- components/admin/statistics/QuestStatisticsCards.test.tsx`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key npm run build`

## Scope
- Bounded to `components/admin/statistics/__tests__/quest-statistics-cards.test.tsx` migration only.
- No runtime behavior changes.

## Release implications
- None; test layout refactor only.

Refs #143
