### PR TITLE
feat: add admin gold ledger UI

### DIFF
--- a/app/admin/users/[userId]/page.test.tsx
+++ b/app/admin/users/[userId]/page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import AdminUserPage from "./page";
 import { supabase } from "@/lib/supabase";
 
@@ -43,8 +44,35 @@ jest.mock("@/components/layout/authenticated-page-shell", () => ({
 }));
 
 jest.mock("@/components/admin/admin-user-detail-view", () => ({
-  AdminUserDetailView: ({ detail }: { detail: { user: { name: string } } }) => (
-    <div>Detail for {detail.user.name}</div>
+  AdminUserDetailView: ({
+    detail,
+    filters,
+    onFiltersChange,
+  }: {
+    detail: { user: { name: string } };
+    filters: { ledgerStartDate: string; ledgerEndDate: string; ledgerEventType: string };
+    onFiltersChange: (filters: {
+      ledgerStartDate: string;
+      ledgerEndDate: string;
+      ledgerEventType: string;
+    }) => void;
+  }) => (
+    <div>
+      <div>Detail for {detail.user.name}</div>
+      <button
+        type="button"
+        onClick={() =>
+          onFiltersChange({
+            ...filters,
+            ledgerStartDate: "2026-01-01",
+            ledgerEndDate: "2026-01-31",
+            ledgerEventType: "ADMIN_ADJUSTMENT",
+          })
+        }
+      >
+        Apply ledger filters
+      </button>
+    </div>
   ),
 }));
 
@@ -62,7 +90,15 @@ describe("AdminUserPage", () => {
           character: null,
           questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
           recentQuests: [],
-          goldLedgerNotice: "Ledger later",
+          goldLedger: {
+            entries: [],
+            reconciliation: {
+              currentGold: 0,
+              ledgerBalance: 0,
+              difference: 0,
+              diverged: false,
+            },
+          },
         },
       }),
     });
@@ -81,6 +117,23 @@ describe("AdminUserPage", () => {
         }),
       );
       expect(screen.getByText("Detail for Towner")).toBeInTheDocument();
+    });
+  });
+
+  it("reloads the admin detail with ledger filter query parameters", async () => {
+    const user = userEvent.setup();
+    render(<AdminUserPage />);
+
+    await screen.findByText("Detail for Towner");
+    await user.click(screen.getByRole("button", { name: "Apply ledger filters" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/admin/users/hero-1?ledgerStartDate=2026-01-01&ledgerEndDate=2026-01-31&ledgerEventType=ADMIN_ADJUSTMENT",
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer token-1" }),
+        }),
+      );
     });
   });
 });

--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui";
 import { useAuth } from "@/lib/auth-context";
 import { useCharacter } from "@/lib/character-context";
 import { supabase } from "@/lib/supabase";
-import type { AdminUserDetail } from "@/lib/admin-user-detail-service";
+import type { AdminUserDetail, AdminUserGoldLedgerFilterOptions } from "@/lib/admin-user-detail-service";
 
 function resolveUserId(param: string | string[] | undefined): string | null {
   if (Array.isArray(param)) return param[0] ?? null;
@@ -25,6 +25,11 @@ export default function AdminUserPage() {
   const [detail, setDetail] = useState<AdminUserDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(true);
+  const [ledgerFilters, setLedgerFilters] = useState<AdminUserGoldLedgerFilterOptions>({
+    ledgerStartDate: "",
+    ledgerEndDate: "",
+    ledgerEventType: "ALL",
+  });
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -53,12 +58,27 @@ export default function AdminUserPage() {
           throw new Error("Authentication required");
         }
 
-        const response = await fetch(`/api/admin/users/${targetUserId}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
+        const query = new URLSearchParams();
+        if (ledgerFilters.ledgerStartDate) {
+          query.set("ledgerStartDate", ledgerFilters.ledgerStartDate);
+        }
+        if (ledgerFilters.ledgerEndDate) {
+          query.set("ledgerEndDate", ledgerFilters.ledgerEndDate);
+        }
+        if (ledgerFilters.ledgerEventType && ledgerFilters.ledgerEventType !== "ALL") {
+          query.set("ledgerEventType", ledgerFilters.ledgerEventType);
+        }
+
+        const queryString = query.toString();
+        const response = await fetch(
+          `/api/admin/users/${targetUserId}${queryString ? `?${queryString}` : ""}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
           },
-        });
+        );
 
         const payload = await response.json();
         if (!response.ok) {
@@ -84,7 +104,7 @@ export default function AdminUserPage() {
     return () => {
       isMounted = false;
     };
-  }, [isLoading, profile?.role, targetUserId, user]);
+  }, [isLoading, ledgerFilters, profile?.role, targetUserId, user]);
 
   if (isLoading || characterLoading || loadingDetail) {
     return (
@@ -119,7 +139,11 @@ export default function AdminUserPage() {
           {error}
         </div>
       ) : detail ? (
-        <AdminUserDetailView detail={detail} />
+        <AdminUserDetailView
+          detail={detail}
+          filters={ledgerFilters}
+          onFiltersChange={setLedgerFilters}
+        />
       ) : null}
     </AuthenticatedPageShell>
   );

--- a/app/api/admin/users/[userId]/route.test.ts
+++ b/app/api/admin/users/[userId]/route.test.ts
@@ -62,6 +62,33 @@ describe("GET /api/admin/users/[userId]", () => {
     );
   });
 
+  it("treats the all-event ledger filter as no event filter", async () => {
+    const detail = {
+      user: { id: "hero-1", name: "Hero", role: "HERO" },
+      character: null,
+      questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
+      recentQuests: [],
+      goldLedger: {
+        entries: [],
+        reconciliation: { currentGold: null, ledgerBalance: 0, difference: null, diverged: false },
+      },
+    };
+    (adminUserDetailService.getUserDetail as jest.Mock).mockResolvedValue(detail);
+
+    const response = await GET(
+      new NextRequest("http://app.test/api/admin/users/hero-1?ledgerEventType=ALL"),
+      { params: Promise.resolve({ userId: "hero-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(adminUserDetailService.getUserDetail).toHaveBeenCalledWith(
+      { client: true },
+      { id: "gm-1", role: "GUILD_MASTER", family_id: "family-1" },
+      "hero-1",
+      { ledgerEndDate: null, ledgerEventType: null, ledgerStartDate: null },
+    );
+  });
+
   it("rejects invalid ledger event type filters", async () => {
     const response = await GET(
       new NextRequest("http://app.test/api/admin/users/hero-1?ledgerEventType=NOPE"),

--- a/app/api/admin/users/[userId]/route.test.ts
+++ b/app/api/admin/users/[userId]/route.test.ts
@@ -41,7 +41,10 @@ describe("GET /api/admin/users/[userId]", () => {
       character: null,
       questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
       recentQuests: [],
-      goldLedgerNotice: "Ledger comes later",
+      goldLedger: {
+        entries: [],
+        reconciliation: { currentGold: null, ledgerBalance: 0, difference: null, diverged: false },
+      },
     };
     (adminUserDetailService.getUserDetail as jest.Mock).mockResolvedValue(detail);
 
@@ -55,7 +58,22 @@ describe("GET /api/admin/users/[userId]", () => {
       { client: true },
       { id: "gm-1", role: "GUILD_MASTER", family_id: "family-1" },
       "hero-1",
+      { ledgerEndDate: null, ledgerEventType: null, ledgerStartDate: null },
     );
+  });
+
+  it("rejects invalid ledger event type filters", async () => {
+    const response = await GET(
+      new NextRequest("http://app.test/api/admin/users/hero-1?ledgerEventType=NOPE"),
+      { params: Promise.resolve({ userId: "hero-1" }) },
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid ledger event type",
+      code: "ADMIN_GOLD_LEDGER_INVALID_EVENT_TYPE",
+    });
+    expect(response.status).toBe(400);
+    expect(adminUserDetailService.getUserDetail).not.toHaveBeenCalled();
   });
 
   it("returns a generic not-found response for missing or cross-family users", async () => {

--- a/app/api/admin/users/[userId]/route.ts
+++ b/app/api/admin/users/[userId]/route.ts
@@ -5,6 +5,11 @@ import {
   extractBearerToken,
 } from "@/lib/api-auth-helpers";
 import { adminUserDetailService } from "@/lib/admin-user-detail-service";
+import {
+  isGoldLedgerEntryType,
+  type GoldLedgerEntryType,
+} from "@/lib/admin-user-gold-ledger";
+import { ValidationError } from "@/lib/errors";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 
 export async function GET(
@@ -20,10 +25,27 @@ export async function GET(
       token,
     );
 
+    const rawLedgerEventType = request.nextUrl.searchParams.get("ledgerEventType");
+    let ledgerEventType: GoldLedgerEntryType | null = null;
+    if (rawLedgerEventType) {
+      if (!isGoldLedgerEntryType(rawLedgerEventType)) {
+        throw new ValidationError(
+          "Invalid ledger event type",
+          "ADMIN_GOLD_LEDGER_INVALID_EVENT_TYPE",
+        );
+      }
+      ledgerEventType = rawLedgerEventType;
+    }
+
     const detail = await adminUserDetailService.getUserDetail(
       supabase,
       requesterProfile,
       userId,
+      {
+        ledgerStartDate: request.nextUrl.searchParams.get("ledgerStartDate"),
+        ledgerEndDate: request.nextUrl.searchParams.get("ledgerEndDate"),
+        ledgerEventType: ledgerEventType as GoldLedgerEntryType | null,
+      },
     );
 
     return NextResponse.json({ success: true, detail });

--- a/app/api/admin/users/[userId]/route.ts
+++ b/app/api/admin/users/[userId]/route.ts
@@ -27,7 +27,7 @@ export async function GET(
 
     const rawLedgerEventType = request.nextUrl.searchParams.get("ledgerEventType");
     let ledgerEventType: GoldLedgerEntryType | null = null;
-    if (rawLedgerEventType) {
+    if (rawLedgerEventType && rawLedgerEventType !== "ALL") {
       if (!isGoldLedgerEntryType(rawLedgerEventType)) {
         throw new ValidationError(
           "Invalid ledger event type",

--- a/components/admin/admin-user-detail-view.test.tsx
+++ b/components/admin/admin-user-detail-view.test.tsx
@@ -43,8 +43,61 @@ const baseDetail: AdminUserDetail = {
       xpReward: 10,
     },
   ],
-  goldLedgerNotice:
-    "Current gold is shown from the character record. Full ledger and audit history will land in a separate audit slice.",
+  goldLedger: {
+    entries: [
+      {
+        id: "ledger-1",
+        createdAt: "2026-01-01T10:00:00Z",
+        eventType: "OPENING_BALANCE",
+        description: "Opening balance from pre-ledger gold",
+        goldDelta: 100,
+        direction: "credit",
+        balanceBefore: 0,
+        runningBalance: 100,
+        actor: { id: "gm-1", name: "GM", email: "gm@example.test" },
+        sourceType: "gold_ledger_remediation",
+        sourceId: null,
+        referenceLabel: "gold_ledger_remediation",
+        metadata: { historical_strategy: "opening balance" },
+      },
+      {
+        id: "ledger-2",
+        createdAt: "2026-01-02T13:00:00Z",
+        eventType: "QUEST_REWARD",
+        description: "Quest reward approved",
+        goldDelta: 5,
+        direction: "credit",
+        balanceBefore: 100,
+        runningBalance: 105,
+        actor: null,
+        sourceType: "quest_instances",
+        sourceId: "quest-1",
+        referenceLabel: "quest_instances: quest-1",
+        metadata: { xp_delta: 10 },
+      },
+      {
+        id: "ledger-3",
+        createdAt: "2026-01-03T13:00:00Z",
+        eventType: "ADMIN_ADJUSTMENT",
+        description: "Manual correction after duplicate award",
+        goldDelta: -20,
+        direction: "debit",
+        balanceBefore: 105,
+        runningBalance: 85,
+        actor: { id: "gm-1", name: "GM", email: "gm@example.test" },
+        sourceType: "admin_gold_adjustment",
+        sourceId: "adjustment-1",
+        referenceLabel: "admin_gold_adjustment: adjustment-1",
+        metadata: {},
+      },
+    ],
+    reconciliation: {
+      currentGold: 125,
+      ledgerBalance: 85,
+      difference: 40,
+      diverged: true,
+    },
+  },
 };
 
 describe("AdminUserDetailView", () => {
@@ -69,7 +122,18 @@ describe("AdminUserDetailView", () => {
 
     expect(screen.getByRole("heading", { name: "Recent Approved Quests" })).toBeInTheDocument();
     expect(screen.getByText("Unload dishwasher")).toBeInTheDocument();
-    expect(screen.getByText(/Full ledger and audit history/)).toBeInTheDocument();
+
+    expect(screen.getByRole("heading", { name: "Gold Ledger" })).toBeInTheDocument();
+    expect(screen.getByText(/Ledger balance differs from current character gold/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Opening Balance").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Quest Reward").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Admin Adjustment").length).toBeGreaterThan(0);
+    expect(screen.getByText("+100 Gold")).toBeInTheDocument();
+    expect(screen.getByText("-20 Gold")).toBeInTheDocument();
+    expect(screen.getByText("85 Gold")).toBeInTheDocument();
+    expect(screen.getAllByText("GM").length).toBeGreaterThan(0);
+    expect(screen.getByText("quest_instances: quest-1")).toBeInTheDocument();
+    expect(screen.getByText(/Opening, migration, and correction rows are explicit ledger controls/i)).toBeInTheDocument();
   });
 
   it("handles users with no character or quest data gracefully", () => {
@@ -80,11 +144,21 @@ describe("AdminUserDetailView", () => {
           character: null,
           questSummary: { active: 0, pendingApproval: 0, approved: 0, missed: 0, total: 0 },
           recentQuests: [],
+          goldLedger: {
+            entries: [],
+            reconciliation: {
+              currentGold: null,
+              ledgerBalance: 0,
+              difference: null,
+              diverged: false,
+            },
+          },
         }}
       />,
     );
 
     expect(screen.getByText(/No character has been created/i)).toBeInTheDocument();
     expect(screen.getByText(/No recent quests found/i)).toBeInTheDocument();
+    expect(screen.getByText(/No ledger entries match the selected filters/i)).toBeInTheDocument();
   });
 });

--- a/components/admin/admin-user-detail-view.tsx
+++ b/components/admin/admin-user-detail-view.tsx
@@ -1,4 +1,7 @@
-import type { AdminUserDetail } from "@/lib/admin-user-detail-service";
+import type {
+  AdminUserDetail,
+  AdminUserGoldLedgerFilterOptions,
+} from "@/lib/admin-user-detail-service";
 
 function titleCase(value: string | null | undefined): string {
   if (!value) return "Unknown";
@@ -18,6 +21,19 @@ function formatDate(value: string | null): string {
   }).format(new Date(value));
 }
 
+const GOLD_LEDGER_EVENT_TYPES = [
+  "QUEST_REWARD",
+  "STORE_PURCHASE",
+  "REWARD_REFUND",
+  "BOSS_REWARD",
+  "ACHIEVEMENT_BONUS",
+  "ADMIN_ADJUSTMENT",
+  "CLASS_CHANGE_COST",
+  "OPENING_BALANCE",
+  "MIGRATION",
+  "CORRECTION",
+] as const;
+
 function StatPill({ label, value }: { label: string; value: number }) {
   return (
     <div className="rounded-lg border border-gray-700 bg-gray-900/50 p-4">
@@ -26,8 +42,32 @@ function StatPill({ label, value }: { label: string; value: number }) {
   );
 }
 
-export function AdminUserDetailView({ detail }: { detail: AdminUserDetail }) {
-  const { user, character, questSummary, recentQuests } = detail;
+function formatGold(delta: number): string {
+  const prefix = delta > 0 ? "+" : "";
+  return `${prefix}${delta} Gold`;
+}
+
+function formatActor(actor: { name: string } | null): string {
+  return actor?.name ?? "System / automatic";
+}
+
+export function AdminUserDetailView({
+  detail,
+  filters = { ledgerStartDate: "", ledgerEndDate: "", ledgerEventType: "ALL" },
+  onFiltersChange,
+}: {
+  detail: AdminUserDetail;
+  filters?: AdminUserGoldLedgerFilterOptions;
+  onFiltersChange?: (filters: AdminUserGoldLedgerFilterOptions) => void;
+}) {
+  const { user, character, questSummary, recentQuests, goldLedger } = detail;
+
+  const updateFilter = (key: keyof AdminUserGoldLedgerFilterOptions, value: string) => {
+    onFiltersChange?.({
+      ...filters,
+      [key]: value,
+    });
+  };
 
   return (
     <div className="space-y-6" data-testid="admin-user-detail-view">
@@ -122,8 +162,98 @@ export function AdminUserDetailView({ detail }: { detail: AdminUserDetail }) {
         )}
       </section>
 
-      <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-amber-100">
-        {detail.goldLedgerNotice}
+      <section className="rounded-lg border border-gray-700 bg-gray-800/50 p-6">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Gold Ledger</h2>
+            <p className="mt-1 text-sm text-gray-400">
+              Chronological gold movements for this character. Opening, migration, and correction rows are explicit ledger controls, not claims of perfect historical provenance. Filters change which rows are displayed; each running balance remains the true ledger balance at that row.
+            </p>
+          </div>
+          <div className="rounded-lg border border-gray-700 bg-gray-900/60 p-3 text-sm text-gray-200">
+            <p>Ledger balance: {goldLedger.reconciliation.ledgerBalance} Gold</p>
+            <p>Current character gold: {goldLedger.reconciliation.currentGold ?? "—"} Gold</p>
+          </div>
+        </div>
+
+        {goldLedger.reconciliation.diverged ? (
+          <div className="mt-4 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-100">
+            Ledger balance differs from current character gold by {goldLedger.reconciliation.difference} Gold. Review reconciliation or correction entries before treating the ledger as settled truth.
+          </div>
+        ) : null}
+
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          <label className="text-sm text-gray-300">
+            Start date
+            <input
+              type="date"
+              className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-gray-100"
+              value={filters.ledgerStartDate ?? ""}
+              onChange={(event) => updateFilter("ledgerStartDate", event.target.value)}
+            />
+          </label>
+          <label className="text-sm text-gray-300">
+            End date
+            <input
+              type="date"
+              className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-gray-100"
+              value={filters.ledgerEndDate ?? ""}
+              onChange={(event) => updateFilter("ledgerEndDate", event.target.value)}
+            />
+          </label>
+          <label className="text-sm text-gray-300">
+            Event type
+            <select
+              className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-gray-100"
+              value={filters.ledgerEventType ?? "ALL"}
+              onChange={(event) => updateFilter("ledgerEventType", event.target.value)}
+            >
+              <option value="ALL">All event types</option>
+              {GOLD_LEDGER_EVENT_TYPES.map((eventType) => (
+                <option key={eventType} value={eventType}>
+                  {titleCase(eventType)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-5 overflow-x-auto">
+          {goldLedger.entries.length > 0 ? (
+            <table className="min-w-full divide-y divide-gray-700 text-sm">
+              <thead className="text-left text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="py-2 pr-4">Timestamp</th>
+                  <th className="py-2 pr-4">Event</th>
+                  <th className="py-2 pr-4">Description</th>
+                  <th className="py-2 pr-4">Credit / Debit</th>
+                  <th className="py-2 pr-4">Running balance</th>
+                  <th className="py-2 pr-4">Actor / source</th>
+                  <th className="py-2 pr-4">Reference</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 text-gray-200">
+                {goldLedger.entries.map((entry) => (
+                  <tr key={entry.id}>
+                    <td className="py-3 pr-4 text-gray-400">{formatDate(entry.createdAt)}</td>
+                    <td className="py-3 pr-4 font-medium text-white">{titleCase(entry.eventType)}</td>
+                    <td className="py-3 pr-4">{entry.description}</td>
+                    <td className={entry.direction === "debit" ? "py-3 pr-4 text-red-300" : "py-3 pr-4 text-emerald-300"}>
+                      {formatGold(entry.goldDelta)}
+                    </td>
+                    <td className="py-3 pr-4">{entry.runningBalance} Gold</td>
+                    <td className="py-3 pr-4">{formatActor(entry.actor)}</td>
+                    <td className="py-3 pr-4 font-mono text-xs text-gray-400">{entry.referenceLabel}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="rounded-lg border border-dashed border-gray-600 bg-gray-900/40 p-4 text-gray-300">
+              No ledger entries match the selected filters.
+            </p>
+          )}
+        </div>
       </section>
     </div>
   );

--- a/lib/admin-user-detail-service.ledger.test.ts
+++ b/lib/admin-user-detail-service.ledger.test.ts
@@ -1,0 +1,175 @@
+import { AdminUserDetailService } from "./admin-user-detail-service";
+
+const requester = {
+  id: "gm-1",
+  role: "GUILD_MASTER" as const,
+  family_id: "family-1",
+};
+
+type QueryResult = { data: unknown; error: unknown };
+
+function createSupabaseStub(results: Record<string, QueryResult | QueryResult[]>) {
+  const calls: Array<{ table: string; operations: Array<[string, unknown[]]> }> = [];
+  const callCounts: Record<string, number> = {};
+  const nextResult = (table: string): QueryResult => {
+    const result = results[table];
+    if (Array.isArray(result)) {
+      const index = callCounts[table] ?? 0;
+      callCounts[table] = index + 1;
+      return result[index] ?? result[result.length - 1];
+    }
+    return result ?? { data: null, error: null };
+  };
+  const makeQuery = (table: string) => {
+    const result = nextResult(table);
+    const operations: Array<[string, unknown[]]> = [];
+    const query: Record<string, unknown> = {
+      select: (...args: unknown[]) => (operations.push(["select", args]), query),
+      eq: (...args: unknown[]) => (operations.push(["eq", args]), query),
+      gte: (...args: unknown[]) => (operations.push(["gte", args]), query),
+      lte: (...args: unknown[]) => (operations.push(["lte", args]), query),
+      in: (...args: unknown[]) => (operations.push(["in", args]), query),
+      or: (...args: unknown[]) => (operations.push(["or", args]), query),
+      order: (...args: unknown[]) => (operations.push(["order", args]), query),
+      limit: (...args: unknown[]) => {
+        operations.push(["limit", args]);
+        return Promise.resolve(result);
+      },
+      maybeSingle: () => {
+        operations.push(["maybeSingle", []]);
+        return Promise.resolve(result);
+      },
+      then: (resolve: (value: QueryResult) => void) => resolve(result),
+    };
+    calls.push({ table, operations });
+    return query;
+  };
+  return { supabase: { from: jest.fn((table: string) => makeQuery(table)) }, calls };
+}
+
+const profileResult = {
+  data: {
+    id: "hero-1",
+    name: "Towner",
+    email: "towner@example.test",
+    role: "HERO",
+    family_id: "family-1",
+    created_at: null,
+    updated_at: null,
+    characters: [{ id: "char-1", name: "Hero", class: "KNIGHT", level: 1, xp: 0, gold: 125, gems: 0, honor_points: 0, created_at: null, updated_at: null }],
+  },
+  error: null,
+};
+
+function ledgerRow(overrides: Record<string, unknown>) {
+  return {
+    id: "ledger-1",
+    created_at: "2026-01-01T10:00:00Z",
+    gold_delta: 100,
+    balance_before: 0,
+    balance_after: 100,
+    entry_type: "OPENING_BALANCE",
+    source_type: "gold_ledger_remediation",
+    source_id: null,
+    actor_user_id: null,
+    reason: null,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("AdminUserDetailService gold ledger", () => {
+  it("maps ledger rows with running balance, actor, references, and divergence", async () => {
+    const { supabase, calls } = createSupabaseStub({
+      user_profiles: [profileResult, { data: [{ id: "gm-1", name: "GM", email: "gm@example.test" }], error: null }],
+      quest_instances: [{ data: [], error: null }, { data: [], error: null }],
+      gold_ledger_entries: [
+        { data: [{ balance_after: 85 }], error: null },
+        {
+          data: [
+            ledgerRow({ id: "ledger-3", created_at: "2026-01-03T13:00:00Z", gold_delta: -20, balance_before: 105, balance_after: 85, entry_type: "ADMIN_ADJUSTMENT", source_type: "admin_gold_adjustment", source_id: "adjustment-1", actor_user_id: "gm-1", reason: "Manual correction after duplicate award" }),
+            ledgerRow({ id: "ledger-2", created_at: "2026-01-02T13:00:00Z", gold_delta: 5, balance_before: 100, balance_after: 105, entry_type: "QUEST_REWARD", source_type: "quest_instances", source_id: "quest-1", actor_user_id: null, reason: "Quest reward approved", metadata: { xp_delta: 10 } }),
+            ledgerRow({ id: "ledger-1", created_at: "2026-01-01T10:00:00Z", gold_delta: 100, balance_before: 0, balance_after: 100, entry_type: "OPENING_BALANCE", source_type: "gold_ledger_remediation", source_id: null, actor_user_id: "gm-1", reason: "Opening balance from pre-ledger gold" }),
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    const detail = await new AdminUserDetailService().getUserDetail(supabase as never, requester, "hero-1");
+
+    expect(detail.goldLedger.entries.map((entry) => entry.id)).toEqual(["ledger-1", "ledger-2", "ledger-3"]);
+    expect(detail.goldLedger.entries[0]).toEqual(expect.objectContaining({ eventType: "OPENING_BALANCE", direction: "credit", runningBalance: 100, actor: expect.objectContaining({ name: "GM" }), referenceLabel: "gold_ledger_remediation" }));
+    expect(detail.goldLedger.entries[2]).toEqual(expect.objectContaining({ eventType: "ADMIN_ADJUSTMENT", direction: "debit", referenceLabel: "admin_gold_adjustment: adjustment-1" }));
+    expect(detail.goldLedger.reconciliation).toEqual({ currentGold: 125, ledgerBalance: 85, difference: 40, diverged: true });
+
+    const ledgerCall = calls.find((call) =>
+      call.table === "gold_ledger_entries" &&
+      call.operations.some((operation) => operation[0] === "select" && String(operation[1][0]).includes("gold_delta")),
+    );
+    expect(ledgerCall?.operations).toContainEqual(["eq", ["character_id", "char-1"]]);
+    expect(ledgerCall?.operations).toContainEqual(["order", ["created_at", { ascending: false }]]);
+    expect(ledgerCall?.operations).toContainEqual(["limit", [100]]);
+  });
+
+  it("applies display filters without changing authoritative reconciliation", async () => {
+    const { supabase, calls } = createSupabaseStub({
+      user_profiles: [profileResult, { data: [], error: null }],
+      quest_instances: [{ data: [], error: null }, { data: [], error: null }],
+      gold_ledger_entries: [{ data: [{ balance_after: 125 }], error: null }, { data: [], error: null }],
+    });
+
+    const detail = await new AdminUserDetailService().getUserDetail(supabase as never, requester, "hero-1", {
+      ledgerStartDate: "2026-01-01",
+      ledgerEndDate: "2026-01-31",
+      ledgerEventType: "ADMIN_ADJUSTMENT",
+    });
+
+    expect(detail.goldLedger.entries).toEqual([]);
+    expect(detail.goldLedger.reconciliation).toEqual({ currentGold: 125, ledgerBalance: 125, difference: 0, diverged: false });
+
+    const latestBalanceCall = calls.find((call) =>
+      call.table === "gold_ledger_entries" &&
+      call.operations.some((operation) => operation[0] === "select" && operation[1][0] === "balance_after"),
+    );
+    expect(latestBalanceCall?.operations).not.toContainEqual(["gte", ["created_at", "2026-01-01T00:00:00.000Z"]]);
+    expect(latestBalanceCall?.operations).not.toContainEqual(["lte", ["created_at", "2026-01-31T23:59:59.999Z"]]);
+    expect(latestBalanceCall?.operations).not.toContainEqual(["eq", ["entry_type", "ADMIN_ADJUSTMENT"]]);
+
+    const ledgerCall = calls.find((call) =>
+      call.table === "gold_ledger_entries" &&
+      call.operations.some((operation) => operation[0] === "select" && String(operation[1][0]).includes("gold_delta")),
+    );
+    expect(ledgerCall?.operations).toContainEqual(["gte", ["created_at", "2026-01-01T00:00:00.000Z"]]);
+    expect(ledgerCall?.operations).toContainEqual(["lte", ["created_at", "2026-01-31T23:59:59.999Z"]]);
+    expect(ledgerCall?.operations).toContainEqual(["eq", ["entry_type", "ADMIN_ADJUSTMENT"]]);
+  });
+
+  it("fetches the latest ledger history slice instead of the oldest rows for long histories", async () => {
+    const { supabase, calls } = createSupabaseStub({
+      user_profiles: [profileResult, { data: [], error: null }],
+      quest_instances: [{ data: [], error: null }, { data: [], error: null }],
+      gold_ledger_entries: [
+        { data: [{ balance_after: 150 }], error: null },
+        {
+          data: [
+            ledgerRow({ id: "ledger-150", created_at: "2026-01-03T00:00:00Z", balance_after: 150 }),
+            ledgerRow({ id: "ledger-149", created_at: "2026-01-02T00:00:00Z", balance_after: 149 }),
+            ledgerRow({ id: "ledger-148", created_at: "2026-01-01T00:00:00Z", balance_after: 148 }),
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    const detail = await new AdminUserDetailService().getUserDetail(supabase as never, requester, "hero-1");
+
+    const ledgerCall = calls.find((call) =>
+      call.table === "gold_ledger_entries" &&
+      call.operations.some((operation) => operation[0] === "select" && String(operation[1][0]).includes("gold_delta")),
+    );
+    expect(ledgerCall?.operations).toContainEqual(["order", ["created_at", { ascending: false }]]);
+    expect(ledgerCall?.operations).toContainEqual(["limit", [100]]);
+    expect(detail.goldLedger.entries.map((entry) => entry.id)).toEqual(["ledger-148", "ledger-149", "ledger-150"]);
+  });
+});

--- a/lib/admin-user-detail-service.test.ts
+++ b/lib/admin-user-detail-service.test.ts
@@ -35,6 +35,18 @@ function createSupabaseStub(results: Record<string, QueryResult | QueryResult[]>
         operations.push(["eq", args]);
         return query;
       },
+      gte: (...args: unknown[]) => {
+        operations.push(["gte", args]);
+        return query;
+      },
+      lte: (...args: unknown[]) => {
+        operations.push(["lte", args]);
+        return query;
+      },
+      in: (...args: unknown[]) => {
+        operations.push(["in", args]);
+        return query;
+      },
       or: (...args: unknown[]) => {
         operations.push(["or", args]);
         return query;
@@ -94,6 +106,7 @@ describe("AdminUserDetailService", () => {
         },
         error: null,
       },
+      gold_ledger_entries: { data: [], error: null },
       quest_instances: [
         {
           data: [
@@ -165,7 +178,7 @@ describe("AdminUserDetailService", () => {
     expect(detail.recentQuests[0]).toEqual(
       expect.objectContaining({ title: "Unload dishwasher", status: "APPROVED" }),
     );
-    expect(detail.goldLedgerNotice).toMatch(/separate audit slice/i);
+    expect(detail.goldLedger.entries).toEqual([]);
 
     const recentQuestCall = calls[2];
     expect(recentQuestCall.table).toBe("quest_instances");

--- a/lib/admin-user-detail-service.ts
+++ b/lib/admin-user-detail-service.ts
@@ -1,12 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type {
-  AuthenticatedUser,
-} from "@/lib/api-auth-helpers";
-import type {
-  CharacterClass,
-  QuestStatus,
-  UserRole,
-} from "@/lib/types/database";
+import type { AuthenticatedUser } from "@/lib/api-auth-helpers";
+import type { CharacterClass, QuestStatus, UserRole } from "@/lib/types/database";
+import {
+  fetchAdminUserGoldLedger,
+  type AdminUserGoldLedger,
+  type AdminUserGoldLedgerFilterOptions,
+} from "@/lib/admin-user-gold-ledger";
 import { AppError, ForbiddenError, NotFoundError } from "@/lib/errors";
 
 export type AdminUserDetailUser = {
@@ -51,12 +50,14 @@ export type AdminUserRecentQuest = {
   xpReward: number;
 };
 
+export type { AdminUserGoldLedgerFilterOptions } from "@/lib/admin-user-gold-ledger";
+
 export type AdminUserDetail = {
   user: AdminUserDetailUser;
   character: AdminUserDetailCharacter | null;
   questSummary: AdminUserQuestSummary;
   recentQuests: AdminUserRecentQuest[];
-  goldLedgerNotice: string;
+  goldLedger: AdminUserGoldLedger;
 };
 
 type RawCharacter = {
@@ -93,9 +94,6 @@ type RawQuest = {
   gold_reward: number | null;
   xp_reward: number | null;
 };
-
-const GOLD_LEDGER_NOTICE =
-  "Current gold is shown from the character record. Full ledger and audit history will land in a separate audit slice.";
 
 function firstCharacter(
   characters: RawCharacter | RawCharacter[] | null,
@@ -180,6 +178,7 @@ export class AdminUserDetailService {
     supabase: SupabaseClient,
     requesterProfile: AuthenticatedUser,
     targetUserId: string,
+    options: AdminUserGoldLedgerFilterOptions = {},
   ): Promise<AdminUserDetail> {
     if (requesterProfile.role !== "GUILD_MASTER") {
       throw new ForbiddenError(
@@ -269,6 +268,14 @@ export class AdminUserDetailService {
 
     const summaryQuests = (questSummaryRows ?? []) as RawQuest[];
     const recentQuests = ((recentQuestRows ?? []) as RawQuest[]).filter(isApprovedQuest);
+    const mappedCharacter = mapCharacter(character);
+
+    const goldLedger = await fetchAdminUserGoldLedger(
+      supabase,
+      mappedCharacter?.id ?? null,
+      mappedCharacter?.gold ?? null,
+      options,
+    );
 
     return {
       user: {
@@ -280,10 +287,10 @@ export class AdminUserDetailService {
         createdAt: profile.created_at,
         updatedAt: profile.updated_at,
       },
-      character: mapCharacter(character),
+      character: mappedCharacter,
       questSummary: summarizeQuests(summaryQuests),
       recentQuests: recentQuests.map(mapRecentQuest),
-      goldLedgerNotice: GOLD_LEDGER_NOTICE,
+      goldLedger,
     };
   }
 }

--- a/lib/admin-user-gold-ledger.ts
+++ b/lib/admin-user-gold-ledger.ts
@@ -1,0 +1,244 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AppError } from "@/lib/errors";
+import { AppError as AppErrorClass } from "@/lib/errors";
+import type { Json } from "@/lib/types/database";
+import type { Database } from "@/lib/types/database-generated";
+
+export type GoldLedgerEntryType = Database["public"]["Enums"]["gold_ledger_entry_type"];
+
+export const GOLD_LEDGER_ENTRY_TYPES: readonly GoldLedgerEntryType[] = [
+  "QUEST_REWARD",
+  "STORE_PURCHASE",
+  "REWARD_REFUND",
+  "BOSS_REWARD",
+  "ACHIEVEMENT_BONUS",
+  "ADMIN_ADJUSTMENT",
+  "CLASS_CHANGE_COST",
+  "OPENING_BALANCE",
+  "MIGRATION",
+  "CORRECTION",
+];
+
+export function isGoldLedgerEntryType(value: string | null): value is GoldLedgerEntryType {
+  return GOLD_LEDGER_ENTRY_TYPES.includes(value as GoldLedgerEntryType);
+}
+
+export type AdminUserGoldLedgerFilterOptions = {
+  ledgerStartDate?: string | null;
+  ledgerEndDate?: string | null;
+  ledgerEventType?: GoldLedgerEntryType | "ALL" | null;
+};
+
+export type AdminUserGoldLedgerActor = {
+  id: string;
+  name: string;
+  email: string | null;
+};
+
+export type AdminUserGoldLedgerEntry = {
+  id: string;
+  createdAt: string;
+  eventType: GoldLedgerEntryType;
+  description: string;
+  goldDelta: number;
+  direction: "credit" | "debit" | "neutral";
+  balanceBefore: number;
+  runningBalance: number;
+  actor: AdminUserGoldLedgerActor | null;
+  sourceType: string;
+  sourceId: string | null;
+  referenceLabel: string;
+  metadata: Json;
+};
+
+export type AdminUserGoldLedger = {
+  entries: AdminUserGoldLedgerEntry[];
+  reconciliation: {
+    currentGold: number | null;
+    ledgerBalance: number;
+    difference: number | null;
+    diverged: boolean;
+  };
+};
+
+const DISPLAY_LEDGER_ENTRY_LIMIT = 100;
+
+type RawGoldLedgerEntry = {
+  id: string;
+  created_at: string;
+  gold_delta: number | null;
+  balance_before: number | null;
+  balance_after: number | null;
+  entry_type: GoldLedgerEntryType;
+  source_type: string;
+  source_id: string | null;
+  actor_user_id: string | null;
+  reason: string | null;
+  metadata: Json | null;
+};
+
+type RawActorProfile = {
+  id: string;
+  name: string;
+  email: string | null;
+};
+
+function titleCase(value: string | null | undefined): string {
+  if (!value) return "Unknown";
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function toDayStartIso(date: string): string {
+  return new Date(`${date}T00:00:00.000Z`).toISOString();
+}
+
+function toDayEndIso(date: string): string {
+  return new Date(`${date}T23:59:59.999Z`).toISOString();
+}
+
+function ledgerDirection(goldDelta: number): AdminUserGoldLedgerEntry["direction"] {
+  if (goldDelta > 0) return "credit";
+  if (goldDelta < 0) return "debit";
+  return "neutral";
+}
+
+function referenceLabel(sourceType: string, sourceId: string | null): string {
+  return sourceId ? `${sourceType}: ${sourceId}` : sourceType;
+}
+
+function mapLedgerEntries(
+  rows: RawGoldLedgerEntry[],
+  actorsById: Map<string, RawActorProfile>,
+): AdminUserGoldLedgerEntry[] {
+  return rows.map((row) => {
+    const goldDelta = row.gold_delta ?? 0;
+    const actor = row.actor_user_id ? actorsById.get(row.actor_user_id) ?? null : null;
+
+    return {
+      id: row.id,
+      createdAt: row.created_at,
+      eventType: row.entry_type,
+      description: row.reason || titleCase(row.entry_type),
+      goldDelta,
+      direction: ledgerDirection(goldDelta),
+      balanceBefore: row.balance_before ?? 0,
+      runningBalance: row.balance_after ?? 0,
+      actor,
+      sourceType: row.source_type,
+      sourceId: row.source_id,
+      referenceLabel: referenceLabel(row.source_type, row.source_id),
+      metadata: row.metadata ?? {},
+    };
+  });
+}
+
+export function buildLedgerReconciliation(
+  currentGold: number | null,
+  ledgerBalance: number,
+): AdminUserGoldLedger["reconciliation"] {
+  const difference = currentGold === null ? null : currentGold - ledgerBalance;
+
+  return {
+    currentGold,
+    ledgerBalance,
+    difference,
+    diverged: difference !== null && difference !== 0,
+  };
+}
+
+export async function fetchAdminUserGoldLedger(
+  supabase: SupabaseClient,
+  characterId: string | null,
+  currentGold: number | null,
+  options: AdminUserGoldLedgerFilterOptions,
+): Promise<AdminUserGoldLedger> {
+  if (!characterId) {
+    return {
+      entries: [],
+      reconciliation: buildLedgerReconciliation(null, 0),
+    };
+  }
+
+  const { data: latestRows, error: latestError } = await supabase
+    .from("gold_ledger_entries")
+    .select("balance_after")
+    .eq("character_id", characterId)
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  if (latestError) {
+    throw new AppErrorClass(
+      "Failed to fetch gold ledger reconciliation",
+      500,
+      "ADMIN_GOLD_LEDGER_RECONCILIATION_FETCH_FAILED",
+    ) as AppError;
+  }
+
+  const latestBalance = ((latestRows ?? []) as Array<{ balance_after: number | null }>)[0]
+    ?.balance_after ?? 0;
+
+  let ledgerQuery = supabase
+    .from("gold_ledger_entries")
+    .select(
+      "id, created_at, gold_delta, balance_before, balance_after, entry_type, source_type, source_id, actor_user_id, reason, metadata",
+    )
+    .eq("character_id", characterId);
+
+  if (options.ledgerStartDate) {
+    ledgerQuery = ledgerQuery.gte("created_at", toDayStartIso(options.ledgerStartDate));
+  }
+  if (options.ledgerEndDate) {
+    ledgerQuery = ledgerQuery.lte("created_at", toDayEndIso(options.ledgerEndDate));
+  }
+  if (options.ledgerEventType && options.ledgerEventType !== "ALL") {
+    ledgerQuery = ledgerQuery.eq("entry_type", options.ledgerEventType);
+  }
+
+  const { data: ledgerRows, error: ledgerError } = await ledgerQuery
+    .order("created_at", { ascending: false })
+    .limit(DISPLAY_LEDGER_ENTRY_LIMIT);
+
+  if (ledgerError) {
+    throw new AppErrorClass(
+      "Failed to fetch gold ledger",
+      500,
+      "ADMIN_GOLD_LEDGER_FETCH_FAILED",
+    ) as AppError;
+  }
+
+  const rawLedgerRows = [...((ledgerRows ?? []) as RawGoldLedgerEntry[])].reverse();
+  const actorIds = Array.from(
+    new Set(rawLedgerRows.map((row) => row.actor_user_id).filter((id): id is string => Boolean(id))),
+  );
+  let actorsById = new Map<string, RawActorProfile>();
+
+  if (actorIds.length > 0) {
+    const { data: actorRows, error: actorError } = await supabase
+      .from("user_profiles")
+      .select("id, name, email")
+      .in("id", actorIds);
+
+    if (actorError) {
+      throw new AppErrorClass(
+        "Failed to fetch gold ledger actor details",
+        500,
+        "ADMIN_GOLD_LEDGER_ACTOR_FETCH_FAILED",
+      ) as AppError;
+    }
+
+    actorsById = new Map(
+      ((actorRows ?? []) as RawActorProfile[]).map((actor) => [actor.id, actor]),
+    );
+  }
+
+  const entries = mapLedgerEntries(rawLedgerRows, actorsById);
+
+  return {
+    entries,
+    reconciliation: buildLedgerReconciliation(currentGold, latestBalance),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the admin user gold-ledger table with date/event filters, running balances, actor/source/reference columns, and honest-forward-truth copy for opening/migration/correction semantics.
- Separates authoritative reconciliation from displayed-row filtering by reading the latest ledger balance independently of the filtered display query.
- Fixes long-history display by fetching the latest 100 ledger rows in descending order, then rendering that slice chronologically so later activity is not silently dropped.
- Validates `ledgerEventType` query params at runtime and rejects unknown event types.

Fixes #239.

## Manual verification notes
- Filter behavior: date/type filters only affect displayed ledger rows; reconciliation balance/difference is still derived from the latest complete ledger state.
- Long-history behavior: the API requests the newest 100 ledger rows, then reverses them for chronological display, avoiding the old first-100/oldest-row truncation.
- Divergence warning semantics: warning state compares current character gold against the latest ledger `balance_after`, not the filtered display subset.

## Test plan
- `npx jest --runTestsByPath lib/admin-user-detail-service.ledger.test.ts app/api/admin/users/[userId]/route.test.ts components/admin/admin-user-detail-view.test.tsx app/admin/users/[userId]/page.test.tsx --runInBand`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run test:unit` currently fails in unrelated achievement/family achievement rollback/evaluator suites already outside this issue scope; the focused issue #239 suites pass.

## Documentation impact
- No operator/user/release documentation changes required; this is an admin UI behavior fix/addition covered by PR notes and tests.
