### PR TITLE
test: colocate achievement progress evaluator tests

### DIFF
--- a/lib/achievement-progress-service.evaluators-compound.test.ts
+++ b/lib/achievement-progress-service.evaluators-compound.test.ts
@@ -1,5 +1,5 @@
-import { createCompoundEvaluator } from "../achievement-progress/compound-evaluator";
-import type { EvaluatorFn } from "../achievement-progress/types";
+import { createCompoundEvaluator } from "./achievement-progress/compound-evaluator";
+import type { EvaluatorFn } from "./achievement-progress/types";
 
 const CHARACTER_ID = "char-001";
 const USER_ID = "user-001";

--- a/lib/achievement-progress-service.evaluators-difficulty-boss.test.ts
+++ b/lib/achievement-progress-service.evaluators-difficulty-boss.test.ts
@@ -1,5 +1,5 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
@@ -7,7 +7,7 @@ import {
   CHARACTER_ID,
   USER_ID,
   ACHIEVEMENT_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),

--- a/lib/achievement-progress-service.evaluators-gold-reward.test.ts
+++ b/lib/achievement-progress-service.evaluators-gold-reward.test.ts
@@ -1,5 +1,5 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
@@ -7,7 +7,7 @@ import {
   CHARACTER_ID,
   USER_ID,
   ACHIEVEMENT_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),

--- a/lib/achievement-progress-service.evaluators-honor.test.ts
+++ b/lib/achievement-progress-service.evaluators-honor.test.ts
@@ -1,12 +1,12 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
   CHARACTER_ID,
   USER_ID,
   ACHIEVEMENT_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),

--- a/lib/achievement-progress-service.evaluators-quest.test.ts
+++ b/lib/achievement-progress-service.evaluators-quest.test.ts
@@ -1,5 +1,5 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
@@ -7,7 +7,7 @@ import {
   CHARACTER_ID,
   USER_ID,
   ACHIEVEMENT_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),

--- a/lib/achievement-progress-service.evaluators-spending.test.ts
+++ b/lib/achievement-progress-service.evaluators-spending.test.ts
@@ -1,5 +1,5 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
@@ -7,7 +7,7 @@ import {
   CHARACTER_ID,
   USER_ID,
   ACHIEVEMENT_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),

--- a/lib/achievement-progress-service.evaluators-stats.test.ts
+++ b/lib/achievement-progress-service.evaluators-stats.test.ts
@@ -1,5 +1,5 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
@@ -7,7 +7,7 @@ import {
   CHARACTER_ID,
   USER_ID,
   ACHIEVEMENT_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),


### PR DESCRIPTION
## Summary
- Migrates the bounded achievement-progress-service evaluators test family out of `lib/__tests__/` into colocated `lib/*.test.ts` files.
- Updates relative imports to use the colocated service fixture and achievement-progress modules.
- Keeps the slice limited to the seven evaluator test files from issue #143.

## Test Plan
- [x] RED path check: `npx jest --runTestsByPath lib/achievement-progress-service.evaluators-compound.test.ts lib/achievement-progress-service.evaluators-difficulty-boss.test.ts lib/achievement-progress-service.evaluators-gold-reward.test.ts lib/achievement-progress-service.evaluators-honor.test.ts lib/achievement-progress-service.evaluators-quest.test.ts lib/achievement-progress-service.evaluators-spending.test.ts lib/achievement-progress-service.evaluators-stats.test.ts` failed before the move with ENOENT for the new colocated paths.
- [x] `npx jest --runTestsByPath lib/achievement-progress-service.evaluators-compound.test.ts lib/achievement-progress-service.evaluators-difficulty-boss.test.ts lib/achievement-progress-service.evaluators-gold-reward.test.ts lib/achievement-progress-service.evaluators-honor.test.ts lib/achievement-progress-service.evaluators-quest.test.ts lib/achievement-progress-service.evaluators-spending.test.ts lib/achievement-progress-service.evaluators-stats.test.ts`
- [x] `git diff --check origin/develop...HEAD`
- [x] `npx eslint lib/achievement-progress-service.evaluators-compound.test.ts lib/achievement-progress-service.evaluators-difficulty-boss.test.ts lib/achievement-progress-service.evaluators-gold-reward.test.ts lib/achievement-progress-service.evaluators-honor.test.ts lib/achievement-progress-service.evaluators-quest.test.ts lib/achievement-progress-service.evaluators-spending.test.ts lib/achievement-progress-service.evaluators-stats.test.ts`
- [x] Env-seeded `npm run build`

## Release implications
- Test-layout-only refactor; no runtime behavior or deployment changes expected.

Refs #143
