### PR TITLE
test: colocate reward-granting achievement progress tests

### DIFF
--- a/lib/achievement-progress-service.reward-granting.test.ts
+++ b/lib/achievement-progress-service.reward-granting.test.ts
@@ -1,9 +1,9 @@
-import { AchievementProgressService } from "../achievement-progress-service";
+import { AchievementProgressService } from "./achievement-progress-service";
 import {
   makeReadClient,
   makeDataResult,
-} from "../achievement-progress-service.fixtures";
-import type { MockChain } from "../achievement-progress-service.fixtures";
+} from "./achievement-progress-service.fixtures";
+import type { MockChain } from "./achievement-progress-service.fixtures";
 import {
   makeWriteMocks,
   makeCharAchChain,
@@ -11,7 +11,7 @@ import {
   DEFAULT_ACHIEVEMENT,
   CHAR_ID,
   USER_ID,
-} from "../achievement-progress/unlock-evaluation-fixtures";
+} from "./achievement-progress/unlock-evaluation-fixtures";
 
 const mockWriteClient = { from: jest.fn(), rpc: jest.fn() };
 jest.mock("@/lib/supabase-server", () => ({


### PR DESCRIPTION
## Summary
- Moves the final reward-granting achievement-progress-service Jest slice from `lib/__tests__` to `lib/achievement-progress-service.reward-granting.test.ts`.
- Updates only the relative imports required by the colocation move.
- Leaves runtime logic untouched.

## Test Plan
- [x] RED path check failed before the move because the reward-granting test still lived under `lib/__tests__` and the colocated destination was missing.
- [x] `npm run test:unit -- --runTestsByPath lib/achievement-progress-service.reward-granting.test.ts --runInBand`
- [x] `npm run lint -- lib/achievement-progress-service.reward-granting.test.ts`
- [x] `git diff --check origin/develop...HEAD`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_INTERNAL_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy JWT_SECRET=*** POSTGRES_PASSWORD=*** DB_PASSWORD=*** CRON_SECRET=*** npm run build`

## Release implications
- Test-only refactor; no runtime behavior, database schema, deployment, or operator documentation impact expected.

Refs #143
