### PR TITLE
refactor: colocate quest template service tests

### DIFF
--- a/lib/quest-template-service-get-by-type.test.ts
+++ b/lib/quest-template-service-get-by-type.test.ts
@@ -1,5 +1,5 @@
-import { QuestTemplateService } from "../quest-template-service";
-jest.mock("../supabase", () => ({
+import { QuestTemplateService } from "./quest-template-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
   },

--- a/lib/quest-template-service-pause-resume.test.ts
+++ b/lib/quest-template-service-pause-resume.test.ts
@@ -1,5 +1,5 @@
-import { QuestTemplateService } from "../quest-template-service";
-jest.mock("../supabase", () => ({
+import { QuestTemplateService } from "./quest-template-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
   },

--- a/lib/quest-template-service.fixtures.ts
+++ b/lib/quest-template-service.fixtures.ts
@@ -1,5 +1,5 @@
-import { QuestTemplateService } from "../quest-template-service";
-import { supabase } from "../supabase";
+import { QuestTemplateService } from "./quest-template-service";
+import { supabase } from "./supabase";
 
 export const mockTemplateId = "template-123";
 export const mockFamilyId = "family-123";


### PR DESCRIPTION
## Summary
- Moves the quest-template-service get-by-type and pause/resume Jest tests out of `lib/__tests__/` and beside `lib/quest-template-service.ts`.
- Moves the directly shared quest-template-service fixture beside the same module.
- Updates relative imports for the colocated layout.

## Verification
- [x] `npm run test:unit -- --runTestsByPath lib/quest-template-service-get-by-type.test.ts lib/quest-template-service-pause-resume.test.ts`
- [x] `npm run lint -- lib/quest-template-service-get-by-type.test.ts lib/quest-template-service-pause-resume.test.ts lib/quest-template-service.fixtures.ts`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`
- [x] `git diff --cached --check` before commit

## Scope
- Bounded to the quest-template-service test family only.
- Does not migrate other `lib/__tests__/` clusters or top-level `tests/unit/...` work.

## Release implications
- Test-layout refactor only; no runtime behavior, migration, deployment, or release-process changes expected.

Refs #143
