### PR TITLE
refactor: colocate compound achievement progress test

### DIFF
--- a/lib/achievement-progress-service.compound-progress.test.ts
+++ b/lib/achievement-progress-service.compound-progress.test.ts
@@ -1,12 +1,12 @@
-import { AchievementProgressService } from "../achievement-progress-service";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+import { AchievementProgressService } from "./achievement-progress-service";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeDataResult,
   makeUpsertResult,
   makeReadClient,
   CHARACTER_ID,
   USER_ID,
-} from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
 
 const mockWriteClient = {
   from: jest.fn(),


### PR DESCRIPTION
## Summary
- Relocates the bounded compound-progress achievement progress service Jest slice from `lib/__tests__/` to `lib/achievement-progress-service.compound-progress.test.ts`.
- Updates only the now-colocated relative imports for `AchievementProgressService` and its shared test fixtures.
- Leaves runtime logic untouched and keeps issue #143 open for the remaining reward-granting slice.

## Verification
- [x] RED path check failed before relocation because the colocated compound-progress test did not exist and the old `lib/__tests__` path still did.
- [x] Path check passed after relocation: new colocated test exists and old path is absent.
- [x] `npm run test:unit -- --runTestsByPath lib/achievement-progress-service.compound-progress.test.ts`
- [x] `npx eslint lib/achievement-progress-service.compound-progress.test.ts`
- [x] `git diff --check origin/develop...HEAD`
- [x] Env-seeded `npm run build`

## Documentation impact
- None; test-layout-only migration.

Refs #143
