### PR TITLE
refactor: colocate profile service tests

### DIFF
--- a/lib/profile-service-class.test.ts
+++ b/lib/profile-service-class.test.ts
@@ -1,5 +1,5 @@
-import { ProfileService } from "../profile-service";
-jest.mock("../supabase", () => ({
+import { ProfileService } from "./profile-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
     rpc: jest.fn(),
@@ -9,7 +9,7 @@ jest.mock("../supabase", () => ({
   },
 }));
 
-import { supabase } from "../supabase";
+import { supabase } from "./supabase";
 
 const mockFrom = supabase.from as jest.Mock;
 

--- a/lib/profile-service-name.test.ts
+++ b/lib/profile-service-name.test.ts
@@ -1,5 +1,5 @@
-import { ProfileService } from "../profile-service";
-jest.mock("../supabase", () => ({
+import { ProfileService } from "./profile-service";
+jest.mock("./supabase", () => ({
   supabase: {
     from: jest.fn(),
     rpc: jest.fn(),
@@ -8,7 +8,7 @@ jest.mock("../supabase", () => ({
     },
   },
 }));
-import { supabase } from "../supabase";
+import { supabase } from "./supabase";
 
 const mockFrom = supabase.from as jest.Mock;
 


### PR DESCRIPTION
## Summary
- Migrates the two profile-service Jest files out of `lib/__tests__/` and beside `lib/profile-service.ts`.
- Updates the relocated tests' relative imports for `profile-service` and mocked `supabase`.
- Keeps this slice scoped to the profile-service family for issue #143; no runtime code changes.

Issue: #143

## Verification
- `npm run test:unit -- --runTestsByPath lib/profile-service-class.test.ts lib/profile-service-name.test.ts --runInBand` — passed (12 tests)
- `npx eslint lib/profile-service-class.test.ts lib/profile-service-name.test.ts` — passed
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key npm run build` — passed on retry after a transient `.next/static/.../_buildManifest.js.tmp` ENOENT from the first Turbopack build attempt
- `git diff --check origin/develop...HEAD` — passed

## Release implications
- None. Test layout-only refactor; no production runtime or deployment behavior changed.
