### PR TITLE
refactor: colocate quest instance service tests

### DIFF
--- a/lib/quest-instance-service.approve.test.ts
+++ b/lib/quest-instance-service.approve.test.ts
@@ -1,6 +1,6 @@
-import { QuestInstanceService } from "../quest-instance-service";
-import { StreakService } from "../streak-service";
-import { supabase } from "../supabase";
+import { QuestInstanceService } from "./quest-instance-service";
+import { StreakService } from "./streak-service";
+import { supabase } from "./supabase";
 import { createServiceSupabaseClient } from "@/lib/supabase-server";
 
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/quest-instance-service.assign.test.ts
+++ b/lib/quest-instance-service.assign.test.ts
@@ -1,5 +1,5 @@
-import { QuestInstanceService } from "../quest-instance-service";
-jest.mock("../supabase", () => ({
+import { QuestInstanceService } from "./quest-instance-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
   },
@@ -9,13 +9,13 @@ import {
   mockCharacter,
   mockCharacterId,
   mockCharacterWithQuest,
-  mockClaimedQuest,
   mockFamilyQuest,
+  mockGMId,
   mockQuestId,
   mockUserId,
 } from "./quest-instance-service.fixtures";
 
-describe("QuestInstanceService - claimQuest", () => {
+describe("QuestInstanceService - assignQuest", () => {
   let service: QuestInstanceService;
   let mockFrom: jest.Mock;
 
@@ -27,7 +27,15 @@ describe("QuestInstanceService - claimQuest", () => {
     jest.clearAllMocks();
   });
 
-  it("should successfully claim an available family quest", async () => {
+  it("should successfully assign an available family quest (GM only)", async () => {
+    const assignedQuest = {
+      ...mockFamilyQuest,
+      status: "PENDING",
+      assigned_to_id: mockUserId,
+      volunteered_by: mockCharacterId,
+      volunteer_bonus: null,
+    };
+
     mockFrom.mockImplementationOnce(() => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -55,7 +63,7 @@ describe("QuestInstanceService - claimQuest", () => {
         eq: jest.fn().mockReturnValue({
           select: jest.fn().mockReturnValue({
             single: jest.fn().mockResolvedValue({
-              data: mockClaimedQuest,
+              data: assignedQuest,
               error: null,
             }),
           }),
@@ -71,13 +79,17 @@ describe("QuestInstanceService - claimQuest", () => {
       }),
     }));
 
-    const result = await service.claimQuest(mockQuestId, mockCharacterId);
+    const result = await service.assignQuest(
+      mockQuestId,
+      mockCharacterId,
+      mockGMId,
+    );
 
-    expect(result).toEqual(mockClaimedQuest);
+    expect(result).toEqual(assignedQuest);
     expect(result.assigned_to_id).toBe(mockUserId);
     expect(result.volunteered_by).toBe(mockCharacterId);
-    expect(result.volunteer_bonus).toBe(0.2);
-    expect(result.status).toBe("CLAIMED");
+    expect(result.volunteer_bonus).toBeNull();
+    expect(result.status).toBe("PENDING");
   });
 
   it("should throw error if quest is not found", async () => {
@@ -93,7 +105,7 @@ describe("QuestInstanceService - claimQuest", () => {
     }));
 
     await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
+      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
     ).rejects.toThrow("Quest not found");
   });
 
@@ -110,18 +122,18 @@ describe("QuestInstanceService - claimQuest", () => {
     }));
 
     await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
+      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
     ).rejects.toThrow("Failed to fetch quest: Database offline");
   });
 
   it("should throw error if quest is not AVAILABLE", async () => {
-    const completedQuest = { ...mockFamilyQuest, status: "COMPLETED" };
+    const claimedQuest = { ...mockFamilyQuest, status: "CLAIMED" };
 
     mockFrom.mockImplementationOnce(() => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
-            data: completedQuest,
+            data: claimedQuest,
             error: null,
           }),
         }),
@@ -129,9 +141,9 @@ describe("QuestInstanceService - claimQuest", () => {
     }));
 
     await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
+      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
     ).rejects.toThrow(
-      "Quest is not available for claiming (status: COMPLETED)",
+      "Quest is not available for assignment (status: CLAIMED)",
     );
   });
 
@@ -150,39 +162,11 @@ describe("QuestInstanceService - claimQuest", () => {
     }));
 
     await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
-    ).rejects.toThrow("Only FAMILY quests can be claimed");
+      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
+    ).rejects.toThrow("Only FAMILY quests can be assigned");
   });
 
-  it("should throw error if character not found", async () => {
-    mockFrom.mockImplementationOnce(() => ({
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data: mockFamilyQuest,
-            error: null,
-          }),
-        }),
-      }),
-    }));
-
-    mockFrom.mockImplementationOnce(() => ({
-      select: jest.fn().mockReturnValue({
-        eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({
-            data: null,
-            error: null,
-          }),
-        }),
-      }),
-    }));
-
-    await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
-    ).rejects.toThrow("Character not found");
-  });
-
-  it("should throw error if hero already has active family quest (anti-hoarding)", async () => {
+  it("should throw error if hero already has active family quest", async () => {
     mockFrom.mockImplementationOnce(() => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -206,18 +190,25 @@ describe("QuestInstanceService - claimQuest", () => {
     }));
 
     await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
+      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
     ).rejects.toThrow(
-      "Hero already has an active family quest. Release the current quest before claiming another.",
+      "Hero already has an active family quest. Release the current quest before assigning another.",
     );
   });
 
   it("should rollback quest update if character update fails", async () => {
+    const assignedQuest = {
+      ...mockFamilyQuest,
+      status: "PENDING",
+      assigned_to_id: mockUserId,
+      volunteered_by: mockCharacterId,
+    };
+
     const mockUpdate = jest.fn().mockReturnValue({
       eq: jest.fn().mockReturnValue({
         select: jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
-            data: mockClaimedQuest,
+            data: assignedQuest,
             error: null,
           }),
         }),
@@ -267,7 +258,7 @@ describe("QuestInstanceService - claimQuest", () => {
     }));
 
     await expect(
-      service.claimQuest(mockQuestId, mockCharacterId),
+      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
     ).rejects.toThrow("Failed to update character: Character update failed");
   });
 });

--- a/lib/quest-instance-service.claim.test.ts
+++ b/lib/quest-instance-service.claim.test.ts
@@ -1,5 +1,5 @@
-import { QuestInstanceService } from "../quest-instance-service";
-jest.mock("../supabase", () => ({
+import { QuestInstanceService } from "./quest-instance-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
   },
@@ -9,13 +9,13 @@ import {
   mockCharacter,
   mockCharacterId,
   mockCharacterWithQuest,
+  mockClaimedQuest,
   mockFamilyQuest,
-  mockGMId,
   mockQuestId,
   mockUserId,
 } from "./quest-instance-service.fixtures";
 
-describe("QuestInstanceService - assignQuest", () => {
+describe("QuestInstanceService - claimQuest", () => {
   let service: QuestInstanceService;
   let mockFrom: jest.Mock;
 
@@ -27,15 +27,7 @@ describe("QuestInstanceService - assignQuest", () => {
     jest.clearAllMocks();
   });
 
-  it("should successfully assign an available family quest (GM only)", async () => {
-    const assignedQuest = {
-      ...mockFamilyQuest,
-      status: "PENDING",
-      assigned_to_id: mockUserId,
-      volunteered_by: mockCharacterId,
-      volunteer_bonus: null,
-    };
-
+  it("should successfully claim an available family quest", async () => {
     mockFrom.mockImplementationOnce(() => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -63,7 +55,7 @@ describe("QuestInstanceService - assignQuest", () => {
         eq: jest.fn().mockReturnValue({
           select: jest.fn().mockReturnValue({
             single: jest.fn().mockResolvedValue({
-              data: assignedQuest,
+              data: mockClaimedQuest,
               error: null,
             }),
           }),
@@ -79,17 +71,13 @@ describe("QuestInstanceService - assignQuest", () => {
       }),
     }));
 
-    const result = await service.assignQuest(
-      mockQuestId,
-      mockCharacterId,
-      mockGMId,
-    );
+    const result = await service.claimQuest(mockQuestId, mockCharacterId);
 
-    expect(result).toEqual(assignedQuest);
+    expect(result).toEqual(mockClaimedQuest);
     expect(result.assigned_to_id).toBe(mockUserId);
     expect(result.volunteered_by).toBe(mockCharacterId);
-    expect(result.volunteer_bonus).toBeNull();
-    expect(result.status).toBe("PENDING");
+    expect(result.volunteer_bonus).toBe(0.2);
+    expect(result.status).toBe("CLAIMED");
   });
 
   it("should throw error if quest is not found", async () => {
@@ -105,7 +93,7 @@ describe("QuestInstanceService - assignQuest", () => {
     }));
 
     await expect(
-      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
+      service.claimQuest(mockQuestId, mockCharacterId),
     ).rejects.toThrow("Quest not found");
   });
 
@@ -122,18 +110,18 @@ describe("QuestInstanceService - assignQuest", () => {
     }));
 
     await expect(
-      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
+      service.claimQuest(mockQuestId, mockCharacterId),
     ).rejects.toThrow("Failed to fetch quest: Database offline");
   });
 
   it("should throw error if quest is not AVAILABLE", async () => {
-    const claimedQuest = { ...mockFamilyQuest, status: "CLAIMED" };
+    const completedQuest = { ...mockFamilyQuest, status: "COMPLETED" };
 
     mockFrom.mockImplementationOnce(() => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
-            data: claimedQuest,
+            data: completedQuest,
             error: null,
           }),
         }),
@@ -141,9 +129,9 @@ describe("QuestInstanceService - assignQuest", () => {
     }));
 
     await expect(
-      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
+      service.claimQuest(mockQuestId, mockCharacterId),
     ).rejects.toThrow(
-      "Quest is not available for assignment (status: CLAIMED)",
+      "Quest is not available for claiming (status: COMPLETED)",
     );
   });
 
@@ -162,11 +150,39 @@ describe("QuestInstanceService - assignQuest", () => {
     }));
 
     await expect(
-      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
-    ).rejects.toThrow("Only FAMILY quests can be assigned");
+      service.claimQuest(mockQuestId, mockCharacterId),
+    ).rejects.toThrow("Only FAMILY quests can be claimed");
   });
 
-  it("should throw error if hero already has active family quest", async () => {
+  it("should throw error if character not found", async () => {
+    mockFrom.mockImplementationOnce(() => ({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: mockFamilyQuest,
+            error: null,
+          }),
+        }),
+      }),
+    }));
+
+    mockFrom.mockImplementationOnce(() => ({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          }),
+        }),
+      }),
+    }));
+
+    await expect(
+      service.claimQuest(mockQuestId, mockCharacterId),
+    ).rejects.toThrow("Character not found");
+  });
+
+  it("should throw error if hero already has active family quest (anti-hoarding)", async () => {
     mockFrom.mockImplementationOnce(() => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -190,25 +206,18 @@ describe("QuestInstanceService - assignQuest", () => {
     }));
 
     await expect(
-      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
+      service.claimQuest(mockQuestId, mockCharacterId),
     ).rejects.toThrow(
-      "Hero already has an active family quest. Release the current quest before assigning another.",
+      "Hero already has an active family quest. Release the current quest before claiming another.",
     );
   });
 
   it("should rollback quest update if character update fails", async () => {
-    const assignedQuest = {
-      ...mockFamilyQuest,
-      status: "PENDING",
-      assigned_to_id: mockUserId,
-      volunteered_by: mockCharacterId,
-    };
-
     const mockUpdate = jest.fn().mockReturnValue({
       eq: jest.fn().mockReturnValue({
         select: jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
-            data: assignedQuest,
+            data: mockClaimedQuest,
             error: null,
           }),
         }),
@@ -258,7 +267,7 @@ describe("QuestInstanceService - assignQuest", () => {
     }));
 
     await expect(
-      service.assignQuest(mockQuestId, mockCharacterId, mockGMId),
+      service.claimQuest(mockQuestId, mockCharacterId),
     ).rejects.toThrow("Failed to update character: Character update failed");
   });
 });

--- a/lib/quest-instance-service.fixtures.ts
+++ b/lib/quest-instance-service.fixtures.ts
@@ -1,7 +1,7 @@
-import { QuestInstanceService } from "../quest-instance-service";
-import { supabase } from "../supabase";
+import { QuestInstanceService } from "./quest-instance-service";
+import { supabase } from "./supabase";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "../types/database-generated";
+import type { Database } from "./types/database-generated";
 
 export const mockQuestId = "quest-123";
 export const mockCharacterId = "character-456";

--- a/lib/quest-instance-service.release.test.ts
+++ b/lib/quest-instance-service.release.test.ts
@@ -1,5 +1,5 @@
-import { QuestInstanceService } from "../quest-instance-service";
-jest.mock("../supabase", () => ({
+import { QuestInstanceService } from "./quest-instance-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
   },


### PR DESCRIPTION
## Summary
- Moves the quest-instance-service approve, assign, claim, and release unit tests out of `lib/__tests__/` into colocated files beside `lib/quest-instance-service.ts`.
- Moves the shared quest-instance-service fixtures beside the service as well, so the migrated tests no longer depend on the `lib/__tests__/` layout.
- Updates relative imports and Jest mocks for the new colocated paths.

## Verification
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_SERVICE_ROLE_KEY=test-service-role-key npx jest --runTestsByPath lib/quest-instance-service.approve.test.ts lib/quest-instance-service.assign.test.ts lib/quest-instance-service.claim.test.ts lib/quest-instance-service.release.test.ts --runInBand`
- `npx eslint lib/quest-instance-service.approve.test.ts lib/quest-instance-service.assign.test.ts lib/quest-instance-service.claim.test.ts lib/quest-instance-service.release.test.ts lib/quest-instance-service.fixtures.ts`
- `git diff --check origin/develop...HEAD`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_SERVICE_ROLE_KEY=test-service-role-key npm run build`

## Release implications
- Test-layout-only refactor; no runtime behavior or deployment change expected.

Refs #143
