### PR TITLE
feat: add admin user detail snapshot

### DIFF
--- a/app/admin/users/[userId]/page.test.tsx
+++ b/app/admin/users/[userId]/page.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import AdminUserPage from "./page";
+import { supabase } from "@/lib/supabase";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ userId: "hero-1" }),
+}));
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    user: { id: "gm-1" },
+    profile: { id: "gm-1", role: "GUILD_MASTER", family_id: "family-1", name: "GM" },
+    family: { id: "family-1", name: "Test Family" },
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/lib/character-context", () => ({
+  useCharacter: () => ({
+    character: { id: "gm-char", name: "Guild Master", level: 10, gold: 0, xp: 0 },
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/components/layout/authenticated-page-shell", () => ({
+  AuthenticatedPageShell: ({ children, title }: React.PropsWithChildren<{ title: string }>) => (
+    <main>
+      <h1>{title}</h1>
+      {children}
+    </main>
+  ),
+}));
+
+jest.mock("@/components/admin/admin-user-detail-view", () => ({
+  AdminUserDetailView: ({ detail }: { detail: { user: { name: string } } }) => (
+    <div>Detail for {detail.user.name}</div>
+  ),
+}));
+
+describe("AdminUserPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { access_token: "token-1" } },
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        detail: {
+          user: { id: "hero-1", name: "Towner", role: "HERO" },
+          character: null,
+          questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
+          recentQuests: [],
+          goldLedgerNotice: "Ledger later",
+        },
+      }),
+    });
+  });
+
+  it("loads the target user detail through the admin API with the session token", async () => {
+    render(<AdminUserPage />);
+
+    expect(screen.getByText("Loading user profile...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/admin/users/hero-1",
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer token-1" }),
+        }),
+      );
+      expect(screen.getByText("Detail for Towner")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Crown } from "lucide-react";
+import { AdminUserDetailView } from "@/components/admin/admin-user-detail-view";
+import { AuthenticatedPageShell } from "@/components/layout/authenticated-page-shell";
+import { Button } from "@/components/ui";
+import { useAuth } from "@/lib/auth-context";
+import { useCharacter } from "@/lib/character-context";
+import { supabase } from "@/lib/supabase";
+import type { AdminUserDetail } from "@/lib/admin-user-detail-service";
+
+function resolveUserId(param: string | string[] | undefined): string | null {
+  if (Array.isArray(param)) return param[0] ?? null;
+  return param ?? null;
+}
+
+export default function AdminUserPage() {
+  const router = useRouter();
+  const params = useParams();
+  const targetUserId = useMemo(() => resolveUserId(params.userId), [params.userId]);
+  const { user, profile, family, isLoading } = useAuth();
+  const { character, isLoading: characterLoading } = useCharacter();
+  const [detail, setDetail] = useState<AdminUserDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(true);
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      router.push("/auth/login");
+      return;
+    }
+
+    if (!isLoading && user && profile?.role !== "GUILD_MASTER") {
+      router.push("/dashboard?error=unauthorized");
+    }
+  }, [isLoading, profile?.role, router, user]);
+
+  useEffect(() => {
+    if (isLoading || !user || profile?.role !== "GUILD_MASTER" || !targetUserId) {
+      return;
+    }
+
+    let isMounted = true;
+
+    async function loadUserDetail() {
+      try {
+        setLoadingDetail(true);
+        setError(null);
+        const token = (await supabase.auth.getSession()).data.session?.access_token;
+        if (!token) {
+          throw new Error("Authentication required");
+        }
+
+        const response = await fetch(`/api/admin/users/${targetUserId}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+        });
+
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error || "Failed to load user profile");
+        }
+
+        if (isMounted) {
+          setDetail(payload.detail);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : "Failed to load user profile");
+        }
+      } finally {
+        if (isMounted) {
+          setLoadingDetail(false);
+        }
+      }
+    }
+
+    loadUserDetail();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isLoading, profile?.role, targetUserId, user]);
+
+  if (isLoading || characterLoading || loadingDetail) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gold-500 mx-auto mb-4"></div>
+          <p className="text-gray-400">Loading user profile...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user || profile?.role !== "GUILD_MASTER" || !character) {
+    return null;
+  }
+
+  return (
+    <AuthenticatedPageShell
+      character={character}
+      family={family}
+      profile={profile}
+      title="Admin User Profile"
+      titleIcon={<Crown size={32} />}
+      actions={
+        <Button onClick={() => router.push("/admin?tab=guild-masters")} variant="secondary" size="sm">
+          ← Back to Roster
+        </Button>
+      }
+    >
+      {error ? (
+        <div className="rounded-lg border border-red-500 bg-red-900/20 p-4 text-red-200">
+          {error}
+        </div>
+      ) : detail ? (
+        <AdminUserDetailView detail={detail} />
+      ) : null}
+    </AuthenticatedPageShell>
+  );
+}

--- a/app/api/admin/users/[userId]/route.test.ts
+++ b/app/api/admin/users/[userId]/route.test.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+import { adminUserDetailService } from "@/lib/admin-user-detail-service";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NotFoundError } from "@/lib/errors";
+
+jest.mock("@/lib/admin-user-detail-service", () => ({
+  adminUserDetailService: {
+    getUserDetail: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/api-auth-helpers", () => ({
+  extractBearerToken: jest.fn(),
+  authenticateAndFetchUserProfile: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(),
+}));
+
+describe("GET /api/admin/users/[userId]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (extractBearerToken as jest.Mock).mockReturnValue("token-1");
+    (createServerSupabaseClient as jest.Mock).mockReturnValue({ client: true });
+    (authenticateAndFetchUserProfile as jest.Mock).mockResolvedValue({
+      id: "gm-1",
+      role: "GUILD_MASTER",
+      family_id: "family-1",
+    });
+  });
+
+  it("returns an authenticated same-family admin user detail response", async () => {
+    const detail = {
+      user: { id: "hero-1", name: "Hero", role: "HERO" },
+      character: null,
+      questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
+      recentQuests: [],
+      goldLedgerNotice: "Ledger comes later",
+    };
+    (adminUserDetailService.getUserDetail as jest.Mock).mockResolvedValue(detail);
+
+    const response = await GET(new NextRequest("http://app.test/api/admin/users/hero-1"), {
+      params: Promise.resolve({ userId: "hero-1" }),
+    });
+
+    await expect(response.json()).resolves.toEqual({ success: true, detail });
+    expect(response.status).toBe(200);
+    expect(adminUserDetailService.getUserDetail).toHaveBeenCalledWith(
+      { client: true },
+      { id: "gm-1", role: "GUILD_MASTER", family_id: "family-1" },
+      "hero-1",
+    );
+  });
+
+  it("returns a generic not-found response for missing or cross-family users", async () => {
+    (adminUserDetailService.getUserDetail as jest.Mock).mockRejectedValue(
+      new NotFoundError("User not found", "ADMIN_USER_DETAIL_NOT_FOUND"),
+    );
+
+    const response = await GET(new NextRequest("http://app.test/api/admin/users/other"), {
+      params: Promise.resolve({ userId: "other" }),
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      error: "User not found",
+      code: "ADMIN_USER_DETAIL_NOT_FOUND",
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/app/api/admin/users/[userId]/route.ts
+++ b/app/api/admin/users/[userId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api-error-handler";
+import {
+  authenticateAndFetchUserProfile,
+  extractBearerToken,
+} from "@/lib/api-auth-helpers";
+import { adminUserDetailService } from "@/lib/admin-user-detail-service";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> },
+) {
+  try {
+    const { userId } = await params;
+    const token = extractBearerToken(request);
+    const supabase = createServerSupabaseClient(token);
+    const requesterProfile = await authenticateAndFetchUserProfile(
+      supabase,
+      token,
+    );
+
+    const detail = await adminUserDetailService.getUserDetail(
+      supabase,
+      requesterProfile,
+      userId,
+    );
+
+    return NextResponse.json({ success: true, detail });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/components/admin/admin-user-detail-view.test.tsx
+++ b/components/admin/admin-user-detail-view.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, within } from "@testing-library/react";
+import { AdminUserDetailView } from "./admin-user-detail-view";
+import type { AdminUserDetail } from "@/lib/admin-user-detail-service";
+
+const baseDetail: AdminUserDetail = {
+  user: {
+    id: "hero-1",
+    name: "Towner",
+    email: "towner@example.test",
+    role: "HERO",
+    familyId: "family-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+  },
+  character: {
+    id: "char-1",
+    name: "Towner the Brave",
+    class: "KNIGHT",
+    level: 7,
+    xp: 340,
+    gold: 125,
+    gems: 4,
+    honor: 9,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+  },
+  questSummary: {
+    active: 2,
+    pendingApproval: 1,
+    approved: 4,
+    missed: 1,
+    total: 8,
+  },
+  recentQuests: [
+    {
+      id: "quest-1",
+      title: "Unload dishwasher",
+      status: "APPROVED",
+      dueDate: "2026-01-03T00:00:00Z",
+      completedAt: "2026-01-02T12:00:00Z",
+      approvedAt: "2026-01-02T13:00:00Z",
+      goldReward: 5,
+      xpReward: 10,
+    },
+  ],
+  goldLedgerNotice:
+    "Current gold is shown from the character record. Full ledger and audit history will land in a separate audit slice.",
+};
+
+describe("AdminUserDetailView", () => {
+  it("renders the read-only profile, character summary, progression snapshot, and ledger placeholder", () => {
+    render(<AdminUserDetailView detail={baseDetail} />);
+
+    expect(screen.getByRole("heading", { name: "Towner" })).toBeInTheDocument();
+    expect(screen.getByText("Hero"));
+    expect(screen.getByText("Towner the Brave")).toBeInTheDocument();
+    expect(screen.getByText("Knight")).toBeInTheDocument();
+    expect(screen.getByText("Level 7")).toBeInTheDocument();
+    expect(screen.getByText("340 XP")).toBeInTheDocument();
+    expect(screen.getByText("125 Gold")).toBeInTheDocument();
+    expect(screen.getByText("4 Gems")).toBeInTheDocument();
+    expect(screen.getByText("9 Honor")).toBeInTheDocument();
+
+    const snapshot = screen.getByTestId("admin-user-progression-snapshot");
+    expect(within(snapshot).getByText("2 Active")).toBeInTheDocument();
+    expect(within(snapshot).getByText("1 Awaiting Approval")).toBeInTheDocument();
+    expect(within(snapshot).getByText("4 Approved")).toBeInTheDocument();
+    expect(within(snapshot).getByText("1 Missed/Expired")).toBeInTheDocument();
+
+    expect(screen.getByText("Unload dishwasher")).toBeInTheDocument();
+    expect(screen.getByText(/Full ledger and audit history/)).toBeInTheDocument();
+  });
+
+  it("handles users with no character or quest data gracefully", () => {
+    render(
+      <AdminUserDetailView
+        detail={{
+          ...baseDetail,
+          character: null,
+          questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
+          recentQuests: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/No character has been created/i)).toBeInTheDocument();
+    expect(screen.getByText(/No recent quests found/i)).toBeInTheDocument();
+  });
+});

--- a/components/admin/admin-user-detail-view.tsx
+++ b/components/admin/admin-user-detail-view.tsx
@@ -1,0 +1,130 @@
+import type { AdminUserDetail } from "@/lib/admin-user-detail-service";
+
+function titleCase(value: string | null | undefined): string {
+  if (!value) return "Unknown";
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+function StatPill({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-900/50 p-4">
+      <p className="text-2xl font-semibold text-white">{value} {label}</p>
+    </div>
+  );
+}
+
+export function AdminUserDetailView({ detail }: { detail: AdminUserDetail }) {
+  const { user, character, questSummary, recentQuests } = detail;
+
+  return (
+    <div className="space-y-6" data-testid="admin-user-detail-view">
+      <section className="rounded-lg border border-gray-700 bg-gray-800/50 p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-fantasy text-white">{user.name}</h1>
+            <p className="mt-1 text-sm text-gray-400">{user.email}</p>
+          </div>
+          <span className="inline-flex w-fit rounded-full border border-gold-500/30 bg-gold-500/10 px-3 py-1 text-sm font-medium text-gold-300">
+            {titleCase(user.role)}
+          </span>
+        </div>
+        <dl className="mt-6 grid gap-4 sm:grid-cols-2">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-gray-500">Joined</dt>
+            <dd className="text-gray-200">{formatDate(user.createdAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-gray-500">Updated</dt>
+            <dd className="text-gray-200">{formatDate(user.updatedAt)}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="rounded-lg border border-gray-700 bg-gray-800/50 p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">Character Summary</h2>
+        {character ? (
+          <div className="space-y-4">
+            <div>
+              <p className="text-2xl font-semibold text-white">{character.name}</p>
+              <p className="text-gray-400">{titleCase(character.class)}</p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+              <div className="rounded-lg bg-gray-900/50 p-3 text-gray-200">Level {character.level}</div>
+              <div className="rounded-lg bg-gray-900/50 p-3 text-gray-200">{character.xp} XP</div>
+              <div className="rounded-lg bg-gray-900/50 p-3 text-gray-200">{character.gold} Gold</div>
+              <div className="rounded-lg bg-gray-900/50 p-3 text-gray-200">{character.gems} Gems</div>
+              <div className="rounded-lg bg-gray-900/50 p-3 text-gray-200">{character.honor} Honor</div>
+            </div>
+          </div>
+        ) : (
+          <p className="rounded-lg border border-dashed border-gray-600 bg-gray-900/40 p-4 text-gray-300">
+            No character has been created for this user yet. Profile details are still available.
+          </p>
+        )}
+      </section>
+
+      <section
+        className="rounded-lg border border-gray-700 bg-gray-800/50 p-6"
+        data-testid="admin-user-progression-snapshot"
+      >
+        <h2 className="mb-4 text-xl font-semibold text-white">Progression Snapshot</h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <StatPill label="Active" value={questSummary.active} />
+          <StatPill label="Awaiting Approval" value={questSummary.pendingApproval} />
+          <StatPill label="Approved" value={questSummary.approved} />
+          <StatPill label="Missed/Expired" value={questSummary.missed} />
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-700 bg-gray-800/50 p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">Recent Quests</h2>
+        {recentQuests.length > 0 ? (
+          <ul className="divide-y divide-gray-700">
+            {recentQuests.map((quest) => (
+              <li key={quest.id} className="py-4 first:pt-0 last:pb-0">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="font-medium text-white">{quest.title}</p>
+                    <p className="text-sm text-gray-400">
+                      {titleCase(quest.status)} • {quest.xpReward} XP • {quest.goldReward} Gold
+                    </p>
+                  </div>
+                  <p className="text-sm text-gray-500">
+                    {quest.approvedAt
+                      ? `Approved ${formatDate(quest.approvedAt)}`
+                      : quest.completedAt
+                        ? `Completed ${formatDate(quest.completedAt)}`
+                        : quest.dueDate
+                          ? `Due ${formatDate(quest.dueDate)}`
+                          : "No date"}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="rounded-lg border border-dashed border-gray-600 bg-gray-900/40 p-4 text-gray-300">
+            No recent quests found for this user.
+          </p>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-amber-100">
+        {detail.goldLedgerNotice}
+      </section>
+    </div>
+  );
+}

--- a/components/admin/guild-master-manager.rendering.test.tsx
+++ b/components/admin/guild-master-manager.rendering.test.tsx
@@ -113,4 +113,14 @@ describe("GuildMasterManager - rendering", () => {
       expect(demoteButtons.length).toBe(1);
     });
   });
+
+  it("links each roster member to a dedicated admin profile page", async () => {
+    renderGuildMasterManager();
+
+    await waitFor(() => {
+      const profileLinks = screen.getAllByRole("link", { name: /View profile/i });
+      expect(profileLinks).toHaveLength(3);
+      expect(profileLinks[1]).toHaveAttribute("href", "/admin/users/user-2");
+    });
+  });
 });

--- a/components/admin/guild-master-manager/GuildMemberRow.tsx
+++ b/components/admin/guild-master-manager/GuildMemberRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { Crown, Sword } from "lucide-react";
 import { Button } from "@/components/ui";
@@ -89,7 +90,13 @@ export function GuildMemberRow({
         </div>
       </div>
 
-      <div className="flex-shrink-0">
+      <div className="flex-shrink-0 flex items-center gap-2">
+        <Link
+          href={`/admin/users/${member.id}`}
+          className="text-sm text-blue-300 hover:text-blue-200 px-3 py-2 rounded-lg border border-blue-500/30 hover:bg-blue-500/10 transition-colors"
+        >
+          View profile
+        </Link>
         {isCurrentUser ? (
           <span className="text-xs text-gray-500 px-4 py-2">
             (You)

--- a/lib/admin-user-detail-service.test.ts
+++ b/lib/admin-user-detail-service.test.ts
@@ -1,0 +1,237 @@
+import { AdminUserDetailService } from "./admin-user-detail-service";
+import { ForbiddenError, NotFoundError } from "./errors";
+
+const requester = {
+  id: "gm-1",
+  role: "GUILD_MASTER" as const,
+  family_id: "family-1",
+};
+
+type QueryResult = { data: unknown; error: unknown };
+
+function createSupabaseStub(results: Record<string, QueryResult | QueryResult[]>) {
+  const calls: Array<{ table: string; operations: Array<[string, unknown[]]> }> = [];
+  const callCounts: Record<string, number> = {};
+
+  const nextResult = (table: string): QueryResult => {
+    const result = results[table];
+    if (Array.isArray(result)) {
+      const index = callCounts[table] ?? 0;
+      callCounts[table] = index + 1;
+      return result[index] ?? result[result.length - 1];
+    }
+    return result ?? { data: null, error: null };
+  };
+
+  const makeQuery = (table: string) => {
+    const result = nextResult(table);
+    const operations: Array<[string, unknown[]]> = [];
+    const query: Record<string, unknown> = {
+      select: (...args: unknown[]) => {
+        operations.push(["select", args]);
+        return query;
+      },
+      eq: (...args: unknown[]) => {
+        operations.push(["eq", args]);
+        return query;
+      },
+      or: (...args: unknown[]) => {
+        operations.push(["or", args]);
+        return query;
+      },
+      order: (...args: unknown[]) => {
+        operations.push(["order", args]);
+        return query;
+      },
+      limit: (...args: unknown[]) => {
+        operations.push(["limit", args]);
+        return Promise.resolve(result);
+      },
+      maybeSingle: () => {
+        operations.push(["maybeSingle", []]);
+        return Promise.resolve(result);
+      },
+      then: (resolve: (value: QueryResult) => void) => {
+        resolve(result);
+      },
+    };
+    calls.push({ table, operations });
+    return query;
+  };
+
+  return {
+    supabase: { from: jest.fn((table: string) => makeQuery(table)) },
+    calls,
+  };
+}
+
+describe("AdminUserDetailService", () => {
+  it("returns same-family profile, character stats, quest counts, and recent quests", async () => {
+    const { supabase } = createSupabaseStub({
+      user_profiles: {
+        data: {
+          id: "hero-1",
+          name: "Towner",
+          email: "towner@example.test",
+          role: "HERO",
+          family_id: "family-1",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+          characters: [
+            {
+              id: "char-1",
+              name: "Towner the Brave",
+              class: "KNIGHT",
+              level: 7,
+              xp: 340,
+              gold: 125,
+              gems: 4,
+              honor_points: 9,
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-02T00:00:00Z",
+            },
+          ],
+        },
+        error: null,
+      },
+      quest_instances: [
+        {
+          data: [
+            { id: "quest-1", title: "Unload dishwasher", status: "APPROVED", due_date: "2026-01-03T00:00:00Z", completed_at: "2026-01-02T12:00:00Z", approved_at: "2026-01-02T13:00:00Z", gold_reward: 5, xp_reward: 10 },
+            { id: "quest-2", title: "Practice piano", status: "COMPLETED", due_date: null, completed_at: "2026-01-04T12:00:00Z", approved_at: null, gold_reward: 10, xp_reward: 15 },
+            { id: "quest-3", title: "Take trash out", status: "IN_PROGRESS", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-4", title: "Read", status: "CLAIMED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-5", title: "Old missed", status: "MISSED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-6", title: "Old approved", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-7", title: "Old approved 2", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-8", title: "Old approved 3", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-9", title: "Older approved outside recent", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+          ],
+          error: null,
+        },
+        {
+          data: [
+            { id: "quest-1", title: "Unload dishwasher", status: "APPROVED", due_date: "2026-01-03T00:00:00Z", completed_at: "2026-01-02T12:00:00Z", approved_at: "2026-01-02T13:00:00Z", gold_reward: 5, xp_reward: 10 },
+            { id: "quest-2", title: "Practice piano", status: "COMPLETED", due_date: null, completed_at: "2026-01-04T12:00:00Z", approved_at: null, gold_reward: 10, xp_reward: 15 },
+            { id: "quest-3", title: "Take trash out", status: "IN_PROGRESS", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-4", title: "Read", status: "CLAIMED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-5", title: "Old missed", status: "MISSED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-6", title: "Old approved", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-7", title: "Old approved 2", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-8", title: "Old approved 3", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    const detail = await new AdminUserDetailService().getUserDetail(
+      supabase as never,
+      requester,
+      "hero-1",
+    );
+
+    expect(detail.user).toEqual(
+      expect.objectContaining({ id: "hero-1", name: "Towner", role: "HERO" }),
+    );
+    expect(detail.character).toEqual(
+      expect.objectContaining({
+        id: "char-1",
+        name: "Towner the Brave",
+        class: "KNIGHT",
+        level: 7,
+        xp: 340,
+        gold: 125,
+        gems: 4,
+        honor: 9,
+      }),
+    );
+    expect(detail.questSummary).toEqual({
+      active: 2,
+      pendingApproval: 1,
+      approved: 5,
+      missed: 1,
+      total: 9,
+    });
+    expect(detail.recentQuests).toHaveLength(8);
+    expect(detail.recentQuests[0]).toEqual(
+      expect.objectContaining({ title: "Unload dishwasher", status: "APPROVED" }),
+    );
+    expect(detail.goldLedgerNotice).toMatch(/separate audit slice/i);
+  });
+
+  it("hides cross-family users behind not found", async () => {
+    const { supabase } = createSupabaseStub({
+      user_profiles: {
+        data: {
+          id: "hero-2",
+          name: "Other Hero",
+          email: "other@example.test",
+          role: "HERO",
+          family_id: "other-family",
+          created_at: null,
+          updated_at: null,
+          characters: [],
+        },
+        error: null,
+      },
+      quest_instances: { data: [], error: null },
+    });
+
+    await expect(
+      new AdminUserDetailService().getUserDetail(
+        supabase as never,
+        requester,
+        "hero-2",
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("allows a same-family user with no character data", async () => {
+    const { supabase } = createSupabaseStub({
+      user_profiles: {
+        data: {
+          id: "hero-3",
+          name: "Characterless Hero",
+          email: "new@example.test",
+          role: "YOUNG_HERO",
+          family_id: "family-1",
+          created_at: null,
+          updated_at: null,
+          characters: [],
+        },
+        error: null,
+      },
+      quest_instances: { data: [], error: null },
+    });
+
+    const detail = await new AdminUserDetailService().getUserDetail(
+      supabase as never,
+      requester,
+      "hero-3",
+    );
+
+    expect(detail.character).toBeNull();
+    expect(detail.questSummary).toEqual({
+      active: 0,
+      pendingApproval: 0,
+      approved: 0,
+      missed: 0,
+      total: 0,
+    });
+    expect(detail.recentQuests).toEqual([]);
+  });
+
+  it("rejects non-Guild-Master requesters before looking up the target", async () => {
+    const { supabase } = createSupabaseStub({});
+
+    await expect(
+      new AdminUserDetailService().getUserDetail(
+        supabase as never,
+        { id: "hero", role: "HERO", family_id: "family-1" },
+        "hero-1",
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+});

--- a/lib/admin-user-detail-service.ts
+++ b/lib/admin-user-detail-service.ts
@@ -1,0 +1,286 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  AuthenticatedUser,
+} from "@/lib/api-auth-helpers";
+import type {
+  CharacterClass,
+  QuestStatus,
+  UserRole,
+} from "@/lib/types/database";
+import { AppError, ForbiddenError, NotFoundError } from "@/lib/errors";
+
+export type AdminUserDetailUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole | null;
+  familyId: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type AdminUserDetailCharacter = {
+  id: string;
+  name: string;
+  class: CharacterClass | null;
+  level: number;
+  xp: number;
+  gold: number;
+  gems: number;
+  honor: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type AdminUserQuestSummary = {
+  active: number;
+  pendingApproval: number;
+  approved: number;
+  missed: number;
+  total: number;
+};
+
+export type AdminUserRecentQuest = {
+  id: string;
+  title: string;
+  status: QuestStatus | null;
+  dueDate: string | null;
+  completedAt: string | null;
+  approvedAt: string | null;
+  goldReward: number;
+  xpReward: number;
+};
+
+export type AdminUserDetail = {
+  user: AdminUserDetailUser;
+  character: AdminUserDetailCharacter | null;
+  questSummary: AdminUserQuestSummary;
+  recentQuests: AdminUserRecentQuest[];
+  goldLedgerNotice: string;
+};
+
+type RawCharacter = {
+  id: string;
+  name: string;
+  class: CharacterClass | null;
+  level: number | null;
+  xp: number | null;
+  gold: number | null;
+  gems: number | null;
+  honor_points: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type RawUserProfile = {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole | null;
+  family_id: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  characters: RawCharacter | RawCharacter[] | null;
+};
+
+type RawQuest = {
+  id: string;
+  title: string;
+  status: QuestStatus | null;
+  due_date: string | null;
+  completed_at: string | null;
+  approved_at: string | null;
+  gold_reward: number | null;
+  xp_reward: number | null;
+};
+
+const GOLD_LEDGER_NOTICE =
+  "Current gold is shown from the character record. Full ledger and audit history will land in a separate audit slice.";
+
+function firstCharacter(
+  characters: RawCharacter | RawCharacter[] | null,
+): RawCharacter | null {
+  if (Array.isArray(characters)) {
+    return characters[0] ?? null;
+  }
+  return characters ?? null;
+}
+
+function emptyQuestSummary(): AdminUserQuestSummary {
+  return {
+    active: 0,
+    pendingApproval: 0,
+    approved: 0,
+    missed: 0,
+    total: 0,
+  };
+}
+
+function summarizeQuests(quests: RawQuest[]): AdminUserQuestSummary {
+  return quests.reduce((summary, quest) => {
+    summary.total += 1;
+
+    if (
+      quest.status === "IN_PROGRESS" ||
+      quest.status === "CLAIMED" ||
+      quest.status === "PENDING" ||
+      quest.status === "AVAILABLE"
+    ) {
+      summary.active += 1;
+    } else if (quest.status === "COMPLETED") {
+      summary.pendingApproval += 1;
+    } else if (quest.status === "APPROVED") {
+      summary.approved += 1;
+    } else if (quest.status === "MISSED" || quest.status === "EXPIRED") {
+      summary.missed += 1;
+    }
+
+    return summary;
+  }, emptyQuestSummary());
+}
+
+function mapRecentQuest(quest: RawQuest): AdminUserRecentQuest {
+  return {
+    id: quest.id,
+    title: quest.title,
+    status: quest.status,
+    dueDate: quest.due_date,
+    completedAt: quest.completed_at,
+    approvedAt: quest.approved_at,
+    goldReward: quest.gold_reward ?? 0,
+    xpReward: quest.xp_reward ?? 0,
+  };
+}
+
+function mapCharacter(
+  character: RawCharacter | null,
+): AdminUserDetailCharacter | null {
+  if (!character) return null;
+
+  return {
+    id: character.id,
+    name: character.name,
+    class: character.class,
+    level: character.level ?? 1,
+    xp: character.xp ?? 0,
+    gold: character.gold ?? 0,
+    gems: character.gems ?? 0,
+    honor: character.honor_points ?? 0,
+    createdAt: character.created_at,
+    updatedAt: character.updated_at,
+  };
+}
+
+export class AdminUserDetailService {
+  async getUserDetail(
+    supabase: SupabaseClient,
+    requesterProfile: AuthenticatedUser,
+    targetUserId: string,
+  ): Promise<AdminUserDetail> {
+    if (requesterProfile.role !== "GUILD_MASTER") {
+      throw new ForbiddenError(
+        "Only Guild Masters can view admin user details",
+        "ADMIN_USER_DETAIL_FORBIDDEN",
+      );
+    }
+
+    const { data: targetProfile, error: targetError } = await supabase
+      .from("user_profiles")
+      .select(
+        `
+        id,
+        name,
+        email,
+        role,
+        family_id,
+        created_at,
+        updated_at,
+        characters (
+          id,
+          name,
+          class,
+          level,
+          xp,
+          gold,
+          gems,
+          honor_points,
+          created_at,
+          updated_at
+        )
+      `,
+      )
+      .eq("id", targetUserId)
+      .maybeSingle();
+
+    if (targetError) {
+      throw new AppError(
+        "Failed to fetch user detail",
+        500,
+        "ADMIN_USER_DETAIL_FETCH_FAILED",
+      );
+    }
+
+    const profile = targetProfile as RawUserProfile | null;
+    if (!profile || profile.family_id !== requesterProfile.family_id) {
+      throw new NotFoundError("User not found", "ADMIN_USER_DETAIL_NOT_FOUND");
+    }
+
+    const character = firstCharacter(profile.characters);
+    const questTargetFilter = character?.id
+      ? `assigned_to_id.eq.${targetUserId},volunteered_by.eq.${character.id}`
+      : `assigned_to_id.eq.${targetUserId}`;
+
+    const { data: questSummaryRows, error: questSummaryError } = await supabase
+      .from("quest_instances")
+      .select("id, status")
+      .eq("family_id", requesterProfile.family_id)
+      .or(questTargetFilter);
+
+    if (questSummaryError) {
+      throw new AppError(
+        "Failed to fetch user progression",
+        500,
+        "ADMIN_USER_PROGRESSION_FETCH_FAILED",
+      );
+    }
+
+    const { data: recentQuestRows, error: recentQuestError } = await supabase
+      .from("quest_instances")
+      .select(
+        "id, title, status, due_date, completed_at, approved_at, gold_reward, xp_reward",
+      )
+      .eq("family_id", requesterProfile.family_id)
+      .or(questTargetFilter)
+      .order("updated_at", { ascending: false })
+      .limit(8);
+
+    if (recentQuestError) {
+      throw new AppError(
+        "Failed to fetch user progression",
+        500,
+        "ADMIN_USER_PROGRESSION_FETCH_FAILED",
+      );
+    }
+
+    const summaryQuests = (questSummaryRows ?? []) as RawQuest[];
+    const recentQuests = (recentQuestRows ?? []) as RawQuest[];
+
+    return {
+      user: {
+        id: profile.id,
+        name: profile.name,
+        email: profile.email,
+        role: profile.role,
+        familyId: profile.family_id,
+        createdAt: profile.created_at,
+        updatedAt: profile.updated_at,
+      },
+      character: mapCharacter(character),
+      questSummary: summarizeQuests(summaryQuests),
+      recentQuests: recentQuests.map(mapRecentQuest),
+      goldLedgerNotice: GOLD_LEDGER_NOTICE,
+    };
+  }
+}
+
+export const adminUserDetailService = new AdminUserDetailService();


### PR DESCRIPTION
## Summary
- Adds a Guild Master roster "View profile" affordance into `/admin/users/[userId]`.
- Adds a server-backed admin user-detail API with Guild-Master-only, same-family-scoped access and generic not-found handling for missing/cross-family targets.
- Adds a read-only admin user-detail page showing profile, character stats, quest status counts, bounded recent quests, and explicit copy that ledger/audit history belongs to a later slice.

## Test Plan
- [x] `npx jest --runTestsByPath lib/admin-user-detail-service.test.ts app/api/admin/users/[userId]/route.test.ts components/admin/guild-master-manager.rendering.test.tsx components/admin/admin-user-detail-view.test.tsx app/admin/users/[userId]/page.test.tsx --runInBand`
- [x] `npm run lint`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`
- [!] `npm run test` initially failed because this fresh worktree lacked Supabase env and `.next/standalone/package.json` from build caused a Jest haste package-name collision; after removing `.next` and rerunning with dummy Supabase env, unrelated family-achievement progress tests still fail on develop-era expectations where `writeUpsert.upsert` is not called. Focused tests for this slice pass.

## Release implications
- Feature-only integration PR against `develop`; no schema migration, no gold-ledger model changes, and no release/deploy action in this PR.

## Documentation impact
- None expected; the UI copy explicitly marks the ledger/audit history as a separate future slice.

Refs #234
