### PR TITLE
refactor: colocate expire quests test

### DIFF
--- a/lib/recurring/expiration.test.ts
+++ b/lib/recurring/expiration.test.ts
@@ -1,5 +1,5 @@
-import { expireQuests } from "../recurring-quest-generator";
-import { createMockSupabase } from "./recurring-quest-generator.fixtures";
+import { expireQuests } from "./expiration";
+import { createMockSupabase } from "../recurring-quest-generator.fixtures";
 
 describe("expireQuests", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Moves the expireQuests Jest coverage out of `lib/__tests__/` into the recurring implementation area as `lib/recurring/expiration.test.ts`.
- Updates relative imports so the migrated test exercises `lib/recurring/expiration.ts` directly while continuing to share the existing Supabase test fixture.
- Keeps issue #143 open because additional layout-standardization work remains outside this bounded slice.

## Test Plan
- [x] RED path check: `npm run test:unit -- --runTestsByPath lib/expire-quests.test.ts` failed with ENOENT before the migration
- [x] `npm run test:unit -- --runTestsByPath lib/recurring/expiration.test.ts`
- [x] `npx eslint lib/recurring/expiration.test.ts lib/recurring/expiration.ts`
- [x] `git diff --check origin/develop...HEAD`
- [x] env-seeded `npm run build`

## Release implications
- Test-only layout refactor; no runtime behavior, deployment, database, or release-process changes expected.

Refs #143
