### PR TITLE
refactor: colocate achievement cascade progress test

### DIFF
--- a/lib/achievement-progress-service.cascade.test.ts
+++ b/lib/achievement-progress-service.cascade.test.ts
@@ -3,13 +3,13 @@
  * Validates that the cascade logic doesn't break existing tests.
  */
 
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
-import { makeWriteMocks, CHAR_ID, USER_ID } from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
+import { makeWriteMocks, CHAR_ID, USER_ID } from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({


### PR DESCRIPTION
## Summary
- Migrate the cascade-family achievement progress service test out of `lib/__tests__/` into the colocated `lib/achievement-progress-service.cascade.test.ts` path.
- Update relative imports for the relocated test only.
- Keep runtime code untouched and leave the remaining compound-progress and reward-granting slices in `lib/__tests__/` for later bounded cards.

Refs #143

## Test Plan
- [x] RED path check: verified `lib/__tests__/achievement-progress-service.cascade.test.ts` existed and `lib/achievement-progress-service.cascade.test.ts` was absent before relocation.
- [x] `git diff --check origin/develop...HEAD`
- [x] `npm run test:unit -- --runTestsByPath lib/achievement-progress-service.cascade.test.ts --runInBand`
- [x] `npm run lint -- lib/achievement-progress-service.cascade.test.ts`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy JWT_SECRET=*** npm run build`

## Documentation impact
- None. Test layout refactor only.

## Release implications
- None. No runtime behavior changes.
