### PR TITLE
test: colocate errors tests

### DIFF
--- a/lib/errors.test.ts
+++ b/lib/errors.test.ts
@@ -5,7 +5,7 @@ import {
   ForbiddenError,
   NotFoundError,
   ValidationError,
-} from "@/lib/errors";
+} from "./errors";
 
 describe("errors", () => {
   it("creates AppError with statusCode and code", () => {


### PR DESCRIPTION
## Summary
- Moves `lib/__tests__/errors.test.ts` beside `lib/errors.ts` as `lib/errors.test.ts`.
- Updates the migrated test to use the colocated relative import.
- Keeps this slice scoped to the `lib/errors` singleton only; issue #143 remains open for the broader layout backlog.

Refs #143

## Test Plan
- [x] RED: `npm run test:unit -- --runTestsByPath lib/errors.test.ts --runInBand` failed before the move because the colocated path did not exist.
- [x] `npm run test:unit -- --runTestsByPath lib/errors.test.ts --runInBand`
- [x] `npm run lint -- lib/errors.ts lib/errors.test.ts`
- [x] `git diff --check origin/develop...HEAD`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon SUPABASE_SERVICE_ROLE_KEY=dummy-service npm run build`

## Documentation Impact
- None. Test layout refactor only.
