### PR TITLE
refactor: colocate recurring quest generator tests

### DIFF
--- a/lib/recurring-quest-generator.base.test.ts
+++ b/lib/recurring-quest-generator.base.test.ts
@@ -1,4 +1,4 @@
-import { generateRecurringQuests } from "../recurring-quest-generator";
+import { generateRecurringQuests } from "./recurring-quest-generator";
 import { createMockSupabase } from "./recurring-quest-generator.fixtures";
 
 describe("generateRecurringQuests - base behaviors", () => {

--- a/lib/recurring-quest-generator.family.test.ts
+++ b/lib/recurring-quest-generator.family.test.ts
@@ -1,4 +1,4 @@
-import { generateRecurringQuests } from "../recurring-quest-generator";
+import { generateRecurringQuests } from "./recurring-quest-generator";
 import { createMockSupabase } from "./recurring-quest-generator.fixtures";
 
 describe("generateRecurringQuests - family and edge cases", () => {

--- a/lib/recurring-quest-generator.fixtures.ts
+++ b/lib/recurring-quest-generator.fixtures.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "../types/database-generated";
+import type { Database } from "./types/database-generated";
 
 export const createMockSupabase = () =>
   ({


### PR DESCRIPTION
## Summary
- Colocates the recurring quest generator Jest cluster beside `lib/recurring-quest-generator.ts`.
- Moves the shared recurring quest generator fixture out of `lib/__tests__/` and updates relative imports.
- Keeps issue #143 open because more `lib/__tests__/` migration slices remain.

## Test Plan
- [x] `npm run test:unit -- --runTestsByPath lib/__tests__/generate-recurring-quests-base.test.ts lib/__tests__/generate-recurring-quests-family.test.ts --runInBand` (baseline before move)
- [x] `npm run test:unit -- --runTestsByPath lib/recurring-quest-generator.base.test.ts lib/recurring-quest-generator.family.test.ts --runInBand`
- [x] `npm run lint -- lib/recurring-quest-generator.base.test.ts lib/recurring-quest-generator.family.test.ts lib/recurring-quest-generator.fixtures.ts`
- [x] `git diff --check --cached`
- [x] env-seeded `npm run build`

## Release implications
- Test-only refactor; no runtime behavior or deployment impact expected.

Refs #143
