### PR TITLE
fix: clarify production direct db configuration

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -19,10 +19,13 @@ JWT_SECRET=replace-with-your-supabase-jwt-secret
 POSTGRES_PASSWORD=replace-with-your-postgres-password
 
 # ============================================================================
-# Database Credentials for initial bootstrap (OPTION C - self-hosted Supabase)
+# Direct Postgres credentials for startup migrations (self-hosted Supabase)
+# These are used only by psql inside the app container. They are intentionally
+# separate from Supabase HTTP/API URLs above and from host-published Postgres
+# ports used by external backup/admin tools.
 # ============================================================================
-DB_HOST=supabase-db
-DB_PORT=5553
+DIRECT_DB_HOST=supabase-db
+DIRECT_DB_PORT=5432
 DB_NAME=postgres
 DB_USER=postgres
 DB_PASSWORD=replace-with-your-postgres-password
@@ -30,7 +33,8 @@ DB_PASSWORD=replace-with-your-postgres-password
 # ============================================================================
 # Application Configuration
 # ============================================================================
-PORT=5555                                           # Exposed via docker-compose.prod.yml
+APP_HOST_BIND=10.10.50.2:                              # Optional host/interface bind prefix for prod, including trailing colon
+PORT=5555                                           # Host port exposed by docker-compose.prod.yml
 NEXTAUTH_URL=https://app.example.com                 # Public URL of the ChoreQuest app
 CRON_SECRET=replace-with-your-cron-secret            # Shared secret for scheduled jobs
-ENABLE_DB_BOOTSTRAP=true                            # Runs Prisma migrations + seed on first boot
+ENABLE_DB_BOOTSTRAP=true                            # Also runs seed.sql after migrations (if present)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ChoreQuest turns household responsibilities into a co-op RPG. Families create gu
 - **Recurring quest engine** – Templates generate daily/weekly quest instances with anti-dup safeguards.
 - **Real-time collaboration** – Live claiming, releasing, and reassignment flows for family quests.
 - **Robust auth & data layer** – Supabase Auth, PostgREST, Realtime, Storage, and Supavisor pooling.
-- **Automated bootstrap** – On first boot the app runs Prisma migrations, syncs Supabase policies, and seeds demo data (toggle via `ENABLE_DB_BOOTSTRAP`).
+- **Automated migrations** – On container startup the app runs checked-in Supabase SQL migrations before Next.js starts, with optional demo seeding toggled via `ENABLE_DB_BOOTSTRAP`.
 
 ## Tech Stack
 - **App**: Next.js 15 (React 19), TypeScript, Tailwind, Radix UI.
@@ -33,11 +33,11 @@ ChoreQuest turns household responsibilities into a co-op RPG. Families create gu
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service-role JWT | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` |
 | `JWT_SECRET` | JWT signing secret shared with Supabase stack | `your-super-secret-jwt-token-with-at-least-32-characters-long` |
 | `POSTGRES_PASSWORD` | Supabase Postgres superuser password | `your-super-secret-and-long-postgres-password` |
-| `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` | Prisma bootstrap credentials (point at Supabase Postgres) | `supabase-db`, `5553`, `postgres`, `postgres`, same password as above |
-| `PORT` | Host port for the Next.js container | `5555` |
+| `DIRECT_DB_HOST`, `DIRECT_DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` | Direct Postgres target for startup migrations from inside the app container | `supabase-db`, `5432`, `postgres`, `postgres`, same password as above |
+| `APP_HOST_BIND`, `PORT` | Optional host interface bind prefix and host port for the Next.js container | `10.10.50.2:`, `5555` |
 | `NEXTAUTH_URL` | Public URL for callbacks and cron | `https://app.example.com` |
 | `CRON_SECRET` | Auth token for scheduled quest jobs | `generate-a-long-random-string-here` |
-| `ENABLE_DB_BOOTSTRAP` | Runs migrations + seed on first boot | `true` |
+| `ENABLE_DB_BOOTSTRAP` | Runs seed data after migrations when explicitly enabled | `true` |
 | `SUPABASE_VOLUME_ROOT` | Host path where Supabase SQL/config assets live | `/path/to/supabase/volumes` |
 
 All environment templates (`.env`, `.env.example`, `.env.dev.example`, `.env.production`, `.env.production.example`, and `supabase-docker/.env.example`) use placeholder domains and secrets—replace them with the values from your own Supabase deployment before going live.
@@ -106,7 +106,7 @@ docker compose up -d
    ```bash
    cp .env.production.example .env.production
    ```
-   Ensure the Supabase values match the running Supabase stack.
+   Ensure the Supabase values match the running Supabase stack. `SUPABASE_INTERNAL_URL` is for server-side Supabase HTTP/API calls through Kong; startup migrations use direct `psql` traffic instead. For the bundled self-hosted stack, keep `DIRECT_DB_HOST=supabase-db` and `DIRECT_DB_PORT=5432` so the app container reaches the database container on the shared `supabase_default` network. Do not use the host-published Postgres port (`5553`) for this container-to-container migration path. If production should listen only on the trusted host interface, set `APP_HOST_BIND=10.10.50.2:` with the trailing colon instead of carrying an uncommitted compose-file edit.
 2. **Build & start the container**
    ```bash
    docker compose --env-file .env.production -f docker-compose.prod.yml up -d --build
@@ -128,7 +128,8 @@ docker compose up -d
 
 ## Operations Playbook
 - **Rotate secrets** – Update `supabase-docker/.env` and `.env.production`, regenerate anon/service keys tied to the new `JWT_SECRET`, then redeploy.
-- **Backups** – Run `pg_dump` against the Supabase Postgres service (`supabase-db:5553`) or configure Supabase WAL backups.
+- **Backups** – From the Docker host, run `pg_dump` against the host-published Supabase Postgres port (`localhost:5553`, or the bound host interface) or configure Supabase WAL backups. From containers on `supabase_default`, use the direct service address `supabase-db:5432`.
+- **Startup migrations** – The app container runs checked-in SQL migrations with `psql` before starting Next.js. A bad direct-DB target now fails startup rather than silently skipping migrations. If migrations must be handled externally for a deployment, set `SKIP_DB_MIGRATIONS=true` deliberately and document the external migration step.
 - **Monitoring** – Supabase Logflare is exposed on `5552`. Pin dashboards or forward logs to your observability stack.
 - **Image updates** – Pull the latest tags listed in `supabase-docker/docker-compose.yml` and rebuild the ChoreQuest app container when Next.js dependencies change.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,10 @@ services:
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
     container_name: chorequest-app
     ports:
-      - "${PORT:-3000}:3000"
+      # Set APP_HOST_BIND to an address plus trailing colon (for example
+      # 10.10.50.2:) when production should bind the host port to one
+      # interface instead of all interfaces.
+      - "${APP_HOST_BIND:-}${PORT:-3000}:3000"
     environment:
       # Supabase Configuration (from external instance)
       - NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
@@ -34,9 +37,11 @@ services:
       - HOST=0.0.0.0
       # Database bootstrap toggle
       - ENABLE_DB_BOOTSTRAP=${ENABLE_DB_BOOTSTRAP:-false}
-      # Database credentials for migrations (Option C only)
-      - DB_HOST=${DB_HOST:-supabase-db}
-      - DB_PORT=${DB_PORT:-5432}
+      # Direct Postgres credentials for startup migrations.
+      # This is separate from Supabase HTTP/API traffic and must use the
+      # database container's internal port on the shared Docker network.
+      - DB_HOST=${DIRECT_DB_HOST:-supabase-db}
+      - DB_PORT=${DIRECT_DB_PORT:-5432}
       - DB_NAME=${DB_NAME:-postgres}
       - DB_USER=${DB_USER:-postgres}
       - DB_PASSWORD=${DB_PASSWORD}

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -28,11 +28,18 @@ DB_NAME="${DB_NAME:-postgres}"
 DB_USER="${DB_USER:-postgres}"
 # DB_PASSWORD should be set via environment variable
 
+echo "✓ Direct Postgres migration target: ${DB_HOST}:${DB_PORT}/${DB_NAME} as ${DB_USER}"
+
 # Function to ensure migrations tracking table exists
 ensure_migrations_table() {
     echo "→ Ensuring migrations tracking table exists..."
 
-    PGPASSWORD="${DB_PASSWORD}" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" <<-EOSQL 2>/dev/null
+    if [ -z "$DB_PASSWORD" ]; then
+        echo "  ✗ DB_PASSWORD is not set; cannot run startup migrations"
+        return 1
+    fi
+
+    if ! PGPASSWORD="${DB_PASSWORD}" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" <<-EOSQL 2>/dev/null
         CREATE SCHEMA IF NOT EXISTS supabase_migrations;
         CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
             version TEXT PRIMARY KEY,
@@ -40,14 +47,13 @@ ensure_migrations_table() {
             applied_at TIMESTAMPTZ DEFAULT NOW()
         );
 EOSQL
-
-    if [ $? -eq 0 ]; then
-        echo "  ✓ Migrations tracking table ready"
-        return 0
-    else
-        echo "  ! Could not access database, skipping migrations"
+    then
+        echo "  ✗ Could not access direct Postgres at ${DB_HOST}:${DB_PORT}; refusing to skip startup migrations"
+        echo "  ✗ Supabase HTTP URLs are not used for psql migrations. Use the database container host and internal port when on Docker network."
         return 1
     fi
+
+    echo "  ✓ Migrations tracking table ready"
 }
 
 # Function to check if a migration has been applied
@@ -84,10 +90,16 @@ run_migrations() {
         return 0
     fi
 
+    SKIP_MIGRATIONS="${SKIP_DB_MIGRATIONS:-false}"
+    if [ "$SKIP_MIGRATIONS" = "true" ]; then
+        echo "! SKIP_DB_MIGRATIONS=true; startup migrations intentionally skipped"
+        return 0
+    fi
+
     # Ensure migrations tracking table exists
     if ! ensure_migrations_table; then
-        echo "! Unable to connect to database, skipping migrations"
-        return 0
+        echo "✗ Unable to connect to database; startup migrations did not run"
+        return 1
     fi
 
     # Run each migration file in order

--- a/supabase-docker/README.md
+++ b/supabase-docker/README.md
@@ -51,7 +51,7 @@ Services become healthy once Postgres finishes applying migrations (usually < 60
 | Kong Gateway / Supabase API | `5550` (HTTP), `5551` (HTTPS) | Reverse proxy to all Supabase services |
 | Supabase Studio | `5550/studio` (proxied via Kong) | Configure DNS/SSL via your reverse proxy |
 | Logflare (analytics) | `5552` | Useful for piping logs elsewhere |
-| Postgres | `5553` | Connect as `postgres` using `POSTGRES_PASSWORD` |
+| Postgres | `5553` host-published / `5432` on `supabase_default` | Use host port `5553` from the Docker host; use `supabase-db:5432` from sibling containers such as ChoreQuest startup migrations. |
 | Supavisor (transaction pool) | `5554` | Use for pooled client connections |
 
 When fronting the stack with Nginx/Traefik/Caddy, terminate TLS there and forward to `kong:8000` inside the Docker network.
@@ -68,7 +68,7 @@ When fronting the stack with Nginx/Traefik/Caddy, terminate TLS there and forwar
 
 - **Update images**: `docker compose pull && docker compose up -d`.
 - **Rotate secrets**: regenerate keys, update `.env`, and restart the affected services.
-- **Backups**: run `pg_dump` against `supabase-db:5553` or enable WAL archiving.
+- **Backups**: from the Docker host, run `pg_dump` against the published Postgres port (`localhost:5553`, or the bound host interface); from a container on `supabase_default`, use `supabase-db:5432`. Enable WAL archiving for stronger recovery guarantees.
 - **Logs**: tail `docker compose logs -f <service>` or forward Logflare events.
 
 ## 8. Troubleshooting


### PR DESCRIPTION
## Summary
- Separate production startup migration traffic from Supabase HTTP/API traffic by mapping compose `DIRECT_DB_HOST`/`DIRECT_DB_PORT` into the container `DB_HOST`/`DB_PORT` used by `psql`.
- Make startup migration connection failures loud: missing/incorrect direct Postgres credentials now fail container startup unless `SKIP_DB_MIGRATIONS=true` is set deliberately.
- Document production truth for Docker-network Postgres (`supabase-db:5432`), host-published Postgres (`5553`), Supabase HTTP/Kong traffic, and the live host interface bind via `APP_HOST_BIND=10.10.50.2:`.

## Production operator note
This PR removes the need for the local uncommitted production compose edit for `10.10.50.2:5555:3000`; set `APP_HOST_BIND=10.10.50.2:` and keep `PORT=5555` in the privileged host `.env` instead. For direct startup migrations, set `DIRECT_DB_HOST=supabase-db` and `DIRECT_DB_PORT=5432`. The legacy host-side `DB_PORT=5553` can remain for external/host tooling, but after this PR compose no longer uses it for in-container startup migrations.

## Verification
- `sh -n scripts/docker-entrypoint.sh`
- `docker compose --env-file .env.production.example -f docker-compose.prod.yml config` confirmed `DB_PORT: "5432"` and host bind `10.10.50.2:5555->3000`.
- `npm run lint` passed.
- `NEXT_PUBLIC_SUPABASE_URL=https://supabase.example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy SUPABASE_URL=https://supabase.example.com SUPABASE_INTERNAL_URL=https://supabase.example.com npm run build` passed.
- `npm run test` still has unrelated failures on existing achievement/family-achievement service tests on `develop` (for example `family-achievement-progress-service.*` upsert expectations and rollback guard expectations); this PR only changes compose/docs/shell startup wiring.

Closes #244
