### PR TITLE
fix: scope admin profile recent quests to approvals

### DIFF
--- a/components/admin/admin-user-detail-view.test.tsx
+++ b/components/admin/admin-user-detail-view.test.tsx
@@ -67,6 +67,7 @@ describe("AdminUserDetailView", () => {
     expect(within(snapshot).getByText("4 Approved")).toBeInTheDocument();
     expect(within(snapshot).getByText("1 Missed/Expired")).toBeInTheDocument();
 
+    expect(screen.getByRole("heading", { name: "Recent Approved Quests" })).toBeInTheDocument();
     expect(screen.getByText("Unload dishwasher")).toBeInTheDocument();
     expect(screen.getByText(/Full ledger and audit history/)).toBeInTheDocument();
   });

--- a/components/admin/admin-user-detail-view.tsx
+++ b/components/admin/admin-user-detail-view.tsx
@@ -90,7 +90,7 @@ export function AdminUserDetailView({ detail }: { detail: AdminUserDetail }) {
       </section>
 
       <section className="rounded-lg border border-gray-700 bg-gray-800/50 p-6">
-        <h2 className="mb-4 text-xl font-semibold text-white">Recent Quests</h2>
+        <h2 className="mb-4 text-xl font-semibold text-white">Recent Approved Quests</h2>
         {recentQuests.length > 0 ? (
           <ul className="divide-y divide-gray-700">
             {recentQuests.map((quest) => (

--- a/lib/admin-user-detail-service.test.ts
+++ b/lib/admin-user-detail-service.test.ts
@@ -66,8 +66,8 @@ function createSupabaseStub(results: Record<string, QueryResult | QueryResult[]>
 }
 
 describe("AdminUserDetailService", () => {
-  it("returns same-family profile, character stats, quest counts, and recent quests", async () => {
-    const { supabase } = createSupabaseStub({
+  it("returns same-family profile, character stats, quest counts, and bounded recent approved quests", async () => {
+    const { supabase, calls } = createSupabaseStub({
       user_profiles: {
         data: {
           id: "hero-1",
@@ -119,6 +119,7 @@ describe("AdminUserDetailService", () => {
             { id: "quest-6", title: "Old approved", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
             { id: "quest-7", title: "Old approved 2", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
             { id: "quest-8", title: "Old approved 3", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
+            { id: "quest-9", title: "Older approved outside recent", status: "APPROVED", due_date: null, completed_at: null, approved_at: null, gold_reward: 3, xp_reward: 6 },
           ],
           error: null,
         },
@@ -153,11 +154,23 @@ describe("AdminUserDetailService", () => {
       missed: 1,
       total: 9,
     });
-    expect(detail.recentQuests).toHaveLength(8);
+    expect(detail.recentQuests).toHaveLength(5);
+    expect(detail.recentQuests.map((quest) => quest.status)).toEqual([
+      "APPROVED",
+      "APPROVED",
+      "APPROVED",
+      "APPROVED",
+      "APPROVED",
+    ]);
     expect(detail.recentQuests[0]).toEqual(
       expect.objectContaining({ title: "Unload dishwasher", status: "APPROVED" }),
     );
     expect(detail.goldLedgerNotice).toMatch(/separate audit slice/i);
+
+    const recentQuestCall = calls[2];
+    expect(recentQuestCall.table).toBe("quest_instances");
+    expect(recentQuestCall.operations).toContainEqual(["eq", ["status", "APPROVED"]]);
+    expect(recentQuestCall.operations).toContainEqual(["limit", [8]]);
   });
 
   it("hides cross-family users behind not found", async () => {

--- a/lib/admin-user-detail-service.ts
+++ b/lib/admin-user-detail-service.ts
@@ -152,6 +152,10 @@ function mapRecentQuest(quest: RawQuest): AdminUserRecentQuest {
   };
 }
 
+function isApprovedQuest(quest: RawQuest): boolean {
+  return quest.status === "APPROVED";
+}
+
 function mapCharacter(
   character: RawCharacter | null,
 ): AdminUserDetailCharacter | null {
@@ -250,6 +254,7 @@ export class AdminUserDetailService {
         "id, title, status, due_date, completed_at, approved_at, gold_reward, xp_reward",
       )
       .eq("family_id", requesterProfile.family_id)
+      .eq("status", "APPROVED")
       .or(questTargetFilter)
       .order("updated_at", { ascending: false })
       .limit(8);
@@ -263,7 +268,7 @@ export class AdminUserDetailService {
     }
 
     const summaryQuests = (questSummaryRows ?? []) as RawQuest[];
-    const recentQuests = (recentQuestRows ?? []) as RawQuest[];
+    const recentQuests = ((recentQuestRows ?? []) as RawQuest[]).filter(isApprovedQuest);
 
     return {
       user: {


### PR DESCRIPTION
## Summary
- Tightens the admin user-detail progression snapshot so its recent activity list is explicitly bounded to approved quests.
- Updates the UI heading to "Recent Approved Quests" so the page does not imply an unfiltered quest ledger.
- Adds regression coverage for the approved-only query/filter while preserving the existing same-family Guild Master authorization and current-gold snapshot behavior.

## Test Plan
- [x] RED: `npx jest --runTestsByPath lib/admin-user-detail-service.test.ts --runInBand` failed before the service was filtered to approved quests.
- [x] RED: `npx jest --runTestsByPath components/admin/admin-user-detail-view.test.tsx --runInBand` failed before the heading was updated.
- [x] `npx jest --runTestsByPath lib/admin-user-detail-service.test.ts components/admin/admin-user-detail-view.test.tsx --runInBand`
- [x] `npx jest --runTestsByPath lib/admin-user-detail-service.test.ts app/api/admin/users/[userId]/route.test.ts components/admin/guild-master-manager.rendering.test.tsx components/admin/admin-user-detail-view.test.tsx app/admin/users/[userId]/page.test.tsx --runInBand`
- [x] `npm run lint`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`
- [x] Self-review: local diff reviewed with `git diff --check` and debug/secret-marker scan; no blocking findings.

## Release implications
- Feature/fix integration PR against `develop`; no schema migration, no gold-ledger model changes, and no live deploy action.

## Documentation impact
- None expected; this clarifies existing admin UI copy and query scope.

Closes #236
