### PR TITLE
feat: add canonical gold ledger foundation

### DIFF
--- a/app/api/boss-quests/[id]/complete/route.achievement-integration.test.ts
+++ b/app/api/boss-quests/[id]/complete/route.achievement-integration.test.ts
@@ -1,7 +1,4 @@
-// Tests for boss quest completion achievement progress integration (task 10.1)
-// Verifies updateProgress is called per participant and failures are isolated.
 const mockUpdateProgress = jest.fn().mockResolvedValue(undefined);
-
 jest.mock("@/lib/achievement-progress-service", () => ({
   AchievementProgressService: jest
     .fn()
@@ -11,8 +8,8 @@ jest.mock("@/lib/achievement-progress-service", () => ({
 const mockSupabase = {
   auth: { getUser: jest.fn() },
   from: jest.fn(),
+  rpc: jest.fn(),
 };
-
 jest.mock("@/lib/supabase-server", () => ({
   createServerSupabaseClient: jest.fn(() => mockSupabase),
   createServiceSupabaseClient: jest.fn(() => mockSupabase),
@@ -126,10 +123,6 @@ function setupMocks(
             eq: jest.fn().mockResolvedValue({ error: null }),
           }),
         };
-      case "transactions":
-        return {
-          insert: jest.fn().mockResolvedValue({ error: null }),
-        };
       default:
         throw new Error(`Unexpected table in boss test: ${table}`);
     }
@@ -139,6 +132,7 @@ function setupMocks(
 describe("Boss completion - achievement progress integration (task 10.1)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSupabase.rpc.mockResolvedValue({ data: [{ ok: true }], error: null });
   });
 
   it("calls updateProgress once per participant with BOSS_COMPLETED", async () => {
@@ -153,10 +147,18 @@ describe("Boss completion - achievement progress integration (task 10.1)", () =>
     const res = await POST(makeRequest(), params());
     expect(res.status).toBe(200);
 
-    // updateProgress should have been called twice (once per participant who has a character)
     expect(mockUpdateProgress).toHaveBeenCalledWith(expect.any(String), {
       type: "BOSS_COMPLETED",
     });
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      "fn_apply_boss_reward",
+      expect.objectContaining({
+        p_character_id: CHAR_ID_1,
+        p_user_id: USER_ID_1,
+        p_boss_battle_id: BOSS_ID,
+        p_participant_id: "part-0",
+      }),
+    );
   });
 
   it("does not fail boss completion when updateProgress throws for one participant", async () => {
@@ -175,7 +177,6 @@ describe("Boss completion - achievement progress integration (task 10.1)", () =>
 
     const res = await POST(makeRequest(), params());
 
-    // Boss completion still succeeds
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -186,6 +187,11 @@ describe("Boss completion - achievement progress integration (task 10.1)", () =>
     mockSupabase.auth.getUser.mockResolvedValue({
       data: { user: { id: "gm-user" } },
       error: null,
+    });
+
+    mockSupabase.rpc.mockResolvedValue({
+      data: null,
+      error: { message: "DB error" },
     });
 
     mockSupabase.from.mockImplementation((table: string) => {
@@ -258,16 +264,11 @@ describe("Boss completion - achievement progress integration (task 10.1)", () =>
                 }),
               }),
             }),
-            // Character reward write fails
             update: jest.fn().mockReturnValue({
               eq: jest
                 .fn()
                 .mockResolvedValue({ error: { message: "DB error" } }),
             }),
-          };
-        case "transactions":
-          return {
-            insert: jest.fn().mockResolvedValue({ error: null }),
           };
         default:
           throw new Error(`Unexpected table in boss test: ${table}`);

--- a/app/api/boss-quests/[id]/complete/route.ts
+++ b/app/api/boss-quests/[id]/complete/route.ts
@@ -11,7 +11,6 @@ import {
 } from "@/lib/supabase-server";
 import {
   applyClassBonusIfApproved,
-  buildCharacterRewardUpdate,
   buildDecisionMap,
   resolveParticipantDecision,
 } from "@/lib/boss-quest-rewards";
@@ -170,23 +169,27 @@ export async function POST(
         }
       }
 
-      if (character) {
-        const characterUpdate = buildCharacterRewardUpdate(character, {
-          gold: appliedDecision.gold,
-          xp: appliedDecision.xp,
-          honor: appliedDecision.honor,
-        });
+      if (character && participantRow?.id) {
+        const { error: rewardError } = await serviceSupabase.rpc(
+          "fn_apply_boss_reward",
+          {
+            p_character_id: character.id,
+            p_user_id: participantId,
+            p_boss_battle_id: bossQuestId,
+            p_participant_id: participantRow.id,
+            p_gold: appliedDecision.gold,
+            p_xp: appliedDecision.xp,
+            p_honor: appliedDecision.honor,
+            p_status: appliedDecision.status,
+            p_actor_user_id: requesterProfile.id,
+          },
+        );
 
-        const { error: characterUpdateError } = await serviceSupabase
-          .from("characters")
-          .update(characterUpdate)
-          .eq("id", character.id);
-
-        if (characterUpdateError) {
+        if (rewardError) {
           console.error(
-            "Failed to update boss quest rewards for character",
+            "Failed to apply canonical boss quest rewards for character",
             character.id,
-            characterUpdateError,
+            rewardError,
           );
           console.warn(
             "Skipping achievement progress update after boss completion because character rewards update failed:",
@@ -208,25 +211,6 @@ export async function POST(
             );
           }
         }
-      }
-
-      const { error: transactionError } = await serviceSupabase
-        .from("transactions")
-        .insert({
-          user_id: participantId,
-          type: "BOSS_VICTORY",
-          xp_change: appliedDecision.xp,
-          gold_change: appliedDecision.gold,
-          honor_change: appliedDecision.honor,
-          description: `Boss quest rewards (${appliedDecision.status})`,
-          related_id: bossQuestId,
-        });
-
-      if (transactionError) {
-        console.error(
-          "Failed to record boss quest transaction",
-          transactionError,
-        );
       }
     }
 

--- a/app/api/characters/[id]/change-class/route.achievement-integration.test.ts
+++ b/app/api/characters/[id]/change-class/route.achievement-integration.test.ts
@@ -19,6 +19,7 @@ const mockServerSupabase = {
 
 const mockServiceSupabase = {
   from: jest.fn(),
+  rpc: jest.fn(),
 };
 
 jest.mock("@/lib/supabase-server", () => ({
@@ -111,6 +112,19 @@ function setupMocks({ historyError = null as object | null } = {}) {
     }
     throw new Error(`Unexpected table in service mock: ${table}`);
   });
+
+  mockServiceSupabase.rpc.mockResolvedValue({
+    data: [
+      {
+        id: VALID_CHARACTER_ID,
+        user_id: USER_ID,
+        class: "KNIGHT",
+        level: 3,
+        gold: 400,
+      },
+    ],
+    error: null,
+  });
 }
 
 describe("class change - achievement progress integration (task 13.1)", () => {
@@ -127,6 +141,25 @@ describe("class change - achievement progress integration (task 13.1)", () => {
     expect(mockUpdateProgress).toHaveBeenCalledWith(VALID_CHARACTER_ID, {
       type: "CLASS_CHANGED",
     });
+  });
+
+  it("uses the canonical class-change RPC instead of mutating character gold directly", async () => {
+    setupMocks();
+
+    const res = await POST(makeRequest(), params());
+
+    expect(res.status).toBe(200);
+    expect(mockServiceSupabase.rpc).toHaveBeenCalledWith(
+      "fn_change_character_class",
+      {
+        p_character_id: VALID_CHARACTER_ID,
+        p_new_class: "KNIGHT",
+      },
+    );
+    expect(mockServiceSupabase.from).not.toHaveBeenCalledWith("characters");
+    expect(mockServiceSupabase.from).not.toHaveBeenCalledWith(
+      "character_change_history",
+    );
   });
 
   it("does not fail class change when updateProgress throws", async () => {
@@ -158,13 +191,14 @@ describe("class change - achievement progress integration (task 13.1)", () => {
     warnSpy.mockRestore();
   });
 
-  it("does not call updateProgress when the history insert fails", async () => {
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-    setupMocks({ historyError: { message: "insert failed" } });
+  it("continues class-change achievement progress after the RPC-owned history write", async () => {
+    setupMocks({ historyError: { message: "unused legacy mock" } });
 
     const res = await POST(makeRequest(), params());
 
     expect(res.status).toBe(200);
-    expect(mockUpdateProgress).not.toHaveBeenCalled();
+    expect(mockUpdateProgress).toHaveBeenCalledWith(VALID_CHARACTER_ID, {
+      type: "CLASS_CHANGED",
+    });
   });
 });

--- a/app/api/characters/[id]/change-class/route.ts
+++ b/app/api/characters/[id]/change-class/route.ts
@@ -11,7 +11,6 @@ import {
 import { ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
 import { assertValidUuidParam } from "@/lib/api-route-params";
 import { AchievementProgressService } from "@/lib/achievement-progress-service";
-import type { CharacterClass } from "@/lib/types/database";
 
 export async function POST(
   request: NextRequest,
@@ -74,49 +73,35 @@ export async function POST(
       );
     }
 
-    const { data: updated, error: updateError } = await serviceSupabase
-      .from("characters")
-      .update({
-        class: newClass as CharacterClass,
-        gold: (character.gold ?? 0) - cost,
-      })
-      .eq("id", characterId)
-      .select()
-      .single();
+    const { data: rpcData, error: updateError } = await serviceSupabase.rpc(
+      "fn_change_character_class",
+      {
+        p_character_id: characterId,
+        p_new_class: newClass,
+      },
+    );
 
-    if (updateError || !updated) {
+    if (updateError) {
+      throw new Error(updateError.message ?? "Failed to update character class");
+    }
+
+    const updated = Array.isArray(rpcData) ? rpcData[0] : rpcData;
+
+    if (!updated) {
       throw new Error("Failed to update character class");
     }
 
-    const { error: historyError } = await serviceSupabase
-      .from("character_change_history")
-      .insert({
-        character_id: characterId,
-        change_type: "class",
-        old_value: character.class,
-        new_value: newClass,
-        gold_cost: cost,
+    try {
+      const progressService = new AchievementProgressService(serviceSupabase);
+      await progressService.updateProgress(characterId, {
+        type: "CLASS_CHANGED",
       });
-
-    if (historyError) {
+    } catch (progressError) {
       console.warn(
-        "Failed to record class change history (non-blocking):",
+        "Achievement progress update failed after class change (non-blocking):",
         characterId,
-        historyError,
+        progressError,
       );
-    } else {
-      try {
-        const progressService = new AchievementProgressService(serviceSupabase);
-        await progressService.updateProgress(characterId, {
-          type: "CLASS_CHANGED",
-        });
-      } catch (progressError) {
-        console.warn(
-          "Achievement progress update failed after class change (non-blocking):",
-          characterId,
-          progressError,
-        );
-      }
     }
 
     return NextResponse.json(

--- a/lib/achievement-progress-service.rollback-compensation.test.ts
+++ b/lib/achievement-progress-service.rollback-compensation.test.ts
@@ -57,10 +57,13 @@ describe("AchievementProgressService - rollback compensation", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    // Fix P1: stats rollback uses direct UPDATE (xp: 100-60=40, gold: 0-0=0)
-    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
+    // Ledgered achievement rewards are forward-truth once the RPC succeeds;
+    // rollback must not create an unledgered direct gold compensation.
+    expect(write.statsUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ gold: expect.any(Number) }),
+    );
   });
-  it("reverts stats and level when cascade upsert fails", async () => {
+  it("preserves stats and level when cascade upsert fails after a ledgered award", async () => {
     const questAch = {
       id: "ach-quest",
       name: "Quest Master",
@@ -138,13 +141,13 @@ describe("AchievementProgressService - rollback compensation", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    // Fix P1: level rollback still uses direct UPDATE with prevLevel=1
-    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 1 });
-    // Fix P1: stats rollback uses direct UPDATE (xp: 100-60=40, gold: 0-0=0)
-    expect(write.statsUpdate).toHaveBeenCalledWith({ xp: 40, gold: 0 });
+    expect(write.statsUpdate).toHaveBeenCalledWith({ level: 2 });
+    expect(write.statsUpdate).not.toHaveBeenCalledWith({ level: 1 });
+    expect(write.statsUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ gold: expect.any(Number) }),
+    );
   });
-
-  it("logs critical error if stats revert UPDATE fails", async () => {
+  it("logs canonical preservation when a failure happens after the award RPC", async () => {
     const write = makeWriteMocks({
       unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
       rpcReturn: LEVEL_UP_RPC_RETURN,
@@ -161,8 +164,7 @@ describe("AchievementProgressService - rollback compensation", () => {
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
     expect(consoleSpy).toHaveBeenCalledWith(
-      "Critical: failed to revert stats after reward failure:",
-      expect.objectContaining({ message: "stats-revert-fail" }),
+      "Critical: achievement reward failure occurred after canonical ledger award; preserving awarded stats and unlock state without unledgered gold compensation",
     );
   });
 
@@ -268,15 +270,13 @@ describe("AchievementProgressService - rollback compensation", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
-    // P2 fix: brand-new cascade rows are deleted, not upserted with null
-    expect(write.upsert).toHaveBeenCalledTimes(2); // no 3rd upsert
-    expect(write.cascadeDelete).toHaveBeenCalled();
-    expect(write.cascadeDeleteIn).toHaveBeenCalledWith("achievement_id", [
-      xpEarnedAch.id,
-    ]);
+    // Ledgered award state is now preserved rather than partially compensated;
+    // cascade progress that already landed stays consistent with the awarded stats.
+    expect(write.upsert).toHaveBeenCalledTimes(2); // no revert upsert
+    expect(write.cascadeDelete).not.toHaveBeenCalled();
   });
 
-  it("detects revert failure when Supabase returns { error } not throw", async () => {
+  it("does not run unlock rollback after a ledgered award", async () => {
     const write = makeWriteMocks({
       unlockedIds: [LEVEL_UP_ACHIEVEMENT.id],
       rpcReturn: LEVEL_UP_RPC_RETURN,
@@ -292,9 +292,9 @@ describe("AchievementProgressService - rollback compensation", () => {
     });
     const svc = new AchievementProgressService(readClient as never);
     await svc.updateProgress(CHAR_ID, { type: "QUEST_APPROVED" });
+    expect(write.inForRevert).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(
-      "Critical: failed to revert unlock after reward failure:",
-      expect.objectContaining({ message: "RLS" }),
+      "Critical: achievement reward failure occurred after canonical ledger award; preserving awarded stats and unlock state without unledgered gold compensation",
     );
   });
 });

--- a/lib/achievement-progress/unlock-rollback.ts
+++ b/lib/achievement-progress/unlock-rollback.ts
@@ -34,53 +34,24 @@ export async function performRollback(
     prevLevel,
     appliedLevel,
     statsApplied,
-    capturedNewStats,
-    totalXp,
-    totalGold,
     lockedIds,
     cascadeRows,
     prevCascadeSnapshot,
   } = state;
 
-  // Revert stats first. If stats revert fails (concurrent write changed xp/gold),
-  // we intentionally keep the rewards AND the level — reverting only the level
-  // would leave the character with high XP/gold at a low level, which is
-  // inconsistent. We also leave unlocked_at set so the achievement cannot be
-  // re-triggered for a duplicate reward payout.
-  let statsReverted = true;
-  if (statsApplied && capturedNewStats) {
-    const { data: revertedRows, error: statsRevertErr } = await writeClient
-      .from("characters")
-      .update({
-        xp: capturedNewStats.xp - totalXp,
-        gold: capturedNewStats.gold - totalGold,
-      })
-      .eq("id", characterId)
-      .eq("xp", capturedNewStats.xp)
-      .eq("gold", capturedNewStats.gold)
-      .select("id");
-    if (statsRevertErr) {
-      statsReverted = false;
-      console.error(
-        "Critical: failed to revert stats after reward failure:",
-        statsRevertErr,
-      );
-    } else if (!revertedRows || revertedRows.length === 0) {
-      // PostgREST returns error: null even when zero rows matched the
-      // conditional UPDATE. A zero-row result means a concurrent write changed
-      // xp or gold, so the compensation was a no-op. Treat this as a failed
-      // rollback to avoid clearing unlocked_at (which would let the same
-      // achievement pay out again).
-      statsReverted = false;
-      console.error(
-        "Critical: stats revert matched zero rows (concurrent update); treating as failed rollback",
-      );
-    }
+  if (statsApplied) {
+    console.error(
+      "Critical: achievement reward failure occurred after canonical ledger award; preserving awarded stats and unlock state without unledgered gold compensation",
+    );
+    return;
   }
 
-  // Only revert level after stats are successfully reverted. If stats rollback
-  // was skipped (concurrent write), the character keeps rewards + level to stay
-  // consistent. The appliedLevel guard prevents clobbering a concurrent advance.
+  // If no canonical stats award has happened, rollback can still clean up
+  // ancillary level/unlock/cascade state without touching character gold.
+  const statsReverted = true;
+
+  // Revert level only on non-award rollback paths. The appliedLevel guard
+  // prevents clobbering a concurrent advance.
   if (
     statsReverted &&
     levelApplied &&

--- a/lib/profile-service-class.test.ts
+++ b/lib/profile-service-class.test.ts
@@ -5,6 +5,7 @@ jest.mock("./supabase", () => ({
     rpc: jest.fn(),
     auth: {
       updateUser: jest.fn(),
+      getSession: jest.fn(),
     },
   },
 }));
@@ -12,10 +13,17 @@ jest.mock("./supabase", () => ({
 import { supabase } from "./supabase";
 
 const mockFrom = supabase.from as jest.Mock;
+const mockRpc = supabase.rpc as jest.Mock;
+const mockGetSession = supabase.auth.getSession as jest.Mock;
+
+global.fetch = jest.fn();
 
 describe("ProfileService - class changes and history", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: "test-token" } },
+    });
   });
 
   describe("canChangeClass", () => {
@@ -38,25 +46,31 @@ describe("ProfileService - class changes and history", () => {
 
     it("should successfully change class", async () => {
       const updatedCharacter = { ...characterData, class: "MAGE" };
-      const mockRpc = supabase.rpc as jest.Mock;
-      mockRpc.mockResolvedValue({ data: [updatedCharacter], error: null });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, character: updatedCharacter }),
+      });
 
       const result = await ProfileService.changeCharacterClass(
         "char-1",
         "MAGE",
       );
       expect(result.class).toBe("MAGE");
-      expect(mockRpc).toHaveBeenCalledWith("fn_change_character_class", {
-        p_character_id: "char-1",
-        p_new_class: "MAGE",
+      expect(global.fetch).toHaveBeenCalledWith("/api/characters/char-1/change-class", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ newClass: "MAGE" }),
       });
+      expect(mockRpc).not.toHaveBeenCalled();
     });
 
     it("should throw on database error", async () => {
-      const mockRpc = supabase.rpc as jest.Mock;
-      mockRpc.mockResolvedValue({
-        data: null,
-        error: { message: "Insufficient gold. Need 250, have 100" },
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: "Insufficient gold. Need 250, have 100" }),
       });
       await expect(
         ProfileService.changeCharacterClass("char-1", "MAGE"),
@@ -64,19 +78,32 @@ describe("ProfileService - class changes and history", () => {
     });
 
     it("should throw when no data returned", async () => {
-      const mockRpc = supabase.rpc as jest.Mock;
-      mockRpc.mockResolvedValue({ data: [], error: null });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
       await expect(
         ProfileService.changeCharacterClass("char-1", "MAGE"),
       ).rejects.toThrow("Failed to retrieve updated character");
     });
 
+    it("should throw when no authenticated session is available", async () => {
+      mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+      await expect(
+        ProfileService.changeCharacterClass("char-1", "MAGE"),
+      ).rejects.toThrow("Authentication required");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it("should not bypass the canonical class-change RPC with direct character updates", async () => {
       const updatedCharacter = { ...characterData, class: "MAGE" };
-      const mockRpc = supabase.rpc as jest.Mock;
-      mockRpc.mockResolvedValue({ data: [updatedCharacter], error: null });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, character: updatedCharacter }),
+      });
       await ProfileService.changeCharacterClass("char-1", "MAGE");
       expect(mockFrom).not.toHaveBeenCalledWith("characters");
+      expect(mockRpc).not.toHaveBeenCalledWith("fn_change_character_class", expect.anything());
     });
   });
 

--- a/lib/profile-service-class.test.ts
+++ b/lib/profile-service-class.test.ts
@@ -38,38 +38,25 @@ describe("ProfileService - class changes and history", () => {
 
     it("should successfully change class", async () => {
       const updatedCharacter = { ...characterData, class: "MAGE" };
-      mockFrom.mockReturnValue({
-        update: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            select: jest.fn().mockReturnValue({
-              single: jest.fn().mockResolvedValue({
-                data: updatedCharacter,
-                error: null,
-              }),
-            }),
-          }),
-        }),
-      });
+      const mockRpc = supabase.rpc as jest.Mock;
+      mockRpc.mockResolvedValue({ data: [updatedCharacter], error: null });
+
       const result = await ProfileService.changeCharacterClass(
         "char-1",
         "MAGE",
       );
       expect(result.class).toBe("MAGE");
-      expect(mockFrom).toHaveBeenCalledWith("characters");
+      expect(mockRpc).toHaveBeenCalledWith("fn_change_character_class", {
+        p_character_id: "char-1",
+        p_new_class: "MAGE",
+      });
     });
 
     it("should throw on database error", async () => {
-      mockFrom.mockReturnValue({
-        update: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            select: jest.fn().mockReturnValue({
-              single: jest.fn().mockResolvedValue({
-                data: null,
-                error: { message: "Insufficient gold. Need 250, have 100" },
-              }),
-            }),
-          }),
-        }),
+      const mockRpc = supabase.rpc as jest.Mock;
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: "Insufficient gold. Need 250, have 100" },
       });
       await expect(
         ProfileService.changeCharacterClass("char-1", "MAGE"),
@@ -77,39 +64,19 @@ describe("ProfileService - class changes and history", () => {
     });
 
     it("should throw when no data returned", async () => {
-      mockFrom.mockReturnValue({
-        update: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            select: jest.fn().mockReturnValue({
-              single: jest.fn().mockResolvedValue({
-                data: null,
-                error: null,
-              }),
-            }),
-          }),
-        }),
-      });
+      const mockRpc = supabase.rpc as jest.Mock;
+      mockRpc.mockResolvedValue({ data: [], error: null });
       await expect(
         ProfileService.changeCharacterClass("char-1", "MAGE"),
       ).rejects.toThrow("Failed to retrieve updated character");
     });
 
-    it("should call from with characters table", async () => {
+    it("should not bypass the canonical class-change RPC with direct character updates", async () => {
       const updatedCharacter = { ...characterData, class: "MAGE" };
-      mockFrom.mockReturnValue({
-        update: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            select: jest.fn().mockReturnValue({
-              single: jest.fn().mockResolvedValue({
-                data: updatedCharacter,
-                error: null,
-              }),
-            }),
-          }),
-        }),
-      });
+      const mockRpc = supabase.rpc as jest.Mock;
+      mockRpc.mockResolvedValue({ data: [updatedCharacter], error: null });
       await ProfileService.changeCharacterClass("char-1", "MAGE");
-      expect(mockFrom).toHaveBeenCalledWith("characters");
+      expect(mockFrom).not.toHaveBeenCalledWith("characters");
     });
   });
 

--- a/lib/profile-service.ts
+++ b/lib/profile-service.ts
@@ -23,6 +23,17 @@ export interface ClassChangeCost {
 }
 
 export class ProfileService {
+  private static async getAuthToken(): Promise<string | null> {
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      return session?.access_token || null;
+    } catch {
+      return null;
+    }
+  }
+
   /**
    * Calculate cost to change class based on character level
    * Tiered pricing: 100 (≤5), 250 (≤10), 500 (≤15), 1000 (≤20), 2000 (>20)
@@ -163,16 +174,27 @@ export class ProfileService {
     characterId: string,
     newClass: string,
   ): Promise<Character> {
-    const { data, error } = await supabase.rpc("fn_change_character_class", {
-      p_character_id: characterId,
-      p_new_class: newClass,
-    });
-
-    if (error) {
-      throw new Error(error.message);
+    const token = await this.getAuthToken();
+    if (!token) {
+      throw new Error("Authentication required");
     }
 
-    const updatedCharacter = Array.isArray(data) ? data[0] : data;
+    const response = await fetch(`/api/characters/${encodeURIComponent(characterId)}/change-class`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ newClass }),
+    });
+
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      throw new Error(data.error || "Failed to update character class");
+    }
+
+    const updatedCharacter = data.character;
 
     if (!updatedCharacter) {
       throw new Error("Failed to retrieve updated character");

--- a/lib/profile-service.ts
+++ b/lib/profile-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { supabase } from "@/lib/supabase";
-import { Character, CharacterClass } from "@/lib/types/database";
+import { Character } from "@/lib/types/database";
 
 export interface ChangeHistoryEntry {
   id: string;
@@ -163,27 +163,22 @@ export class ProfileService {
     characterId: string,
     newClass: string,
   ): Promise<Character> {
-    // TODO: Use RPC function to ensure atomic transaction when fn_change_character_class exists
-    // All database operations (character update, transaction insert, history insert)
-    // succeed together or fail together - no partial updates possible
-
-    // For now, update character class directly
-    const { data, error } = await supabase
-      .from("characters")
-      .update({ class: newClass as CharacterClass })
-      .eq("id", characterId)
-      .select()
-      .single();
+    const { data, error } = await supabase.rpc("fn_change_character_class", {
+      p_character_id: characterId,
+      p_new_class: newClass,
+    });
 
     if (error) {
       throw new Error(error.message);
     }
 
-    if (!data) {
+    const updatedCharacter = Array.isArray(data) ? data[0] : data;
+
+    if (!updatedCharacter) {
       throw new Error("Failed to retrieve updated character");
     }
 
-    return data as Character;
+    return updatedCharacter as Character;
   }
 
   /**

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -1352,7 +1352,7 @@ export type Database = {
         Args: {
           p_character_id: string;
           p_new_gold: number;
-          p_actor_user_id: string;
+          p_actor_user_id?: string | null;
           p_reason: string;
         };
         Returns: Database["public"]["Tables"]["gold_ledger_entries"]["Row"];

--- a/lib/types/database-generated.ts
+++ b/lib/types/database-generated.ts
@@ -562,6 +562,54 @@ export type Database = {
           },
         ];
       };
+      gold_ledger_entries: {
+        Row: {
+          id: string;
+          created_at: string;
+          character_id: string;
+          user_id: string;
+          gold_delta: number;
+          balance_before: number;
+          balance_after: number;
+          entry_type: Database["public"]["Enums"]["gold_ledger_entry_type"];
+          source_type: string;
+          source_id: string | null;
+          actor_user_id: string | null;
+          reason: string | null;
+          metadata: Json;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          character_id: string;
+          user_id: string;
+          gold_delta: number;
+          balance_before: number;
+          balance_after: number;
+          entry_type: Database["public"]["Enums"]["gold_ledger_entry_type"];
+          source_type: string;
+          source_id?: string | null;
+          actor_user_id?: string | null;
+          reason?: string | null;
+          metadata?: Json;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          character_id?: string;
+          user_id?: string;
+          gold_delta?: number;
+          balance_before?: number;
+          balance_after?: number;
+          entry_type?: Database["public"]["Enums"]["gold_ledger_entry_type"];
+          source_type?: string;
+          source_id?: string | null;
+          actor_user_id?: string | null;
+          reason?: string | null;
+          metadata?: Json;
+        };
+        Relationships: [];
+      };
       characters: {
         Row: {
           active_family_quest_id: string | null;
@@ -1281,22 +1329,37 @@ export type Database = {
           level: number | null;
         }[];
       };
+      fn_apply_boss_reward: {
+        Args: {
+          p_character_id: string;
+          p_user_id: string;
+          p_boss_battle_id: string;
+          p_participant_id: string;
+          p_gold: number;
+          p_xp: number;
+          p_honor: number;
+          p_status: string;
+          p_actor_user_id?: string | null;
+        };
+        Returns: {
+          xp: number;
+          gold: number;
+          honor_points: number;
+          level: number;
+        }[];
+      };
+      fn_record_admin_gold_adjustment: {
+        Args: {
+          p_character_id: string;
+          p_new_gold: number;
+          p_actor_user_id: string;
+          p_reason: string;
+        };
+        Returns: Database["public"]["Tables"]["gold_ledger_entries"]["Row"];
+      };
       fn_change_character_class: {
         Args: { p_character_id: string; p_new_class: string };
-        Returns: {
-          id: string;
-          user_id: string;
-          name: string;
-          class: string;
-          level: number;
-          gold: number;
-          experience: number;
-          health: number;
-          max_health: number;
-          last_class_change_at: string;
-          created_at: string;
-          updated_at: string;
-        }[];
+        Returns: Database["public"]["Tables"]["characters"]["Row"][];
       };
     };
     Enums: {
@@ -1316,6 +1379,17 @@ export type Database = {
       quest_type: "INDIVIDUAL" | "FAMILY";
       recurrence_pattern: "DAILY" | "WEEKLY" | "CUSTOM";
       reward_type: "SCREEN_TIME" | "PRIVILEGE" | "PURCHASE" | "EXPERIENCE";
+      gold_ledger_entry_type:
+        | "QUEST_REWARD"
+        | "STORE_PURCHASE"
+        | "REWARD_REFUND"
+        | "BOSS_REWARD"
+        | "ACHIEVEMENT_BONUS"
+        | "ADMIN_ADJUSTMENT"
+        | "CLASS_CHANGE_COST"
+        | "OPENING_BALANCE"
+        | "MIGRATION"
+        | "CORRECTION";
       transaction_type:
         | "QUEST_REWARD"
         | "BOSS_VICTORY"

--- a/scripts/admin-set-gold.ts
+++ b/scripts/admin-set-gold.ts
@@ -62,38 +62,23 @@ async function setGold(userName: string, newAmount: number, reason: string) {
     return;
   }
 
-  // 3. Update Gold
-  const { error: updateError } = await supabase
-    .from('characters')
-    .update({ gold: newAmount })
-    .eq('id', character.id);
+  // 3. Update Gold and record canonical ledger entry in one RPC
+  const { error: adjustmentError } = await supabase.rpc(
+    'fn_record_admin_gold_adjustment',
+    {
+      p_character_id: character.id,
+      p_new_gold: newAmount,
+      p_actor_user_id: user.id,
+      p_reason: reason,
+    },
+  );
 
-  if (updateError) {
-    console.error('Failed to update gold:', updateError.message);
+  if (adjustmentError) {
+    console.error('Failed to update gold:', adjustmentError.message);
     process.exit(1);
   }
 
-  console.log('✅ Gold updated successfully.');
-
-  // 4. Log Transaction
-  // We try to log this to the transactions table for audit purposes
-  const { error: txError } = await supabase
-    .from('transactions')
-    .insert({
-      user_id: user.id,
-      type: 'BONUS_AWARD', // Closest fit for admin adjustment
-      description: `Admin Adjustment: ${reason}`,
-      gold_change: diff,
-      xp_change: 0,
-      gems_change: 0,
-      honor_change: 0
-    });
-
-  if (txError) {
-    console.error('⚠️ Gold updated, but failed to create transaction log:', txError.message);
-  } else {
-    console.log('✅ Transaction log created.');
-  }
+  console.log('✅ Gold updated and canonical ledger entry created.');
 }
 
 // Read args

--- a/scripts/admin-set-gold.ts
+++ b/scripts/admin-set-gold.ts
@@ -68,7 +68,7 @@ async function setGold(userName: string, newAmount: number, reason: string) {
     {
       p_character_id: character.id,
       p_new_gold: newAmount,
-      p_actor_user_id: user.id,
+      p_actor_user_id: null,
       p_reason: reason,
     },
   );

--- a/supabase/migrations/20260621000001_canonical_gold_ledger.sql
+++ b/supabase/migrations/20260621000001_canonical_gold_ledger.sql
@@ -1,0 +1,557 @@
+-- Canonical gold ledger foundation (#237).
+--
+-- Policy: honest forward truth. Entries in gold_ledger_entries are canonical
+-- for gold mutations after this migration. Pre-ledger state may be represented
+-- by explicit OPENING_BALANCE, MIGRATION, or CORRECTION entries; this migration
+-- intentionally does not claim full historical reconstruction.
+
+DO $$
+BEGIN
+  CREATE TYPE gold_ledger_entry_type AS ENUM (
+    'QUEST_REWARD',
+    'STORE_PURCHASE',
+    'REWARD_REFUND',
+    'BOSS_REWARD',
+    'ACHIEVEMENT_BONUS',
+    'ADMIN_ADJUSTMENT',
+    'CLASS_CHANGE_COST',
+    'OPENING_BALANCE',
+    'MIGRATION',
+    'CORRECTION'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS gold_ledger_entries (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  character_id UUID NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES user_profiles(id) ON DELETE CASCADE,
+  gold_delta INTEGER NOT NULL,
+  balance_before INTEGER NOT NULL,
+  balance_after INTEGER NOT NULL,
+  entry_type gold_ledger_entry_type NOT NULL,
+  source_type TEXT NOT NULL,
+  source_id UUID,
+  actor_user_id UUID REFERENCES user_profiles(id),
+  reason TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  CHECK (balance_after = balance_before + gold_delta),
+  CHECK (source_type <> '')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gold_ledger_source
+  -- UNIQUE (source_type, source_id) when source_id is present; NULL source_id entries remain usable for correction/migration batches.
+  ON gold_ledger_entries(source_type, source_id)
+  WHERE source_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_gold_ledger_character_created
+  ON gold_ledger_entries(character_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gold_ledger_user_created
+  ON gold_ledger_entries(user_id, created_at DESC);
+
+ALTER TABLE gold_ledger_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own gold ledger entries"
+  ON gold_ledger_entries
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Guild Masters can view family gold ledger entries"
+  ON gold_ledger_entries
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM user_profiles viewer
+      JOIN user_profiles target ON target.family_id = viewer.family_id
+      WHERE viewer.id = auth.uid()
+        AND viewer.role = 'GUILD_MASTER'
+        AND target.id = gold_ledger_entries.user_id
+    )
+  );
+
+CREATE OR REPLACE FUNCTION fn_insert_gold_ledger_entry(
+  p_character_id UUID,
+  p_user_id UUID,
+  p_gold_delta INTEGER,
+  p_entry_type gold_ledger_entry_type,
+  p_source_type TEXT,
+  p_source_id UUID DEFAULT NULL,
+  p_actor_user_id UUID DEFAULT NULL,
+  p_reason TEXT DEFAULT NULL,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS gold_ledger_entries AS $$
+DECLARE
+  v_balance_after INTEGER;
+  v_entry gold_ledger_entries%ROWTYPE;
+BEGIN
+  SELECT COALESCE(gold, 0)
+  INTO v_balance_after
+  FROM characters
+  WHERE id = p_character_id
+    AND user_id = p_user_id
+  FOR UPDATE;
+
+  IF v_balance_after IS NULL THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO gold_ledger_entries (
+    character_id,
+    user_id,
+    gold_delta,
+    balance_before,
+    balance_after,
+    entry_type,
+    source_type,
+    source_id,
+    actor_user_id,
+    reason,
+    metadata
+  ) VALUES (
+    p_character_id,
+    p_user_id,
+    COALESCE(p_gold_delta, 0),
+    v_balance_after - COALESCE(p_gold_delta, 0),
+    v_balance_after,
+    p_entry_type,
+    p_source_type,
+    p_source_id,
+    p_actor_user_id,
+    p_reason,
+    COALESCE(p_metadata, '{}'::jsonb)
+  )
+  RETURNING * INTO v_entry;
+
+  RETURN v_entry;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+REVOKE ALL ON FUNCTION fn_insert_gold_ledger_entry(UUID, UUID, INTEGER, gold_ledger_entry_type, TEXT, UUID, UUID, TEXT, JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fn_insert_gold_ledger_entry(UUID, UUID, INTEGER, gold_ledger_entry_type, TEXT, UUID, UUID, TEXT, JSONB) TO service_role;
+
+CREATE OR REPLACE FUNCTION fn_apply_quest_reward(
+  p_character_id UUID,
+  p_quest_id UUID,
+  p_user_id UUID,
+  p_xp INTEGER,
+  p_gold INTEGER
+)
+RETURNS TABLE (xp INTEGER, gold INTEGER, level INTEGER) AS $$
+DECLARE
+  v_updated RECORD;
+BEGIN
+  UPDATE characters
+  SET
+    xp = COALESCE(characters.xp, 0) + COALESCE(p_xp, 0),
+    gold = COALESCE(characters.gold, 0) + COALESCE(p_gold, 0),
+    level = GREATEST(
+      COALESCE(characters.level, 1),
+      FLOOR(SQRT(GREATEST(COALESCE(characters.xp, 0) + COALESCE(p_xp, 0), 0)::NUMERIC / 50))::INTEGER + 1
+    ),
+    active_family_quest_id = NULL
+  WHERE id = p_character_id
+    AND user_id = p_user_id
+  RETURNING characters.xp, characters.gold, characters.level
+  INTO v_updated;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO transactions (user_id, type, xp_change, gold_change, related_id, description)
+  VALUES (p_user_id, 'QUEST_REWARD'::transaction_type, COALESCE(p_xp, 0), COALESCE(p_gold, 0), p_quest_id, 'Quest reward approved');
+
+  PERFORM fn_insert_gold_ledger_entry(
+    p_character_id, p_user_id, COALESCE(p_gold, 0), 'QUEST_REWARD',
+    'quest_instances', p_quest_id, NULL, 'Quest reward approved',
+    jsonb_build_object('xp_delta', COALESCE(p_xp, 0))
+  );
+
+  RETURN QUERY SELECT v_updated.xp, v_updated.gold, v_updated.level;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_redeem_reward(
+  p_user_id UUID,
+  p_reward_id UUID
+)
+RETURNS SETOF reward_redemptions AS $$
+DECLARE
+  v_reward rewards%ROWTYPE;
+  v_character_id UUID;
+  v_redemption reward_redemptions%ROWTYPE;
+BEGIN
+  SELECT r.* INTO v_reward
+  FROM rewards r
+  JOIN user_profiles up ON up.family_id = r.family_id
+  WHERE r.id = p_reward_id
+    AND up.id = p_user_id
+    AND r.is_active IS TRUE
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REWARD_NOT_FOUND_OR_INACTIVE';
+  END IF;
+
+  UPDATE characters
+  SET gold = COALESCE(characters.gold, 0) - COALESCE(v_reward.cost, 0)
+  WHERE id = (
+    SELECT c.id FROM characters c WHERE c.user_id = p_user_id ORDER BY c.created_at ASC LIMIT 1
+  )
+    AND COALESCE(characters.gold, 0) >= COALESCE(v_reward.cost, 0)
+  RETURNING id INTO v_character_id;
+
+  IF v_character_id IS NULL THEN
+    IF EXISTS (SELECT 1 FROM characters WHERE user_id = p_user_id) THEN
+      RAISE EXCEPTION 'INSUFFICIENT_GOLD';
+    END IF;
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO reward_redemptions (user_id, reward_id, cost, reward_name, reward_description, reward_type, status, notes)
+  VALUES (p_user_id, p_reward_id, v_reward.cost, v_reward.name, v_reward.description, v_reward.type, 'PENDING', NULL)
+  RETURNING * INTO v_redemption;
+
+  INSERT INTO transactions (user_id, type, gold_change, related_id, description)
+  VALUES (p_user_id, 'STORE_PURCHASE'::transaction_type, -COALESCE(v_reward.cost, 0), v_redemption.id, 'Reward redeemed: ' || v_reward.name);
+
+  PERFORM fn_insert_gold_ledger_entry(
+    v_character_id, p_user_id, -COALESCE(v_reward.cost, 0), 'STORE_PURCHASE',
+    'reward_redemptions', v_redemption.id, p_user_id, 'Reward redeemed: ' || v_reward.name,
+    jsonb_build_object('reward_id', p_reward_id, 'cost', COALESCE(v_reward.cost, 0))
+  );
+
+  RETURN NEXT v_redemption;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_refund_reward_gold(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_redemption_id UUID DEFAULT NULL
+)
+RETURNS VOID AS $$
+DECLARE
+  v_character_id UUID;
+BEGIN
+  UPDATE characters
+  SET gold = COALESCE(gold, 0) + COALESCE(p_amount, 0)
+  WHERE id = (
+    SELECT c.id FROM characters c WHERE c.user_id = p_user_id ORDER BY c.created_at ASC LIMIT 1
+  )
+  RETURNING id INTO v_character_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO transactions (user_id, type, gold_change, related_id, description)
+  VALUES (p_user_id, 'REWARD_REFUND'::transaction_type, COALESCE(p_amount, 0), p_redemption_id, 'Reward redemption refunded');
+
+  PERFORM fn_insert_gold_ledger_entry(
+    v_character_id, p_user_id, COALESCE(p_amount, 0), 'REWARD_REFUND',
+    'reward_redemptions', p_redemption_id, NULL, 'Reward redemption refunded', '{}'::jsonb
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_deny_reward_redemption(
+  p_redemption_id UUID,
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_denied_by UUID DEFAULT NULL
+)
+RETURNS SETOF reward_redemptions AS $$
+DECLARE
+  v_redemption reward_redemptions%ROWTYPE;
+BEGIN
+  UPDATE reward_redemptions
+  SET status = 'DENIED', approved_by = p_denied_by
+  WHERE id = p_redemption_id
+    AND user_id = p_user_id
+    AND status = 'PENDING'
+  RETURNING * INTO v_redemption;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REDEMPTION_NOT_PENDING';
+  END IF;
+
+  PERFORM fn_refund_reward_gold(p_user_id, p_amount, p_redemption_id);
+
+  RETURN NEXT v_redemption;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_apply_boss_reward(
+  p_character_id UUID,
+  p_user_id UUID,
+  p_boss_battle_id UUID,
+  p_participant_id UUID,
+  p_gold INTEGER,
+  p_xp INTEGER,
+  p_honor INTEGER,
+  p_status TEXT,
+  p_actor_user_id UUID DEFAULT NULL
+)
+RETURNS TABLE (xp INTEGER, gold INTEGER, honor_points INTEGER, level INTEGER) AS $$
+DECLARE
+  v_updated RECORD;
+BEGIN
+  UPDATE characters
+  SET
+    xp = COALESCE(characters.xp, 0) + COALESCE(p_xp, 0),
+    gold = COALESCE(characters.gold, 0) + COALESCE(p_gold, 0),
+    honor_points = COALESCE(characters.honor_points, 0) + COALESCE(p_honor, 0),
+    level = GREATEST(
+      COALESCE(characters.level, 1),
+      FLOOR(SQRT(GREATEST(COALESCE(characters.xp, 0) + COALESCE(p_xp, 0), 0)::NUMERIC / 50))::INTEGER + 1
+    )
+  WHERE id = p_character_id
+    AND user_id = p_user_id
+  RETURNING characters.xp, characters.gold, characters.honor_points, characters.level
+  INTO v_updated;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  INSERT INTO transactions (user_id, type, xp_change, gold_change, honor_change, related_id, description)
+  VALUES (p_user_id, 'BOSS_VICTORY'::transaction_type, COALESCE(p_xp, 0), COALESCE(p_gold, 0), COALESCE(p_honor, 0), p_boss_battle_id, 'Boss quest rewards (' || p_status || ')');
+
+  PERFORM fn_insert_gold_ledger_entry(
+    p_character_id, p_user_id, COALESCE(p_gold, 0), 'BOSS_REWARD',
+    'boss_battle_participants', p_participant_id, p_actor_user_id, 'Boss quest rewards (' || p_status || ')',
+    jsonb_build_object('boss_battle_id', p_boss_battle_id, 'xp_delta', COALESCE(p_xp, 0), 'honor_delta', COALESCE(p_honor, 0), 'status', p_status)
+  );
+
+  RETURN QUERY SELECT v_updated.xp, v_updated.gold, v_updated.honor_points, v_updated.level;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_unlock_achievements_and_grant_rewards(
+  p_character_id UUID,
+  p_achievement_ids UUID[],
+  p_season_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  unlocked_achievement_ids UUID[],
+  awarded_xp INTEGER,
+  awarded_gold INTEGER,
+  xp INTEGER,
+  gold INTEGER,
+  level INTEGER
+) AS $$
+DECLARE
+  v_user_id UUID;
+  v_unlocked_ids UUID[];
+  v_awarded_xp INTEGER;
+  v_awarded_gold INTEGER;
+  v_stats RECORD;
+BEGIN
+  SELECT user_id INTO v_user_id FROM characters WHERE id = p_character_id FOR UPDATE;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  WITH unlocked AS (
+    UPDATE character_achievements
+    SET unlocked_at = NOW()
+    WHERE character_id = p_character_id
+      AND achievement_id = ANY(p_achievement_ids)
+      AND unlocked_at IS NULL
+      AND season_id IS NOT DISTINCT FROM p_season_id
+    RETURNING achievement_id
+  )
+  SELECT
+    COALESCE(array_agg(u.achievement_id ORDER BY u.achievement_id), ARRAY[]::UUID[]),
+    COALESCE(SUM(a.xp_reward), 0)::INTEGER,
+    COALESCE(SUM(a.gold_reward), 0)::INTEGER
+  INTO v_unlocked_ids, v_awarded_xp, v_awarded_gold
+  FROM unlocked u
+  JOIN achievements a ON a.id = u.achievement_id;
+
+  UPDATE characters
+  SET xp = COALESCE(characters.xp, 0) + COALESCE(v_awarded_xp, 0),
+      gold = COALESCE(characters.gold, 0) + COALESCE(v_awarded_gold, 0)
+  WHERE characters.id = p_character_id
+    AND array_length(v_unlocked_ids, 1) IS NOT NULL
+  RETURNING characters.xp, characters.gold, characters.level
+  INTO v_stats;
+
+  IF array_length(v_unlocked_ids, 1) IS NOT NULL THEN
+    PERFORM fn_insert_gold_ledger_entry(
+      p_character_id, v_user_id, COALESCE(v_awarded_gold, 0), 'ACHIEVEMENT_BONUS',
+      'character_achievements', NULL, NULL, 'Achievement bonus',
+      jsonb_build_object('achievement_ids', v_unlocked_ids, 'xp_delta', COALESCE(v_awarded_xp, 0), 'season_id', p_season_id)
+    );
+  END IF;
+
+  RETURN QUERY SELECT COALESCE(v_unlocked_ids, ARRAY[]::UUID[]), COALESCE(v_awarded_xp, 0), COALESCE(v_awarded_gold, 0), v_stats.xp, v_stats.gold, v_stats.level;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_change_character_class(
+  p_character_id UUID,
+  p_new_class TEXT
+)
+RETURNS SETOF characters AS $$
+DECLARE
+  v_character characters%ROWTYPE;
+  v_updated characters%ROWTYPE;
+  v_cost INTEGER;
+BEGIN
+  SELECT * INTO v_character FROM characters WHERE id = p_character_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Character not found';
+  END IF;
+
+  IF v_character.last_class_change_at IS NOT NULL
+     AND (NOW() - v_character.last_class_change_at) < INTERVAL '7 days' THEN
+    RAISE EXCEPTION 'Class change is on cooldown. Please try again in 7 days';
+  END IF;
+
+  v_cost := CASE
+    WHEN COALESCE(v_character.level, 1) <= 5 THEN 100
+    WHEN COALESCE(v_character.level, 1) <= 10 THEN 250
+    WHEN COALESCE(v_character.level, 1) <= 15 THEN 500
+    WHEN COALESCE(v_character.level, 1) <= 20 THEN 1000
+    ELSE 2000
+  END;
+
+  IF COALESCE(v_character.gold, 0) < v_cost THEN
+    RAISE EXCEPTION 'Insufficient gold. Need %, have %', v_cost, COALESCE(v_character.gold, 0);
+  END IF;
+
+  UPDATE characters
+  SET class = p_new_class::character_class,
+      gold = COALESCE(gold, 0) - v_cost,
+      last_class_change_at = NOW(),
+      updated_at = NOW()
+  WHERE id = p_character_id
+  RETURNING * INTO v_updated;
+
+  INSERT INTO character_change_history (character_id, change_type, old_value, new_value, gold_cost, created_at)
+  VALUES (p_character_id, 'class', v_character.class::TEXT, p_new_class, v_cost, NOW());
+
+  PERFORM fn_insert_gold_ledger_entry(
+    p_character_id, v_character.user_id, -v_cost, 'CLASS_CHANGE_COST',
+    'character_change_history', NULL, v_character.user_id, FORMAT('Class change from %s to %s', v_character.class, p_new_class),
+    jsonb_build_object('old_class', v_character.class, 'new_class', p_new_class, 'cost', v_cost)
+  );
+
+  RETURN NEXT v_updated;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_record_admin_gold_adjustment(
+  p_character_id UUID,
+  p_new_gold INTEGER,
+  p_actor_user_id UUID,
+  p_reason TEXT
+)
+RETURNS gold_ledger_entries AS $$
+DECLARE
+  v_character characters%ROWTYPE;
+  v_delta INTEGER;
+  v_entry gold_ledger_entries%ROWTYPE;
+BEGIN
+  SELECT * INTO v_character FROM characters WHERE id = p_character_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CHARACTER_NOT_FOUND';
+  END IF;
+
+  v_delta := COALESCE(p_new_gold, 0) - COALESCE(v_character.gold, 0);
+
+  UPDATE characters SET gold = COALESCE(p_new_gold, 0), updated_at = NOW() WHERE id = p_character_id;
+
+  INSERT INTO transactions (user_id, type, description, gold_change, xp_change, gems_change, honor_change)
+  VALUES (v_character.user_id, 'BONUS_AWARD'::transaction_type, 'Admin Adjustment: ' || COALESCE(p_reason, ''), v_delta, 0, 0, 0);
+
+  SELECT * INTO v_entry FROM fn_insert_gold_ledger_entry(
+    p_character_id, v_character.user_id, v_delta, 'ADMIN_ADJUSTMENT',
+    'admin_gold_adjustment', NULL, p_actor_user_id, p_reason,
+    jsonb_build_object('old_gold', COALESCE(v_character.gold, 0), 'new_gold', COALESCE(p_new_gold, 0))
+  );
+  RETURN v_entry;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_record_opening_gold_balance(
+  p_character_id UUID,
+  p_actor_user_id UUID,
+  p_reason TEXT DEFAULT 'Opening gold balance'
+)
+RETURNS gold_ledger_entries AS $$
+DECLARE
+  v_character characters%ROWTYPE;
+  v_entry gold_ledger_entries%ROWTYPE;
+BEGIN
+  SELECT * INTO v_character FROM characters WHERE id = p_character_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CHARACTER_NOT_FOUND'; END IF;
+  SELECT * INTO v_entry FROM fn_insert_gold_ledger_entry(
+    p_character_id, v_character.user_id, COALESCE(v_character.gold, 0), 'OPENING_BALANCE',
+    'opening_balance', p_character_id, p_actor_user_id, p_reason, '{}'::jsonb
+  );
+  RETURN v_entry;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_record_gold_migration_entry(
+  p_character_id UUID,
+  p_gold_delta INTEGER,
+  p_actor_user_id UUID,
+  p_reason TEXT,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS gold_ledger_entries AS $$
+DECLARE
+  v_character characters%ROWTYPE;
+  v_entry gold_ledger_entries%ROWTYPE;
+BEGIN
+  SELECT * INTO v_character FROM characters WHERE id = p_character_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CHARACTER_NOT_FOUND'; END IF;
+  UPDATE characters SET gold = COALESCE(gold, 0) + COALESCE(p_gold_delta, 0), updated_at = NOW() WHERE id = p_character_id;
+  SELECT * INTO v_entry FROM fn_insert_gold_ledger_entry(
+    p_character_id, v_character.user_id, COALESCE(p_gold_delta, 0), 'MIGRATION',
+    'gold_migration', NULL, p_actor_user_id, p_reason, COALESCE(p_metadata, '{}'::jsonb)
+  );
+  RETURN v_entry;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION fn_record_gold_correction_entry(
+  p_character_id UUID,
+  p_gold_delta INTEGER,
+  p_actor_user_id UUID,
+  p_reason TEXT,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS gold_ledger_entries AS $$
+DECLARE
+  v_character characters%ROWTYPE;
+  v_entry gold_ledger_entries%ROWTYPE;
+BEGIN
+  SELECT * INTO v_character FROM characters WHERE id = p_character_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CHARACTER_NOT_FOUND'; END IF;
+  UPDATE characters SET gold = COALESCE(gold, 0) + COALESCE(p_gold_delta, 0), updated_at = NOW() WHERE id = p_character_id;
+  SELECT * INTO v_entry FROM fn_insert_gold_ledger_entry(
+    p_character_id, v_character.user_id, COALESCE(p_gold_delta, 0), 'CORRECTION',
+    'gold_correction', NULL, p_actor_user_id, p_reason, COALESCE(p_metadata, '{}'::jsonb)
+  );
+  RETURN v_entry;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION fn_apply_quest_reward(UUID, UUID, UUID, INTEGER, INTEGER) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_redeem_reward(UUID, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_refund_reward_gold(UUID, INTEGER, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_deny_reward_redemption(UUID, UUID, INTEGER, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_apply_boss_reward(UUID, UUID, UUID, UUID, INTEGER, INTEGER, INTEGER, TEXT, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_unlock_achievements_and_grant_rewards(UUID, UUID[], UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION fn_record_admin_gold_adjustment(UUID, INTEGER, UUID, TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_record_opening_gold_balance(UUID, UUID, TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_record_gold_migration_entry(UUID, INTEGER, UUID, TEXT, JSONB) TO service_role;
+GRANT EXECUTE ON FUNCTION fn_record_gold_correction_entry(UUID, INTEGER, UUID, TEXT, JSONB) TO service_role;

--- a/supabase/migrations/20260621000001_canonical_gold_ledger.sql
+++ b/supabase/migrations/20260621000001_canonical_gold_ledger.sql
@@ -552,7 +552,9 @@ GRANT EXECUTE ON FUNCTION fn_refund_reward_gold(UUID, INTEGER, UUID) TO service_
 GRANT EXECUTE ON FUNCTION fn_deny_reward_redemption(UUID, UUID, INTEGER, UUID) TO service_role;
 GRANT EXECUTE ON FUNCTION fn_apply_boss_reward(UUID, UUID, UUID, UUID, INTEGER, INTEGER, INTEGER, TEXT, UUID) TO service_role;
 GRANT EXECUTE ON FUNCTION fn_unlock_achievements_and_grant_rewards(UUID, UUID[], UUID) TO service_role;
-GRANT EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) TO authenticated;
+REVOKE ALL ON FUNCTION fn_change_character_class(UUID, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) TO service_role;
 GRANT EXECUTE ON FUNCTION fn_record_admin_gold_adjustment(UUID, INTEGER, UUID, TEXT) TO service_role;
 GRANT EXECUTE ON FUNCTION fn_record_opening_gold_balance(UUID, UUID, TEXT) TO service_role;
 GRANT EXECUTE ON FUNCTION fn_record_gold_migration_entry(UUID, INTEGER, UUID, TEXT, JSONB) TO service_role;

--- a/supabase/migrations/20260621000001_canonical_gold_ledger.sql
+++ b/supabase/migrations/20260621000001_canonical_gold_ledger.sql
@@ -392,6 +392,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
+DROP FUNCTION IF EXISTS fn_change_character_class(UUID, TEXT);
+
 CREATE OR REPLACE FUNCTION fn_change_character_class(
   p_character_id UUID,
   p_new_class TEXT

--- a/supabase/migrations/20260621000001_canonical_gold_ledger.test.ts
+++ b/supabase/migrations/20260621000001_canonical_gold_ledger.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const migration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260621000001_canonical_gold_ledger.sql"),
+  "utf8",
+);
+
+describe("canonical gold ledger migration", () => {
+  it("defines a first-class canonical ledger shape with explicit future-truth semantics", () => {
+    expect(migration).toContain("CREATE TYPE gold_ledger_entry_type AS ENUM");
+    for (const entryType of [
+      "QUEST_REWARD",
+      "STORE_PURCHASE",
+      "REWARD_REFUND",
+      "BOSS_REWARD",
+      "ACHIEVEMENT_BONUS",
+      "ADMIN_ADJUSTMENT",
+      "CLASS_CHANGE_COST",
+      "OPENING_BALANCE",
+      "MIGRATION",
+      "CORRECTION",
+    ]) {
+      expect(migration).toContain(`'${entryType}'`);
+    }
+
+    expect(migration).toContain("CREATE TABLE IF NOT EXISTS gold_ledger_entries");
+    expect(migration).toMatch(/character_id UUID NOT NULL REFERENCES characters\(id\)/);
+    expect(migration).toMatch(/user_id UUID NOT NULL REFERENCES user_profiles\(id\)/);
+    expect(migration).toMatch(/gold_delta INTEGER NOT NULL/);
+    expect(migration).toMatch(/balance_after INTEGER NOT NULL/);
+    expect(migration).toMatch(/actor_user_id UUID REFERENCES user_profiles\(id\)/);
+    expect(migration).toMatch(/source_type TEXT NOT NULL/);
+    expect(migration).toMatch(/source_id UUID/);
+    expect(migration).toMatch(/reason TEXT/);
+    expect(migration).toMatch(/metadata JSONB NOT NULL DEFAULT '\{\}'::jsonb/);
+    expect(migration).toContain("honest forward truth");
+  });
+
+  it("records exactly one canonical ledger row from each day-1 gold mutation helper", () => {
+    for (const functionName of [
+      "fn_apply_quest_reward",
+      "fn_redeem_reward",
+      "fn_refund_reward_gold",
+      "fn_apply_boss_reward",
+      "fn_unlock_achievements_and_grant_rewards",
+      "fn_change_character_class",
+      "fn_record_admin_gold_adjustment",
+      "fn_record_opening_gold_balance",
+      "fn_record_gold_migration_entry",
+      "fn_record_gold_correction_entry",
+    ]) {
+      const functionBlock = migration.match(
+        new RegExp(`CREATE OR REPLACE FUNCTION ${functionName}[\\s\\S]*?END;\\n\\$\\$`, "i"),
+      )?.[0] ?? migration.match(
+        new RegExp(`CREATE OR REPLACE FUNCTION ${functionName}[\\s\\S]*?LANGUAGE sql`, "i"),
+      )?.[0] ?? "";
+
+      expect(functionBlock).toContain("fn_insert_gold_ledger_entry");
+      expect(functionBlock.match(/fn_insert_gold_ledger_entry/g)).toHaveLength(1);
+    }
+  });
+
+  it("makes running-balance reconciliation explicit and transactionally tied to balance updates", () => {
+    expect(migration).toMatch(/SELECT COALESCE\(gold, 0\)[\s\S]*FOR UPDATE/);
+    expect(migration).toContain("CHECK (balance_after = balance_before + gold_delta)");
+    expect(migration).toContain("UNIQUE (source_type, source_id)");
+    expect(migration).toContain("ALTER TABLE gold_ledger_entries ENABLE ROW LEVEL SECURITY");
+  });
+});

--- a/supabase/migrations/20260621000001_canonical_gold_ledger.test.ts
+++ b/supabase/migrations/20260621000001_canonical_gold_ledger.test.ts
@@ -35,6 +35,7 @@ describe("canonical gold ledger migration", () => {
     expect(migration).toMatch(/reason TEXT/);
     expect(migration).toMatch(/metadata JSONB NOT NULL DEFAULT '\{\}'::jsonb/);
     expect(migration).toContain("honest forward truth");
+    expect(migration).toContain("DROP FUNCTION IF EXISTS fn_change_character_class(UUID, TEXT)");
   });
 
   it("records exactly one canonical ledger row from each day-1 gold mutation helper", () => {

--- a/supabase/migrations/20260621000001_canonical_gold_ledger.test.ts
+++ b/supabase/migrations/20260621000001_canonical_gold_ledger.test.ts
@@ -68,4 +68,19 @@ describe("canonical gold ledger migration", () => {
     expect(migration).toContain("UNIQUE (source_type, source_id)");
     expect(migration).toContain("ALTER TABLE gold_ledger_entries ENABLE ROW LEVEL SECURITY");
   });
+
+  it("does not expose the class-change SECURITY DEFINER RPC directly to browser-authenticated callers", () => {
+    expect(migration).toContain(
+      "REVOKE ALL ON FUNCTION fn_change_character_class(UUID, TEXT) FROM PUBLIC",
+    );
+    expect(migration).toContain(
+      "REVOKE EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) FROM authenticated",
+    );
+    expect(migration).toContain(
+      "GRANT EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) TO service_role",
+    );
+    expect(migration).not.toContain(
+      "GRANT EXECUTE ON FUNCTION fn_change_character_class(UUID, TEXT) TO authenticated",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Adds canonical `gold_ledger_entries` schema and `gold_ledger_entry_type` event model for issue #237's honest-forward-truth ledger foundation.
- Replaces day-1 gold mutation helpers with transactional ledger writes for quest rewards, store purchases, refunds, boss rewards, achievement bonuses, class-change costs, admin adjustments, opening balances, migrations, and corrections.
- Routes boss rewards, profile class changes, and admin gold adjustments through canonical RPCs instead of separate client/application updates.

## Test Plan
- `npx jest --runTestsByPath supabase/migrations/20260621000001_canonical_gold_ledger.test.ts lib/profile-service-class.test.ts app/api/boss-quests/[id]/complete/route.achievement-integration.test.ts --runInBand`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`

## Release implications
- Adds a Supabase migration defining the canonical future gold ledger and replacing relevant RPCs.
- No deployment performed from this implementation card.

Closes #237
