### PR TITLE
refactor: colocate rollback achievement progress tests

### DIFF
--- a/lib/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/achievement-progress-service.rollback-compensation.test.ts
@@ -1,16 +1,16 @@
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeUnlockReadClient,
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/achievement-progress-service.rollback-consistency.test.ts
+++ b/lib/achievement-progress-service.rollback-consistency.test.ts
@@ -4,13 +4,13 @@
  * - Level, unlocked_at, and cascade progress are all skipped when stats fail
  * - Cascade snapshot read failure aborts before corrupting rollback state
  */
-import { AchievementProgressService } from "../achievement-progress-service";
-import { makeWriteMocks, CHAR_ID } from "../achievement-progress/unlock-evaluation-fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import { makeWriteMocks, CHAR_ID } from "./achievement-progress/unlock-evaluation-fixtures";
 import {
   makeQuestLevelAchievements,
   makeDualCharAchChain,
   makeMultiAchReadClient,
-} from "../achievement-progress/unlock-multi-ach-fixtures";
+} from "./achievement-progress/unlock-multi-ach-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/achievement-progress-service.rollback-guards.test.ts
+++ b/lib/achievement-progress-service.rollback-guards.test.ts
@@ -4,19 +4,19 @@
  *   P1b: stats rollback uses a conditional SET, not a negative RPC increment
  *   P2:  cascade rollback restores pre-existing progress, not null
  */
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeUnlockReadClient,
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({


### PR DESCRIPTION
## Summary
- Migrates the bounded achievement-progress-service rollback test cluster out of `lib/__tests__` into colocated `lib/*.test.ts` files.
- Updates relative imports for the moved rollback compensation, consistency, and guard tests only.
- Leaves runtime behavior unchanged; this PR is a layout-standardization slice for #143.

## Verification
- RED path check: confirmed the three rollback files still existed under `lib/__tests__` before migration.
- `git diff --check origin/develop...HEAD`
- `npx jest --runTestsByPath lib/achievement-progress-service.rollback-compensation.test.ts lib/achievement-progress-service.rollback-consistency.test.ts lib/achievement-progress-service.rollback-guards.test.ts --runInBand`
- `npx eslint lib/achievement-progress-service.rollback-compensation.test.ts lib/achievement-progress-service.rollback-consistency.test.ts lib/achievement-progress-service.rollback-guards.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key npm run build`

## Documentation impact
- None. Test layout only.

Refs #143
