### PR TITLE
refactor: colocate unlock evaluator tests

### DIFF
--- a/lib/__tests__/achievement-progress-service.cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.cascade.test.ts
@@ -9,7 +9,7 @@ import {
   makeDataResult,
 } from "./achievement-progress-service.fixtures";
 import type { MockChain } from "./achievement-progress-service.fixtures";
-import { makeWriteMocks, CHAR_ID, USER_ID } from "./unlock-evaluation-fixtures";
+import { makeWriteMocks, CHAR_ID, USER_ID } from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.reward-granting.test.ts
+++ b/lib/__tests__/achievement-progress-service.reward-granting.test.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-compensation.test.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-consistency.test.ts
@@ -5,12 +5,12 @@
  * - Cascade snapshot read failure aborts before corrupting rollback state
  */
 import { AchievementProgressService } from "../achievement-progress-service";
-import { makeWriteMocks, CHAR_ID } from "./unlock-evaluation-fixtures";
+import { makeWriteMocks, CHAR_ID } from "../achievement-progress/unlock-evaluation-fixtures";
 import {
   makeQuestLevelAchievements,
   makeDualCharAchChain,
   makeMultiAchReadClient,
-} from "./unlock-multi-ach-fixtures";
+} from "../achievement-progress/unlock-multi-ach-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
+++ b/lib/__tests__/achievement-progress-service.rollback-guards.test.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-cascade.test.ts
@@ -9,7 +9,7 @@ import {
   makeCharAchChain,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };

--- a/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-integration.test.ts
@@ -9,7 +9,7 @@ import {
   makeCharAchChain,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
+++ b/lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts
@@ -9,7 +9,7 @@ import {
   makeCharAchChain,
   CHAR_ID,
   USER_ID,
-} from "./unlock-evaluation-fixtures";
+} from "../achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/achievement-progress/unlock-data-result-fixture.ts
+++ b/lib/achievement-progress/unlock-data-result-fixture.ts
@@ -1,0 +1,28 @@
+export type MockChain = Record<string, jest.Mock>;
+
+export function makeDataResult<T>(data: T): {
+  select: jest.Mock;
+  eq: jest.Mock;
+  in: jest.Mock;
+  single: jest.Mock;
+  or: jest.Mock;
+  is: jest.Mock;
+} {
+  const single = jest.fn().mockResolvedValue({ data, error: null });
+  const directData = Array.isArray(data) ? data : [data];
+  const resolved = { data: directData, error: null };
+  const or = jest.fn().mockResolvedValue(resolved);
+  const is = jest.fn().mockResolvedValue(resolved);
+  const inFn = jest.fn().mockResolvedValue({ data, error: null });
+  const eq2 = jest.fn().mockReturnValue({ single, in: inFn });
+  const eq1 = jest.fn().mockReturnValue({ eq: eq2, single, in: inFn, or });
+  const selectReturn = Object.assign(Promise.resolve(resolved), {
+    eq: eq1,
+    single,
+    in: inFn,
+    or,
+    is,
+  });
+  const select = jest.fn().mockReturnValue(selectReturn);
+  return { select, eq: eq1, in: inFn, single, or, is };
+}

--- a/lib/achievement-progress/unlock-evaluation-fixtures.ts
+++ b/lib/achievement-progress/unlock-evaluation-fixtures.ts
@@ -1,5 +1,4 @@
-import type { MockChain } from "./achievement-progress-service.fixtures";
-import { makeDataResult } from "./achievement-progress-service.fixtures";
+import { makeDataResult, type MockChain } from "./unlock-data-result-fixture";
 
 export const CHAR_ID = "char-001";
 export const USER_ID = "user-001";

--- a/lib/achievement-progress/unlock-evaluator.test.ts
+++ b/lib/achievement-progress/unlock-evaluator.test.ts
@@ -3,7 +3,7 @@ import {
   evaluateBoolean,
   evaluateCompound,
   evaluateCriteriaMet,
-} from "../achievement-progress/unlock-evaluator";
+} from "./unlock-evaluator";
 
 // ─── 1.6 Threshold strategy ───────────────────────────────────────────────────
 

--- a/lib/achievement-progress/unlock-multi-ach-fixtures.ts
+++ b/lib/achievement-progress/unlock-multi-ach-fixtures.ts
@@ -2,8 +2,10 @@
  * Shared fixtures for multi-achievement rollback tests.
  * Provides helpers for scenarios with two+ achievements (e.g. quest + level).
  */
-import type { MockChain } from "./achievement-progress-service.fixtures";
-import { makeDataResult } from "./achievement-progress-service.fixtures";
+import {
+  makeDataResult,
+  type MockChain,
+} from "./unlock-data-result-fixture";
 import { USER_ID } from "./unlock-evaluation-fixtures";
 
 /** Two achievements: quest_complete (with XP reward) + level_reached */


### PR DESCRIPTION
## Summary
- Migrates the unlock evaluator test family from `lib/__tests__/` into `lib/achievement-progress/` beside `unlock-evaluator.ts`.
- Moves the unlock evaluation and multi-achievement fixture helpers with the family, with a tiny local `unlock-data-result-fixture` helper so the moved fixtures no longer depend on `lib/__tests__/`.
- Updates the remaining achievement-progress-service tests that consume the moved unlock fixtures to import them from the colocated path.

Part of #143.

## Test Plan
- [x] `git diff --check origin/develop...HEAD`
- [x] `npm run test:unit -- --runTestsByPath lib/achievement-progress/unlock-evaluator.test.ts`
- [x] `npm run test:unit -- --runTestsByPath lib/achievement-progress/unlock-evaluator.test.ts lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts lib/__tests__/achievement-progress-service.rollback-compensation.test.ts lib/__tests__/achievement-progress-service.unlock-cascade.test.ts lib/__tests__/achievement-progress-service.unlock-integration.test.ts lib/__tests__/achievement-progress-service.reward-granting.test.ts lib/__tests__/achievement-progress-service.rollback-guards.test.ts lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts lib/__tests__/achievement-progress-service.rollback-consistency.test.ts lib/__tests__/achievement-progress-service.cascade.test.ts`
- [x] `npx eslint lib/achievement-progress/unlock-evaluator.test.ts lib/achievement-progress/unlock-evaluation-fixtures.ts lib/achievement-progress/unlock-multi-ach-fixtures.ts lib/achievement-progress/unlock-data-result-fixture.ts lib/__tests__/achievement-progress-service.unlock-evaluation.test.ts lib/__tests__/achievement-progress-service.rollback-compensation.test.ts lib/__tests__/achievement-progress-service.unlock-cascade.test.ts lib/__tests__/achievement-progress-service.unlock-integration.test.ts lib/__tests__/achievement-progress-service.reward-granting.test.ts lib/__tests__/achievement-progress-service.rollback-guards.test.ts lib/__tests__/achievement-progress-service.unlock-p1p2-fixes.test.ts lib/__tests__/achievement-progress-service.rollback-consistency.test.ts lib/__tests__/achievement-progress-service.cascade.test.ts`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://supabase.example.com SUPABASE_URL=https://supabase.example.com SUPABASE_INTERNAL_URL=https://supabase.example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy JWT_SECRET=your-s...long npm run build`

## Release implications
- None. Test-layout-only refactor; no runtime behavior, database, deployment, or operator workflow changes.
