### PR TITLE
test: colocate context provider tests

### DIFF
--- a/lib/character-context.test.tsx
+++ b/lib/character-context.test.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { render, act, screen } from "@testing-library/react";
-import { CharacterProvider, useCharacter } from "../character-context";
-import type { Listener } from "../realtime/types";
-import type { Character } from "../types/database";
+import { CharacterProvider, useCharacter } from "./character-context";
+import type { Listener } from "./realtime/types";
+import type { Character } from "./types/database";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-jest.mock("../network-ready-context", () => ({
+jest.mock("./network-ready-context", () => ({
   useNetworkReady: () => ({
     waitForReady: jest.fn().mockResolvedValue(undefined),
   }),
@@ -22,7 +22,7 @@ const mockOnCharacterUpdate = jest.fn((cb: Listener) => {
   };
 });
 
-jest.mock("../realtime-context", () => ({
+jest.mock("./realtime-context", () => ({
   useRealtime: () => ({
     onCharacterUpdate: mockOnCharacterUpdate,
     isConnected: true,
@@ -43,7 +43,7 @@ jest.mock("../realtime-context", () => ({
   }),
 }));
 
-jest.mock("../auth-context", () => ({
+jest.mock("./auth-context", () => ({
   useAuth: () => ({
     user: { id: "user-1" },
     session: { user: { id: "user-1" }, access_token: "tok" },
@@ -55,7 +55,7 @@ type SetCharacter = (c: Character | null) => void;
 let capturedSetCharacter: SetCharacter | null = null;
 let capturedPreviousLevelRef: { current: number | null } | null = null;
 
-jest.mock("../character/fetch-character", () => ({
+jest.mock("./character/fetch-character", () => ({
   createCharacterFetcher: (deps: {
     setCharacter: SetCharacter;
     previousLevelRef: { current: number | null };

--- a/lib/network-ready-context.test.tsx
+++ b/lib/network-ready-context.test.tsx
@@ -3,7 +3,7 @@ import { render, act, cleanup } from "@testing-library/react";
 import {
   NetworkReadyProvider,
   useNetworkReady,
-} from "../network-ready-context";
+} from "./network-ready-context";
 
 describe("NetworkReadyProvider", () => {
   const originalUserAgent = navigator.userAgent;


### PR DESCRIPTION
## Summary
- Moves `character-context` and `network-ready-context` Jest suites from `lib/__tests__/` beside their source modules in `lib/`.
- Updates relative imports and Jest mocks for the colocated layout.
- Keeps issue #143 open; this is only the bounded context-provider migration slice.

## Verification
- [x] RED: `npx jest --runTestsByPath lib/character-context.test.tsx lib/network-ready-context.test.tsx --runInBand` failed before relocation because the colocated test paths did not exist.
- [x] `git diff --check origin/develop...HEAD`
- [x] `npx jest --runTestsByPath lib/character-context.test.tsx lib/network-ready-context.test.tsx --runInBand`
- [x] `npx eslint lib/character-context.test.tsx lib/network-ready-context.test.tsx`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_ROLE_KEY=dummy NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`

## Documentation impact
- None; test layout refactor only.

Refs #143
