### PR TITLE
refactor: colocate remaining pass 5 lib tests

### DIFF
--- a/lib/admin/start-season-reset-cli.test.ts
+++ b/lib/admin/start-season-reset-cli.test.ts
@@ -1,9 +1,9 @@
-import { type SeasonResetStore } from "@/lib/admin/start-season-reset";
+import { type SeasonResetStore } from "./start-season-reset";
 import {
   formatStartSeasonDiscoveryAudit,
   parseStartSeasonResetArgs,
   runStartSeasonDiscovery,
-} from "@/lib/admin/start-season-reset-cli";
+} from "./start-season-reset-cli";
 
 describe("admin start-season reset CLI discovery", () => {
   it("parses list-families discovery without requiring reset arguments", () => {

--- a/lib/admin/start-season-reset-preflight.test.ts
+++ b/lib/admin/start-season-reset-preflight.test.ts
@@ -2,7 +2,7 @@ import {
   buildLocalSupabasePreflightMessage,
   createLocalSupabasePreflightPlan,
   isMissingSeasonsMigrationError,
-} from "@/lib/admin/start-season-reset-preflight";
+} from "./start-season-reset-preflight";
 
 describe("local Supabase migration preflight", () => {
   it("requires a seasons-table check for local Supabase URLs", () => {

--- a/lib/admin/start-season-reset-store.test.ts
+++ b/lib/admin/start-season-reset-store.test.ts
@@ -1,4 +1,4 @@
-import { createSupabaseSeasonResetStore } from "@/lib/admin/start-season-reset-store";
+import { createSupabaseSeasonResetStore } from "./start-season-reset-store";
 
 describe("Supabase start-season reset store", () => {
   it("lists families without selecting schema-dependent active_season_id", async () => {

--- a/lib/admin/start-season-reset.test.ts
+++ b/lib/admin/start-season-reset.test.ts
@@ -1,5 +1,5 @@
-import { buildCharacterResetPatch, runStartSeasonReset, type SeasonResetStore } from "@/lib/admin/start-season-reset";
-import { parseStartSeasonResetArgs } from "@/lib/admin/start-season-reset-cli";
+import { buildCharacterResetPatch, runStartSeasonReset, type SeasonResetStore } from "./start-season-reset";
+import { parseStartSeasonResetArgs } from "./start-season-reset-cli";
 
 describe("admin start-season reset", () => {
   it("resets season-derived character state while preserving spendable gold", () => {

--- a/lib/family-achievement-progress-service.backfill-if-stale.test.ts
+++ b/lib/family-achievement-progress-service.backfill-if-stale.test.ts
@@ -13,7 +13,7 @@ jest.mock("@/lib/seasons/active-season", () => ({
   getActiveSeasonForFamily: jest.fn(),
 }));
 
-import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
+import { FamilyAchievementProgressService } from "./family-achievement-progress-service";
 import { getActiveSeasonForFamily } from "@/lib/seasons/active-season";
 
 const mockGetActiveSeasonForFamily = getActiveSeasonForFamily as jest.Mock;

--- a/lib/family-achievement-progress-service.update-progress.test.ts
+++ b/lib/family-achievement-progress-service.update-progress.test.ts
@@ -23,8 +23,8 @@ jest.mock("@/lib/seasons/active-season", () => ({
   }),
 }));
 
-import { FamilyAchievementProgressService } from "@/lib/family-achievement-progress-service";
-import { FAMILY_EVALUATOR_REGISTRY } from "@/lib/family-achievement-progress/family-evaluators";
+import { FamilyAchievementProgressService } from "./family-achievement-progress-service";
+import { FAMILY_EVALUATOR_REGISTRY } from "./family-achievement-progress/family-evaluators";
 
 const mockEvaluator = FAMILY_EVALUATOR_REGISTRY.quest_complete as jest.Mock;
 

--- a/lib/family-achievement-progress/family-evaluators.quest-difficulty.test.ts
+++ b/lib/family-achievement-progress/family-evaluators.quest-difficulty.test.ts
@@ -1,4 +1,4 @@
-import { FAMILY_EVALUATOR_REGISTRY } from "@/lib/family-achievement-progress/family-evaluators";
+import { FAMILY_EVALUATOR_REGISTRY } from "./family-evaluators";
 
 function makeQueryChain() {
   const eqCalls: [string, unknown][] = [];

--- a/lib/family-achievement-progress/service-helpers.recomputeAchievement.test.ts
+++ b/lib/family-achievement-progress/service-helpers.recomputeAchievement.test.ts
@@ -1,11 +1,11 @@
-jest.mock("@/lib/family-achievement-progress/family-evaluators", () => ({
+jest.mock("./family-evaluators", () => ({
   FAMILY_EVALUATOR_REGISTRY: {
     quest_complete: jest.fn(),
   },
 }));
 
-import { recomputeAchievementImpl } from "@/lib/family-achievement-progress/service-helpers";
-import { FAMILY_EVALUATOR_REGISTRY } from "@/lib/family-achievement-progress/family-evaluators";
+import { recomputeAchievementImpl } from "./service-helpers";
+import { FAMILY_EVALUATOR_REGISTRY } from "./family-evaluators";
 
 const mockEvaluator = FAMILY_EVALUATOR_REGISTRY.quest_complete as jest.Mock;
 


### PR DESCRIPTION
## Summary
- Migrates the remaining Pass 5 admin start-season reset tests from `tests/unit/lib` into `lib/admin`.
- Migrates the remaining Pass 5 family achievement reset/progress tests into the colocated `lib` / `lib/family-achievement-progress` paths beside the modules they cover.
- Updates imports to use local relative module paths where the tests now sit.

References #143. This is Pass 5 only and intentionally does not close the issue.

## Test Plan
- `npx jest --runTestsByPath lib/admin/start-season-reset-cli.test.ts lib/admin/start-season-reset-preflight.test.ts lib/admin/start-season-reset-store.test.ts lib/admin/start-season-reset.test.ts lib/family-achievement-progress-service.backfill-if-stale.test.ts lib/family-achievement-progress/service-helpers.recomputeAchievement.test.ts lib/family-achievement-progress-service.update-progress.test.ts lib/family-achievement-progress/family-evaluators.quest-difficulty.test.ts`
- `npx eslint lib/admin/start-season-reset-cli.test.ts lib/admin/start-season-reset-preflight.test.ts lib/admin/start-season-reset-store.test.ts lib/admin/start-season-reset.test.ts lib/family-achievement-progress-service.backfill-if-stale.test.ts lib/family-achievement-progress/service-helpers.recomputeAchievement.test.ts lib/family-achievement-progress-service.update-progress.test.ts lib/family-achievement-progress/family-evaluators.quest-difficulty.test.ts`
- `git diff --check origin/develop...HEAD`

## Documentation impact
- None; test layout refactor only.

## Notes
- `npm ci` could not complete in this worktree because the host filesystem was full; the focused checks used the existing shared ChoreQuest `node_modules` from a prior worktree symlinked into this workspace. A tiresome economy, but effective.
