### PR TITLE
fix: use IPv4 loopback for Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,9 +86,10 @@ USER nextjs
 # Expose port 3000
 EXPOSE 3000
 
-# Health check endpoint
+# Health check endpoint. Use IPv4 loopback so Docker health matches the
+# 0.0.0.0 listener even when localhost resolves to ::1 first.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
 
 # Set entrypoint to initialization script
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ docker compose up -d
    docker compose --env-file .env.production -f docker-compose.prod.yml logs -f app
    curl -I https://app.example.com/api/health
    ```
+   Docker health probes `http://127.0.0.1:3000/api/health` from inside the
+   container. The app still listens on `0.0.0.0:3000`; the explicit IPv4
+   loopback avoids false unhealthy results on hosts/images where `localhost`
+   resolves to `::1` before IPv4.
 4. **Cron jobs**
    - Set `CRON_SECRET` in `.env.production`.
    - Configure your scheduler (e.g., systemd timer, GitHub Actions, managed cron) to hit:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,7 +54,9 @@ services:
       - RECURRING_TEST_INTERVAL_MINUTES=${RECURRING_TEST_INTERVAL_MINUTES:-}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      # Probe IPv4 loopback explicitly. Alpine wget may resolve localhost to ::1
+      # first, while the Next.js standalone server is bound on IPv4 0.0.0.0.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-healthcheck-config.test.ts
+++ b/docker-healthcheck-config.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(__dirname);
+
+function readText(relativePath: string) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("production Docker healthcheck configuration", () => {
+  it("probes the IPv4 loopback address while the app listens on all container interfaces", () => {
+    const compose = readText("docker-compose.prod.yml");
+    const dockerfile = readText("Dockerfile");
+
+    expect(compose).toContain("HOSTNAME=${HOSTNAME_OVERRIDE:-0.0.0.0}");
+    expect(compose).toContain("HOST=0.0.0.0");
+    expect(compose).toContain("http://127.0.0.1:3000/api/health");
+    expect(compose).not.toContain("http://localhost:3000/api/health");
+
+    expect(dockerfile).toContain("http://127.0.0.1:3000/api/health");
+    expect(dockerfile).not.toContain("http://localhost:3000/api/health");
+  });
+});


### PR DESCRIPTION
## Summary
- change the production compose healthcheck from `localhost` to `127.0.0.1` so Docker probes IPv4 loopback instead of accidentally trying `::1`
- make the Dockerfile healthcheck use the same IPv4 target for image-level consistency
- document that the app still listens on `0.0.0.0:3000` and only the internal probe target is IPv4-specific
- add a config regression test covering the listener/healthcheck contract

## Verification
- `npm run test:unit -- --runTestsByPath docker-healthcheck-config.test.ts` — pass after rebasing onto latest `origin/develop`
- `docker compose --env-file .env.production.example -f docker-compose.prod.yml config` — pass; rendered healthcheck uses `http://127.0.0.1:3000/api/health`
- `npm run lint` — pass after rebasing onto latest `origin/develop`
- `NEXT_PUBLIC_SUPABASE_URL=https://supabase.example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy SUPABASE_URL=https://supabase.example.com SUPABASE_INTERNAL_URL=https://supabase.example.com npm run build` — pass after removing stale local `.next`; the earlier attempt hit stale Turbopack trace ENOENTs from the reused worktree
- `docker image inspect chorequest-healthcheck-test:245 --format '{{json .Config.Healthcheck.Test}}'` — `["CMD-SHELL","wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1"]`
- `npm run test:unit -- --runInBand` — fails in existing achievement/family-achievement suites and env-dependent component/hook tests unrelated to this Docker healthcheck-only change

## Release implications
- This is a production deployment healthcheck fix only. No public `/api/health` response code/body behavior was changed.
- After the image/compose update is deployed, Portainer/Docker should stop reporting the app unhealthy solely because `localhost` resolved to IPv6 loopback first.

Closes #245
