### PR TITLE
refactor: colocate pending approvals section test

### DIFF
--- a/components/quests/pending-approvals-section.test.tsx
+++ b/components/quests/pending-approvals-section.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { QuestInstance, QuestStatus } from '@/lib/types/database';
-import PendingApprovalsSection from '../pending-approvals-section';
+import PendingApprovalsSection from './pending-approvals-section';
 
 // Capture QuestCard props for assertions
 const mockQuestCard = jest.fn();
 
-jest.mock('../quest-card', () => ({
+jest.mock('./quest-card', () => ({
   __esModule: true,
   default: (props: Record<string, unknown>) => {
     mockQuestCard(props);


### PR DESCRIPTION
## Summary
- Move `components/quests/__tests__/pending-approvals-section.test.tsx` beside `components/quests/pending-approvals-section.tsx`
- Update relative imports/mocks for colocated layout
- Keep this as the bounded pending-approvals-section slice for issue #143

## Verification
- `npm run test:unit -- --runTestsByPath components/quests/__tests__/pending-approvals-section.test.tsx --runInBand` (baseline before move)
- `npm run test:unit -- --runTestsByPath components/quests/pending-approvals-section.test.tsx --runInBand`
- `npx eslint components/quests/pending-approvals-section.test.tsx`
- `git diff --check origin/develop...HEAD`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co SUPABASE_INTERNAL_URL=https://example.supabase.co SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key JWT_SECRET=*** CRON_SECRET=*** npm run build`

## Release implications
- None. Test layout refactor only; no runtime behavior or deployment changes.

Refs #143
