### PR TITLE
refactor: colocate admin core route tests

### DIFF
--- a/app/api/achievement-progress/evaluate/route.test.ts
+++ b/app/api/achievement-progress/evaluate/route.test.ts
@@ -20,7 +20,7 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import { POST } from "@/app/api/achievement-progress/evaluate/route";
+import { POST } from "./route";
 
 const USER_ID = "user-001";
 const CHAR_ID = "char-001";

--- a/app/api/achievements/route.test.ts
+++ b/app/api/achievements/route.test.ts
@@ -13,7 +13,7 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import { GET } from "@/app/api/achievements/route";
+import { GET } from "./route";
 
 const CHARACTER_ID = "char-aaaa-bbbb-cccc-dddddddddddd";
 

--- a/app/api/admin/achievement-categories/[id]/route.test.ts
+++ b/app/api/admin/achievement-categories/[id]/route.test.ts
@@ -13,14 +13,17 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import { PATCH } from "@/app/api/admin/achievements/[id]/route";
+import {
+  PATCH,
+  DELETE,
+} from "./route";
 
 function makeRequest(
   method: string,
   auth: string | null = "Bearer token",
   body?: Record<string, unknown>,
 ) {
-  const url = new URL("http://localhost/api/admin/achievements/id");
+  const url = new URL("http://localhost/api/admin/achievement-categories/id");
   const headers: Record<string, string> = {
     "content-type": "application/json",
   };
@@ -33,7 +36,7 @@ function makeRequest(
   });
 }
 
-function setupAuth(role: string = "GUILD_MASTER", familyId: string = "fam-1") {
+function setupAuth(role: string = "GUILD_MASTER") {
   mockServerSupabase.auth.getUser.mockResolvedValue({
     data: { user: { id: "user-1" } },
     error: null,
@@ -44,7 +47,7 @@ function setupAuth(role: string = "GUILD_MASTER", familyId: string = "fam-1") {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         single: jest.fn().mockResolvedValue({
-          data: { role, family_id: familyId },
+          data: { role, family_id: "fam-1" },
           error: null,
         }),
       };
@@ -57,23 +60,14 @@ function setupAuth(role: string = "GUILD_MASTER", familyId: string = "fam-1") {
   });
 }
 
-function setupServiceForPatch(
-  achievementFamilyId: string = "fam-1",
-  mockDeleteCharAchievements?: jest.Mock,
-) {
-  const deleteMock =
-    mockDeleteCharAchievements ?? jest.fn().mockResolvedValue({ error: null });
+function setupServiceForPatch() {
   mockServiceSupabase.from.mockImplementation((table: string) => {
-    if (table === "achievements") {
+    if (table === "achievement_categories") {
       return {
         select: jest.fn().mockReturnValue({
           eq: jest.fn().mockReturnValue({
             maybeSingle: jest.fn().mockResolvedValue({
-              data: {
-                id: "ach-1",
-                name: "First Quest",
-                family_id: achievementFamilyId,
-              },
+              data: { id: "cat-1", name: "Adventurer" },
               error: null,
             }),
           }),
@@ -82,7 +76,7 @@ function setupServiceForPatch(
           eq: jest.fn().mockReturnValue({
             select: jest.fn().mockReturnValue({
               single: jest.fn().mockResolvedValue({
-                data: { id: "ach-1", name: "Updated" },
+                data: { id: "cat-1", name: "Updated" },
                 error: null,
               }),
             }),
@@ -90,29 +84,22 @@ function setupServiceForPatch(
         }),
       };
     }
-    if (table === "character_achievements") {
-      return {
-        delete: jest.fn().mockReturnValue({
-          eq: deleteMock,
-        }),
-      };
-    }
     return { select: jest.fn().mockReturnThis() };
   });
 }
 
-describe("PATCH /api/admin/achievements/[id]", () => {
+describe("PATCH /api/admin/achievement-categories/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("updates an achievement and returns 200", async () => {
+  it("updates a category and returns 200", async () => {
     setupAuth();
     setupServiceForPatch();
 
     const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
     const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
+      params: Promise.resolve({ id: "cat-1" }),
     });
     expect(res.status).toBe(200);
 
@@ -125,26 +112,15 @@ describe("PATCH /api/admin/achievements/[id]", () => {
 
     const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
     const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
+      params: Promise.resolve({ id: "cat-1" }),
     });
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when achievement belongs to a different family", async () => {
-    setupAuth("GUILD_MASTER", "fam-1");
-    setupServiceForPatch("other-fam");
-
-    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
-    const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
-    });
-    expect(res.status).toBe(403);
-  });
-
-  it("returns 404 when achievement does not exist", async () => {
+  it("returns 404 when category does not exist", async () => {
     setupAuth();
     mockServiceSupabase.from.mockImplementation((table: string) => {
-      if (table === "achievements") {
+      if (table === "achievement_categories") {
         return {
           select: jest.fn().mockReturnValue({
             eq: jest.fn().mockReturnValue({
@@ -165,60 +141,97 @@ describe("PATCH /api/admin/achievements/[id]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("updates hidden flag successfully", async () => {
+  it("returns 400 when name is empty string", async () => {
     setupAuth();
     setupServiceForPatch();
 
-    const req = makeRequest("PATCH", "Bearer token", { is_hidden: true });
+    const req = makeRequest("PATCH", "Bearer token", { name: "" });
     const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
+      params: Promise.resolve({ id: "cat-1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/admin/achievement-categories/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deletes a category with no achievements", async () => {
+    setupAuth();
+    mockServiceSupabase.from.mockImplementation((table: string) => {
+      if (table === "achievement_categories") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: "cat-1" },
+                error: null,
+              }),
+            }),
+          }),
+          delete: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ error: null }),
+          }),
+        };
+      }
+      if (table === "achievements") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ count: 0, error: null }),
+          }),
+        };
+      }
+      return { select: jest.fn().mockReturnThis() };
+    });
+
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "cat-1" }),
     });
     expect(res.status).toBe(200);
   });
 
-  it("deletes character_achievements rows when criteria_type changes", async () => {
+  it("returns 409 when category has achievements", async () => {
     setupAuth();
-    const deleteEq = jest.fn().mockResolvedValue({ error: null });
-    setupServiceForPatch("fam-1", deleteEq);
+    mockServiceSupabase.from.mockImplementation((table: string) => {
+      if (table === "achievement_categories") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: "cat-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "achievements") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ count: 3, error: null }),
+          }),
+        };
+      }
+      return { select: jest.fn().mockReturnThis() };
+    });
 
-    const req = makeRequest("PATCH", "Bearer token", {
-      criteria_type: "chore_complete",
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "cat-1" }),
     });
-    const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
-    });
-    expect(res.status).toBe(200);
-    expect(deleteEq).toHaveBeenCalledWith("achievement_id", "ach-1");
+    expect(res.status).toBe(409);
   });
 
-  it("deletes character_achievements rows when criteria_config changes", async () => {
-    setupAuth();
-    const deleteEq = jest.fn().mockResolvedValue({ error: null });
-    setupServiceForPatch("fam-1", deleteEq);
+  it("returns 403 when user is not Guild Master", async () => {
+    setupAuth("HERO");
 
-    const req = makeRequest("PATCH", "Bearer token", {
-      criteria_config: { count: 5 },
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, {
+      params: Promise.resolve({ id: "cat-1" }),
     });
-    const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
-    });
-    expect(res.status).toBe(200);
-    expect(deleteEq).toHaveBeenCalledWith("achievement_id", "ach-1");
-  });
-
-  it("does not delete character_achievements rows when only non-criteria fields change", async () => {
-    setupAuth();
-    const deleteEq = jest.fn().mockResolvedValue({ error: null });
-    setupServiceForPatch("fam-1", deleteEq);
-
-    const req = makeRequest("PATCH", "Bearer token", {
-      name: "New Name",
-      is_hidden: true,
-    });
-    const res = await PATCH(req, {
-      params: Promise.resolve({ id: "ach-1" }),
-    });
-    expect(res.status).toBe(200);
-    expect(deleteEq).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
   });
 });

--- a/app/api/admin/achievement-categories/route.test.ts
+++ b/app/api/admin/achievement-categories/route.test.ts
@@ -13,7 +13,7 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import { GET, POST } from "@/app/api/admin/achievement-categories/route";
+import { GET, POST } from "./route";
 
 function makeRequest(
   method: string,

--- a/app/api/admin/achievements/[id]/route.test.ts
+++ b/app/api/admin/achievements/[id]/route.test.ts
@@ -13,17 +13,14 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import {
-  PATCH,
-  DELETE,
-} from "@/app/api/admin/achievement-categories/[id]/route";
+import { PATCH } from "./route";
 
 function makeRequest(
   method: string,
   auth: string | null = "Bearer token",
   body?: Record<string, unknown>,
 ) {
-  const url = new URL("http://localhost/api/admin/achievement-categories/id");
+  const url = new URL("http://localhost/api/admin/achievements/id");
   const headers: Record<string, string> = {
     "content-type": "application/json",
   };
@@ -36,7 +33,7 @@ function makeRequest(
   });
 }
 
-function setupAuth(role: string = "GUILD_MASTER") {
+function setupAuth(role: string = "GUILD_MASTER", familyId: string = "fam-1") {
   mockServerSupabase.auth.getUser.mockResolvedValue({
     data: { user: { id: "user-1" } },
     error: null,
@@ -47,7 +44,7 @@ function setupAuth(role: string = "GUILD_MASTER") {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         single: jest.fn().mockResolvedValue({
-          data: { role, family_id: "fam-1" },
+          data: { role, family_id: familyId },
           error: null,
         }),
       };
@@ -60,14 +57,23 @@ function setupAuth(role: string = "GUILD_MASTER") {
   });
 }
 
-function setupServiceForPatch() {
+function setupServiceForPatch(
+  achievementFamilyId: string = "fam-1",
+  mockDeleteCharAchievements?: jest.Mock,
+) {
+  const deleteMock =
+    mockDeleteCharAchievements ?? jest.fn().mockResolvedValue({ error: null });
   mockServiceSupabase.from.mockImplementation((table: string) => {
-    if (table === "achievement_categories") {
+    if (table === "achievements") {
       return {
         select: jest.fn().mockReturnValue({
           eq: jest.fn().mockReturnValue({
             maybeSingle: jest.fn().mockResolvedValue({
-              data: { id: "cat-1", name: "Adventurer" },
+              data: {
+                id: "ach-1",
+                name: "First Quest",
+                family_id: achievementFamilyId,
+              },
               error: null,
             }),
           }),
@@ -76,7 +82,7 @@ function setupServiceForPatch() {
           eq: jest.fn().mockReturnValue({
             select: jest.fn().mockReturnValue({
               single: jest.fn().mockResolvedValue({
-                data: { id: "cat-1", name: "Updated" },
+                data: { id: "ach-1", name: "Updated" },
                 error: null,
               }),
             }),
@@ -84,22 +90,29 @@ function setupServiceForPatch() {
         }),
       };
     }
+    if (table === "character_achievements") {
+      return {
+        delete: jest.fn().mockReturnValue({
+          eq: deleteMock,
+        }),
+      };
+    }
     return { select: jest.fn().mockReturnThis() };
   });
 }
 
-describe("PATCH /api/admin/achievement-categories/[id]", () => {
+describe("PATCH /api/admin/achievements/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("updates a category and returns 200", async () => {
+  it("updates an achievement and returns 200", async () => {
     setupAuth();
     setupServiceForPatch();
 
     const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
     const res = await PATCH(req, {
-      params: Promise.resolve({ id: "cat-1" }),
+      params: Promise.resolve({ id: "ach-1" }),
     });
     expect(res.status).toBe(200);
 
@@ -112,15 +125,26 @@ describe("PATCH /api/admin/achievement-categories/[id]", () => {
 
     const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
     const res = await PATCH(req, {
-      params: Promise.resolve({ id: "cat-1" }),
+      params: Promise.resolve({ id: "ach-1" }),
     });
     expect(res.status).toBe(403);
   });
 
-  it("returns 404 when category does not exist", async () => {
+  it("returns 403 when achievement belongs to a different family", async () => {
+    setupAuth("GUILD_MASTER", "fam-1");
+    setupServiceForPatch("other-fam");
+
+    const req = makeRequest("PATCH", "Bearer token", { name: "Updated" });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when achievement does not exist", async () => {
     setupAuth();
     mockServiceSupabase.from.mockImplementation((table: string) => {
-      if (table === "achievement_categories") {
+      if (table === "achievements") {
         return {
           select: jest.fn().mockReturnValue({
             eq: jest.fn().mockReturnValue({
@@ -141,97 +165,60 @@ describe("PATCH /api/admin/achievement-categories/[id]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when name is empty string", async () => {
+  it("updates hidden flag successfully", async () => {
     setupAuth();
     setupServiceForPatch();
 
-    const req = makeRequest("PATCH", "Bearer token", { name: "" });
+    const req = makeRequest("PATCH", "Bearer token", { is_hidden: true });
     const res = await PATCH(req, {
-      params: Promise.resolve({ id: "cat-1" }),
-    });
-    expect(res.status).toBe(400);
-  });
-});
-
-describe("DELETE /api/admin/achievement-categories/[id]", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("deletes a category with no achievements", async () => {
-    setupAuth();
-    mockServiceSupabase.from.mockImplementation((table: string) => {
-      if (table === "achievement_categories") {
-        return {
-          select: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              maybeSingle: jest.fn().mockResolvedValue({
-                data: { id: "cat-1" },
-                error: null,
-              }),
-            }),
-          }),
-          delete: jest.fn().mockReturnValue({
-            eq: jest.fn().mockResolvedValue({ error: null }),
-          }),
-        };
-      }
-      if (table === "achievements") {
-        return {
-          select: jest.fn().mockReturnValue({
-            eq: jest.fn().mockResolvedValue({ count: 0, error: null }),
-          }),
-        };
-      }
-      return { select: jest.fn().mockReturnThis() };
-    });
-
-    const req = makeRequest("DELETE");
-    const res = await DELETE(req, {
-      params: Promise.resolve({ id: "cat-1" }),
+      params: Promise.resolve({ id: "ach-1" }),
     });
     expect(res.status).toBe(200);
   });
 
-  it("returns 409 when category has achievements", async () => {
+  it("deletes character_achievements rows when criteria_type changes", async () => {
     setupAuth();
-    mockServiceSupabase.from.mockImplementation((table: string) => {
-      if (table === "achievement_categories") {
-        return {
-          select: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              maybeSingle: jest.fn().mockResolvedValue({
-                data: { id: "cat-1" },
-                error: null,
-              }),
-            }),
-          }),
-        };
-      }
-      if (table === "achievements") {
-        return {
-          select: jest.fn().mockReturnValue({
-            eq: jest.fn().mockResolvedValue({ count: 3, error: null }),
-          }),
-        };
-      }
-      return { select: jest.fn().mockReturnThis() };
-    });
+    const deleteEq = jest.fn().mockResolvedValue({ error: null });
+    setupServiceForPatch("fam-1", deleteEq);
 
-    const req = makeRequest("DELETE");
-    const res = await DELETE(req, {
-      params: Promise.resolve({ id: "cat-1" }),
+    const req = makeRequest("PATCH", "Bearer token", {
+      criteria_type: "chore_complete",
     });
-    expect(res.status).toBe(409);
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(deleteEq).toHaveBeenCalledWith("achievement_id", "ach-1");
   });
 
-  it("returns 403 when user is not Guild Master", async () => {
-    setupAuth("HERO");
+  it("deletes character_achievements rows when criteria_config changes", async () => {
+    setupAuth();
+    const deleteEq = jest.fn().mockResolvedValue({ error: null });
+    setupServiceForPatch("fam-1", deleteEq);
 
-    const req = makeRequest("DELETE");
-    const res = await DELETE(req, {
-      params: Promise.resolve({ id: "cat-1" }),
+    const req = makeRequest("PATCH", "Bearer token", {
+      criteria_config: { count: 5 },
     });
-    expect(res.status).toBe(403);
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(deleteEq).toHaveBeenCalledWith("achievement_id", "ach-1");
+  });
+
+  it("does not delete character_achievements rows when only non-criteria fields change", async () => {
+    setupAuth();
+    const deleteEq = jest.fn().mockResolvedValue({ error: null });
+    setupServiceForPatch("fam-1", deleteEq);
+
+    const req = makeRequest("PATCH", "Bearer token", {
+      name: "New Name",
+      is_hidden: true,
+    });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "ach-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(deleteEq).not.toHaveBeenCalled();
   });
 });

--- a/app/api/admin/achievements/route.test.ts
+++ b/app/api/admin/achievements/route.test.ts
@@ -13,7 +13,7 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import { GET, POST } from "@/app/api/admin/achievements/route";
+import { GET, POST } from "./route";
 
 function makeRequest(
   method: string,

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -5,7 +5,7 @@ jest.mock('@/lib/supabase', () => ({
 }));
 
 import packageJson from '@/package.json';
-import { GET } from '@/app/api/health/route';
+import { GET } from './route';
 import { supabase } from '@/lib/supabase';
 
 const originalNpmPackageVersion = process.env.npm_package_version;


### PR DESCRIPTION
## Summary
- Moves the Pass 1 issue #143 admin/core route test cluster from `tests/unit/app/api/...` into colocated `route.test.ts` files beside the covered route handlers.
- Updates route-handler imports in the moved tests to use local `./route` imports.
- Leaves runtime route logic untouched.

## Test Plan
- [x] `npm run test:unit -- --runTestsByPath tests/unit/app/api/admin/achievement-categories-id.test.ts tests/unit/app/api/admin/achievement-categories.test.ts tests/unit/app/api/admin/achievements-id.test.ts tests/unit/app/api/admin/achievements.test.ts tests/unit/app/api/achievement-progress-evaluate.test.ts tests/unit/app/api/achievements.test.ts tests/unit/app/api/health-route.test.ts` (baseline before move)
- [x] `npm run test:unit -- --runTestsByPath app/api/admin/achievement-categories/'[id]'/route.test.ts app/api/admin/achievement-categories/route.test.ts app/api/admin/achievements/'[id]'/route.test.ts app/api/admin/achievements/route.test.ts app/api/achievement-progress/evaluate/route.test.ts app/api/achievements/route.test.ts app/api/health/route.test.ts`
- [x] `npm run lint -- app/api/admin/achievement-categories/'[id]'/route.test.ts app/api/admin/achievement-categories/route.test.ts app/api/admin/achievements/'[id]'/route.test.ts app/api/admin/achievements/route.test.ts app/api/achievement-progress/evaluate/route.test.ts app/api/achievements/route.test.ts app/api/health/route.test.ts`
- [x] `npx tsc --noEmit --pretty false`
- [x] `git diff --check origin/develop...HEAD`

## Release implications
- Test-only refactor. No runtime, deployment, migration, or release behavior changes expected.

Refs #143
