### PR TITLE
refactor: colocate achievement unlock service tests

### DIFF
--- a/lib/achievement-progress-service.unlock-cascade.test.ts
+++ b/lib/achievement-progress-service.unlock-cascade.test.ts
@@ -1,15 +1,15 @@
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeCharAchChain,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
@@ -21,7 +21,7 @@ const QUEST_ACH = {
   name: "Quest Master",
   criteria_type: "quest_complete",
   criteria_config: { threshold: 5 },
-  xp_reward: 60,
+  xp_reward: 60, // triggers level-up from level 1 with 40 XP
   gold_reward: 0,
 };
 const LEVEL_ACH = {
@@ -29,33 +29,6 @@ const LEVEL_ACH = {
   name: "Ascending",
   criteria_type: "level_reached",
   criteria_config: { threshold: 2 },
-  xp_reward: 0,
-  gold_reward: 0,
-};
-const XP_COMPOUND_ACH = {
-  id: "ach-xp-compound",
-  name: "XP Collector",
-  criteria_type: "compound",
-  criteria_config: {
-    operator: "AND",
-    evaluation_strategy: "compound",
-    conditions: [{ criteria_type: "xp_earned", threshold: 10 }],
-  },
-  xp_reward: 0,
-  gold_reward: 0,
-};
-const DEDUP_COMPOUND_ACH = {
-  id: "ach-dedup-compound",
-  name: "XP and Level",
-  criteria_type: "compound",
-  criteria_config: {
-    operator: "AND",
-    evaluation_strategy: "compound",
-    conditions: [
-      { criteria_type: "xp_earned", threshold: 100 },
-      { criteria_type: "level_reached", threshold: 2 },
-    ],
-  },
   xp_reward: 0,
   gold_reward: 0,
 };
@@ -70,8 +43,11 @@ function makeQuestChain(count: number): MockChain {
   };
 }
 
-/** Two-state char chain: n=1 → user context, n>=2 → stats. */
-function makeCharChain(stats: { xp: number; gold: number; level: number }) {
+function makeCharChain(secondCallStats: {
+  xp: number;
+  gold: number;
+  level: number;
+}) {
   let n = 0;
   return {
     select: jest.fn().mockImplementation(() => {
@@ -79,7 +55,10 @@ function makeCharChain(stats: { xp: number; gold: number; level: number }) {
       return {
         eq: jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
-            data: n === 1 ? { user_id: USER_ID, user_profiles: null } : stats,
+            data:
+              n === 1
+                ? { user_id: USER_ID, user_profiles: null }
+                : secondCallStats,
             error: null,
           }),
         }),
@@ -88,140 +67,27 @@ function makeCharChain(stats: { xp: number; gold: number; level: number }) {
   };
 }
 
-describe("AchievementProgressService - P1/P2 cascade fixes", () => {
+const COMPOUND_ACH = {
+  id: "ach-compound",
+  name: "Quest & Ascend Master",
+  criteria_type: "compound",
+  criteria_config: {
+    operator: "AND",
+    evaluation_strategy: "compound",
+    conditions: [
+      { criteria_type: "quest_complete", threshold: 5 },
+      { criteria_type: "level_reached", threshold: 3 },
+    ],
+  },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+
+describe("AchievementProgressService - level-up cascade (7.3)", () => {
   afterEach(() => jest.clearAllMocks());
 
-  it("[P2] cascades to unlock compound achievement with xp_earned sub-condition after XP reward (no level-up)", async () => {
-    const XP_QUEST = { ...QUEST_ACH, id: "ach-xp-quest", xp_reward: 10 };
-    const write = makeWriteMocks({
-      unlockedIds: [XP_QUEST.id],
-      rpcReturn: {
-        unlocked_achievement_ids: [XP_QUEST.id],
-        awarded_xp: 10,
-        awarded_gold: 0,
-        xp: 10,
-        gold: 0,
-        level: 1,
-      },
-    });
-    mockWriteClient.from.mockImplementation(write.from);
-    mockWriteClient.rpc.mockImplementation(write.rpc);
-    write.selectAfterIs
-      .mockResolvedValueOnce({
-        data: [{ achievement_id: XP_QUEST.id }],
-        error: null,
-      })
-      .mockResolvedValueOnce({
-        data: [{ achievement_id: XP_COMPOUND_ACH.id }],
-        error: null,
-      });
-
-    let charN = 0;
-    const charChain = {
-      select: jest.fn().mockImplementation(() => {
-        charN++;
-        return {
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data:
-                charN === 1
-                  ? { user_id: USER_ID, user_profiles: null }
-                  : charN === 2
-                    ? { xp: 0, gold: 0, level: 1 }
-                    : { xp: 10, gold: 0, level: 1 },
-              error: null,
-            }),
-          }),
-        };
-      }),
-    };
-
-    let charAchN = 0;
-    const charAchChain = {
-      select: jest.fn().mockImplementation(() => {
-        charAchN++;
-        if (charAchN === 1) {
-          return {
-            eq: jest.fn().mockResolvedValue({
-              data: [
-                { achievement_id: XP_QUEST.id },
-                { achievement_id: XP_COMPOUND_ACH.id },
-              ],
-              error: null,
-            }),
-          };
-        }
-        const id = charAchN === 2 ? XP_QUEST.id : XP_COMPOUND_ACH.id;
-        return {
-          eq: jest.fn().mockReturnValue({
-            in: jest.fn().mockResolvedValue({
-              data: [{ achievement_id: id, unlocked_at: null }],
-              error: null,
-            }),
-          }),
-        };
-      }),
-    };
-
-    const readClient = makeReadClient({
-      characters: charChain as unknown as MockChain,
-      achievements: makeDataResult([
-        XP_QUEST,
-        XP_COMPOUND_ACH,
-      ]) as unknown as MockChain,
-      character_achievements: charAchChain,
-      quest_instances: makeQuestChain(5),
-    });
-
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
-  });
-
-  it("[P1] does not cascade level_reached achievement when concurrent write loses level race", async () => {
-    const write = makeWriteMocks({
-      unlockedIds: [QUEST_ACH.id],
-      rpcReturn: {
-        unlocked_achievement_ids: [QUEST_ACH.id],
-        awarded_xp: 60,
-        awarded_gold: 0,
-        xp: 100,
-        gold: 0,
-        level: 1,
-      },
-      levelSelectRows: [],
-    });
-    mockWriteClient.from.mockImplementation(write.from);
-    mockWriteClient.rpc.mockImplementation(write.rpc);
-    write.selectAfterIs.mockResolvedValueOnce({
-      data: [{ achievement_id: QUEST_ACH.id }],
-      error: null,
-    });
-
-    const readClient = makeReadClient({
-      characters: makeCharChain({
-        xp: 40,
-        gold: 0,
-        level: 1,
-      }) as unknown as MockChain,
-      achievements: makeDataResult([
-        QUEST_ACH,
-        LEVEL_ACH,
-      ]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(QUEST_ACH.id, null),
-      quest_instances: makeQuestChain(5),
-    });
-
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
-    expect(write.statsSelect).toHaveBeenCalledTimes(1);
-    await expect(write.statsSelect.mock.results[0].value).resolves.toMatchObject({ data: [] });
-  });
-
-  it("[P2] evaluates compound achievement with both xp_earned and level_reached exactly once on XP+level-up", async () => {
+  it("7.3 cascades to unlock level_reached achievement after XP-triggered level-up", async () => {
+    // prevXp=40, award xp=60 → new xp=100 → level 2; cascade unlocks LEVEL_ACH
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
       rpcReturn: {
@@ -235,13 +101,14 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
+    // First IS NULL update unlocks QUEST_ACH; cascade update unlocks LEVEL_ACH
     write.selectAfterIs
       .mockResolvedValueOnce({
         data: [{ achievement_id: QUEST_ACH.id }],
         error: null,
       })
       .mockResolvedValueOnce({
-        data: [{ achievement_id: DEDUP_COMPOUND_ACH.id }],
+        data: [{ achievement_id: LEVEL_ACH.id }],
         error: null,
       });
 
@@ -254,13 +121,13 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
             eq: jest.fn().mockResolvedValue({
               data: [
                 { achievement_id: QUEST_ACH.id },
-                { achievement_id: DEDUP_COMPOUND_ACH.id },
+                { achievement_id: LEVEL_ACH.id },
               ],
               error: null,
             }),
           };
         }
-        const id = charAchN === 2 ? QUEST_ACH.id : DEDUP_COMPOUND_ACH.id;
+        const id = charAchN === 2 ? QUEST_ACH.id : LEVEL_ACH.id;
         return {
           eq: jest.fn().mockReturnValue({
             in: jest.fn().mockResolvedValue({
@@ -274,13 +141,13 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
 
     const readClient = makeReadClient({
       characters: makeCharChain({
-        xp: 100,
+        xp: 40,
         gold: 0,
-        level: 2,
+        level: 1,
       }) as unknown as MockChain,
       achievements: makeDataResult([
         QUEST_ACH,
-        DEDUP_COMPOUND_ACH,
+        LEVEL_ACH,
       ]) as unknown as MockChain,
       character_achievements: charAchChain,
       quest_instances: makeQuestChain(5),
@@ -289,9 +156,119 @@ describe("AchievementProgressService - P1/P2 cascade fixes", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    expect(write.upsert).toHaveBeenCalledTimes(2);
-    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{ achievement_id: string }>;
-    expect(cascadeRows).toHaveLength(1);
-    expect(cascadeRows[0].achievement_id).toBe(DEDUP_COMPOUND_ACH.id);
+    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("7.3 no cascade when XP reward does not trigger level-up", async () => {
+    const noLevelUpAch = { ...QUEST_ACH, xp_reward: 10 };
+    const write = makeWriteMocks({
+      unlockedIds: [noLevelUpAch.id],
+      rpcReturn: {
+        unlocked_achievement_ids: [noLevelUpAch.id],
+        awarded_xp: 10,
+        awarded_gold: 0,
+        xp: 10,
+        gold: 0,
+        level: 1,
+      },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 0,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        noLevelUpAch,
+        LEVEL_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(noLevelUpAch.id, null),
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
+  });
+
+  it("7.3b cascades to unlock compound achievement with level_reached sub-condition after level-up", async () => {
+    // Character at level 2 with 5 quests done.
+    // Quest achievement (xp_reward: 60) unlocks → level-up to 3.
+    // Compound achievement (quest_complete >= 5 AND level_reached >= 3) should also unlock in cascade.
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST_ACH.id, COMPOUND_ACH.id],
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 260,
+        gold: 0,
+        level: 2,
+      },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: QUEST_ACH.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: COMPOUND_ACH.id }],
+        error: null,
+      });
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: QUEST_ACH.id },
+                { achievement_id: COMPOUND_ACH.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        const id = charAchN === 2 ? QUEST_ACH.id : COMPOUND_ACH.id;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 260,
+        gold: 0,
+        level: 3,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        QUEST_ACH,
+        COMPOUND_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/achievement-progress-service.unlock-evaluation.test.ts
+++ b/lib/achievement-progress-service.unlock-evaluation.test.ts
@@ -1,16 +1,16 @@
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeUnlockReadClient,
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };

--- a/lib/achievement-progress-service.unlock-integration.test.ts
+++ b/lib/achievement-progress-service.unlock-integration.test.ts
@@ -1,15 +1,15 @@
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeCharAchChain,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({

--- a/lib/achievement-progress-service.unlock-p1p2-fixes.test.ts
+++ b/lib/achievement-progress-service.unlock-p1p2-fixes.test.ts
@@ -1,15 +1,15 @@
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeCharAchChain,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({
@@ -21,7 +21,7 @@ const QUEST_ACH = {
   name: "Quest Master",
   criteria_type: "quest_complete",
   criteria_config: { threshold: 5 },
-  xp_reward: 60, // triggers level-up from level 1 with 40 XP
+  xp_reward: 60,
   gold_reward: 0,
 };
 const LEVEL_ACH = {
@@ -29,6 +29,33 @@ const LEVEL_ACH = {
   name: "Ascending",
   criteria_type: "level_reached",
   criteria_config: { threshold: 2 },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+const XP_COMPOUND_ACH = {
+  id: "ach-xp-compound",
+  name: "XP Collector",
+  criteria_type: "compound",
+  criteria_config: {
+    operator: "AND",
+    evaluation_strategy: "compound",
+    conditions: [{ criteria_type: "xp_earned", threshold: 10 }],
+  },
+  xp_reward: 0,
+  gold_reward: 0,
+};
+const DEDUP_COMPOUND_ACH = {
+  id: "ach-dedup-compound",
+  name: "XP and Level",
+  criteria_type: "compound",
+  criteria_config: {
+    operator: "AND",
+    evaluation_strategy: "compound",
+    conditions: [
+      { criteria_type: "xp_earned", threshold: 100 },
+      { criteria_type: "level_reached", threshold: 2 },
+    ],
+  },
   xp_reward: 0,
   gold_reward: 0,
 };
@@ -43,11 +70,8 @@ function makeQuestChain(count: number): MockChain {
   };
 }
 
-function makeCharChain(secondCallStats: {
-  xp: number;
-  gold: number;
-  level: number;
-}) {
+/** Two-state char chain: n=1 → user context, n>=2 → stats. */
+function makeCharChain(stats: { xp: number; gold: number; level: number }) {
   let n = 0;
   return {
     select: jest.fn().mockImplementation(() => {
@@ -55,10 +79,7 @@ function makeCharChain(secondCallStats: {
       return {
         eq: jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
-            data:
-              n === 1
-                ? { user_id: USER_ID, user_profiles: null }
-                : secondCallStats,
+            data: n === 1 ? { user_id: USER_ID, user_profiles: null } : stats,
             error: null,
           }),
         }),
@@ -67,27 +88,140 @@ function makeCharChain(secondCallStats: {
   };
 }
 
-const COMPOUND_ACH = {
-  id: "ach-compound",
-  name: "Quest & Ascend Master",
-  criteria_type: "compound",
-  criteria_config: {
-    operator: "AND",
-    evaluation_strategy: "compound",
-    conditions: [
-      { criteria_type: "quest_complete", threshold: 5 },
-      { criteria_type: "level_reached", threshold: 3 },
-    ],
-  },
-  xp_reward: 0,
-  gold_reward: 0,
-};
-
-describe("AchievementProgressService - level-up cascade (7.3)", () => {
+describe("AchievementProgressService - P1/P2 cascade fixes", () => {
   afterEach(() => jest.clearAllMocks());
 
-  it("7.3 cascades to unlock level_reached achievement after XP-triggered level-up", async () => {
-    // prevXp=40, award xp=60 → new xp=100 → level 2; cascade unlocks LEVEL_ACH
+  it("[P2] cascades to unlock compound achievement with xp_earned sub-condition after XP reward (no level-up)", async () => {
+    const XP_QUEST = { ...QUEST_ACH, id: "ach-xp-quest", xp_reward: 10 };
+    const write = makeWriteMocks({
+      unlockedIds: [XP_QUEST.id],
+      rpcReturn: {
+        unlocked_achievement_ids: [XP_QUEST.id],
+        awarded_xp: 10,
+        awarded_gold: 0,
+        xp: 10,
+        gold: 0,
+        level: 1,
+      },
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    write.selectAfterIs
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: XP_QUEST.id }],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [{ achievement_id: XP_COMPOUND_ACH.id }],
+        error: null,
+      });
+
+    let charN = 0;
+    const charChain = {
+      select: jest.fn().mockImplementation(() => {
+        charN++;
+        return {
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data:
+                charN === 1
+                  ? { user_id: USER_ID, user_profiles: null }
+                  : charN === 2
+                    ? { xp: 0, gold: 0, level: 1 }
+                    : { xp: 10, gold: 0, level: 1 },
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    let charAchN = 0;
+    const charAchChain = {
+      select: jest.fn().mockImplementation(() => {
+        charAchN++;
+        if (charAchN === 1) {
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { achievement_id: XP_QUEST.id },
+                { achievement_id: XP_COMPOUND_ACH.id },
+              ],
+              error: null,
+            }),
+          };
+        }
+        const id = charAchN === 2 ? XP_QUEST.id : XP_COMPOUND_ACH.id;
+        return {
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ achievement_id: id, unlocked_at: null }],
+              error: null,
+            }),
+          }),
+        };
+      }),
+    };
+
+    const readClient = makeReadClient({
+      characters: charChain as unknown as MockChain,
+      achievements: makeDataResult([
+        XP_QUEST,
+        XP_COMPOUND_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: charAchChain,
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("[P1] does not cascade level_reached achievement when concurrent write loses level race", async () => {
+    const write = makeWriteMocks({
+      unlockedIds: [QUEST_ACH.id],
+      rpcReturn: {
+        unlocked_achievement_ids: [QUEST_ACH.id],
+        awarded_xp: 60,
+        awarded_gold: 0,
+        xp: 100,
+        gold: 0,
+        level: 1,
+      },
+      levelSelectRows: [],
+    });
+    mockWriteClient.from.mockImplementation(write.from);
+    mockWriteClient.rpc.mockImplementation(write.rpc);
+    write.selectAfterIs.mockResolvedValueOnce({
+      data: [{ achievement_id: QUEST_ACH.id }],
+      error: null,
+    });
+
+    const readClient = makeReadClient({
+      characters: makeCharChain({
+        xp: 40,
+        gold: 0,
+        level: 1,
+      }) as unknown as MockChain,
+      achievements: makeDataResult([
+        QUEST_ACH,
+        LEVEL_ACH,
+      ]) as unknown as MockChain,
+      character_achievements: makeCharAchChain(QUEST_ACH.id, null),
+      quest_instances: makeQuestChain(5),
+    });
+
+    const svc = new AchievementProgressService(readClient as never);
+    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+
+    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
+    expect(write.statsSelect).toHaveBeenCalledTimes(1);
+    await expect(write.statsSelect.mock.results[0].value).resolves.toMatchObject({ data: [] });
+  });
+
+  it("[P2] evaluates compound achievement with both xp_earned and level_reached exactly once on XP+level-up", async () => {
     const write = makeWriteMocks({
       unlockedIds: [QUEST_ACH.id],
       rpcReturn: {
@@ -101,14 +235,13 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     });
     mockWriteClient.from.mockImplementation(write.from);
     mockWriteClient.rpc.mockImplementation(write.rpc);
-    // First IS NULL update unlocks QUEST_ACH; cascade update unlocks LEVEL_ACH
     write.selectAfterIs
       .mockResolvedValueOnce({
         data: [{ achievement_id: QUEST_ACH.id }],
         error: null,
       })
       .mockResolvedValueOnce({
-        data: [{ achievement_id: LEVEL_ACH.id }],
+        data: [{ achievement_id: DEDUP_COMPOUND_ACH.id }],
         error: null,
       });
 
@@ -121,13 +254,13 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
             eq: jest.fn().mockResolvedValue({
               data: [
                 { achievement_id: QUEST_ACH.id },
-                { achievement_id: LEVEL_ACH.id },
+                { achievement_id: DEDUP_COMPOUND_ACH.id },
               ],
               error: null,
             }),
           };
         }
-        const id = charAchN === 2 ? QUEST_ACH.id : LEVEL_ACH.id;
+        const id = charAchN === 2 ? QUEST_ACH.id : DEDUP_COMPOUND_ACH.id;
         return {
           eq: jest.fn().mockReturnValue({
             in: jest.fn().mockResolvedValue({
@@ -141,125 +274,13 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
 
     const readClient = makeReadClient({
       characters: makeCharChain({
-        xp: 40,
-        gold: 0,
-        level: 1,
-      }) as unknown as MockChain,
-      achievements: makeDataResult([
-        QUEST_ACH,
-        LEVEL_ACH,
-      ]) as unknown as MockChain,
-      character_achievements: charAchChain,
-      quest_instances: makeQuestChain(5),
-    });
-
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-
-    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
-  });
-
-  it("7.3 no cascade when XP reward does not trigger level-up", async () => {
-    const noLevelUpAch = { ...QUEST_ACH, xp_reward: 10 };
-    const write = makeWriteMocks({
-      unlockedIds: [noLevelUpAch.id],
-      rpcReturn: {
-        unlocked_achievement_ids: [noLevelUpAch.id],
-        awarded_xp: 10,
-        awarded_gold: 0,
-        xp: 10,
-        gold: 0,
-        level: 1,
-      },
-    });
-    mockWriteClient.from.mockImplementation(write.from);
-    mockWriteClient.rpc.mockImplementation(write.rpc);
-
-    const readClient = makeReadClient({
-      characters: makeCharChain({
-        xp: 0,
-        gold: 0,
-        level: 1,
-      }) as unknown as MockChain,
-      achievements: makeDataResult([
-        noLevelUpAch,
-        LEVEL_ACH,
-      ]) as unknown as MockChain,
-      character_achievements: makeCharAchChain(noLevelUpAch.id, null),
-      quest_instances: makeQuestChain(5),
-    });
-
-    const svc = new AchievementProgressService(readClient as never);
-    await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(0);
-  });
-
-  it("7.3b cascades to unlock compound achievement with level_reached sub-condition after level-up", async () => {
-    // Character at level 2 with 5 quests done.
-    // Quest achievement (xp_reward: 60) unlocks → level-up to 3.
-    // Compound achievement (quest_complete >= 5 AND level_reached >= 3) should also unlock in cascade.
-    const write = makeWriteMocks({
-      unlockedIds: [QUEST_ACH.id, COMPOUND_ACH.id],
-      rpcReturn: {
-        unlocked_achievement_ids: [QUEST_ACH.id],
-        awarded_xp: 60,
-        awarded_gold: 0,
-        xp: 260,
+        xp: 100,
         gold: 0,
         level: 2,
-      },
-    });
-    mockWriteClient.from.mockImplementation(write.from);
-    mockWriteClient.rpc.mockImplementation(write.rpc);
-
-    write.selectAfterIs
-      .mockResolvedValueOnce({
-        data: [{ achievement_id: QUEST_ACH.id }],
-        error: null,
-      })
-      .mockResolvedValueOnce({
-        data: [{ achievement_id: COMPOUND_ACH.id }],
-        error: null,
-      });
-
-    let charAchN = 0;
-    const charAchChain = {
-      select: jest.fn().mockImplementation(() => {
-        charAchN++;
-        if (charAchN === 1) {
-          return {
-            eq: jest.fn().mockResolvedValue({
-              data: [
-                { achievement_id: QUEST_ACH.id },
-                { achievement_id: COMPOUND_ACH.id },
-              ],
-              error: null,
-            }),
-          };
-        }
-        const id = charAchN === 2 ? QUEST_ACH.id : COMPOUND_ACH.id;
-        return {
-          eq: jest.fn().mockReturnValue({
-            in: jest.fn().mockResolvedValue({
-              data: [{ achievement_id: id, unlocked_at: null }],
-              error: null,
-            }),
-          }),
-        };
-      }),
-    };
-
-    const readClient = makeReadClient({
-      characters: makeCharChain({
-        xp: 260,
-        gold: 0,
-        level: 3,
       }) as unknown as MockChain,
       achievements: makeDataResult([
         QUEST_ACH,
-        COMPOUND_ACH,
+        DEDUP_COMPOUND_ACH,
       ]) as unknown as MockChain,
       character_achievements: charAchChain,
       quest_instances: makeQuestChain(5),
@@ -268,7 +289,9 @@ describe("AchievementProgressService - level-up cascade (7.3)", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
 
-    // Only the zero-reward cascade unlock uses the direct unlocked_at update.
-    expect(write.charAchUpdate).toHaveBeenCalledTimes(1);
+    expect(write.upsert).toHaveBeenCalledTimes(2);
+    const cascadeRows = write.upsert.mock.calls[1][0] as Array<{ achievement_id: string }>;
+    expect(cascadeRows).toHaveLength(1);
+    expect(cascadeRows[0].achievement_id).toBe(DEDUP_COMPOUND_ACH.id);
   });
 });


### PR DESCRIPTION
## Summary
- Moves the four unlock-family achievement-progress-service Jest tests out of `lib/__tests__/` and into colocated `lib/*.test.ts` files.
- Updates the relative imports for the relocated tests only.
- Leaves the remaining cascade, compound-progress, and reward-granting achievement-progress-service test files for later bounded slices.

## Verification
- RED path check failed before relocation because the four colocated test files did not exist and the old `lib/__tests__` paths still existed.
- `npx jest --runTestsByPath lib/achievement-progress-service.unlock-cascade.test.ts lib/achievement-progress-service.unlock-evaluation.test.ts lib/achievement-progress-service.unlock-integration.test.ts lib/achievement-progress-service.unlock-p1p2-fixes.test.ts --runInBand`
- `npx eslint lib/achievement-progress-service.unlock-cascade.test.ts lib/achievement-progress-service.unlock-evaluation.test.ts lib/achievement-progress-service.unlock-integration.test.ts lib/achievement-progress-service.unlock-p1p2-fixes.test.ts`
- `env NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_ROLE_KEY=test-service-role-key DISABLE_LOCAL_GIT_METADATA=true npm run build`
- `git diff --check origin/develop...HEAD`

## Scope notes
- No runtime logic changes.
- No migration of `achievement-progress-service.cascade`, `achievement-progress-service.compound-progress`, `achievement-progress-service.reward-granting`, or top-level `tests/unit/...` files.

Refs #143
