### PR TITLE
test: colocate admin dashboard tests

### DIFF
--- a/components/admin/admin-dashboard.content.test.tsx
+++ b/components/admin/admin-dashboard.content.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { AdminDashboard } from "@/components/admin/admin-dashboard";
+import { AdminDashboard } from "./admin-dashboard";
 
 const mockPush = jest.fn();
 const mockGet = jest.fn();

--- a/components/admin/admin-dashboard.navigation.test.tsx
+++ b/components/admin/admin-dashboard.navigation.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { AdminDashboard } from "@/components/admin/admin-dashboard";
+import { AdminDashboard } from "./admin-dashboard";
 
 const mockPush = jest.fn();
 const mockGet = jest.fn();


### PR DESCRIPTION
## Summary
- Relocates the bounded admin-dashboard unit test cluster from `tests/unit/components/` to `components/admin/`.
- Updates the relocated tests to import `AdminDashboard` via the colocated relative path.
- Leaves runtime code and the existing `components/admin/admin-dashboard.test.tsx` surface untouched.

## Test Plan
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test npm run test:unit -- --runTestsByPath components/admin/admin-dashboard.content.test.tsx components/admin/admin-dashboard.navigation.test.tsx --runInBand`
- `git diff --check origin/develop...HEAD`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test npx eslint components/admin/admin-dashboard.content.test.tsx components/admin/admin-dashboard.navigation.test.tsx`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test npm run build`

## Notes
- Baseline focused Jest before relocation could not start until test env variables were provided; with dummy Supabase public env set, the migrated focused Jest suite passes.
- This is one bounded slice of #143 and should keep the issue open.

Closes: none
Refs #143
